### PR TITLE
Add tests for SegmentTreeHalf and transform utilities

### DIFF
--- a/svg-time-series/src/MyTransform.test.ts
+++ b/svg-time-series/src/MyTransform.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { MyTransform } from './MyTransform.ts'
+import { AR1Basis } from './viewZoomTransform.ts'
+
+class Matrix {
+  constructor(
+    public a = 1,
+    public b = 0,
+    public c = 0,
+    public d = 1,
+    public e = 0,
+    public f = 0,
+  ) {}
+
+  multiply(m: Matrix) {
+    return new Matrix(
+      this.a * m.a + this.c * m.b,
+      this.b * m.a + this.d * m.b,
+      this.a * m.c + this.c * m.d,
+      this.b * m.c + this.d * m.d,
+      this.a * m.e + this.c * m.f + this.e,
+      this.b * m.e + this.d * m.f + this.f,
+    )
+  }
+
+  translate(tx: number, ty: number) {
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty))
+  }
+
+  scaleNonUniform(sx: number, sy: number) {
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0))
+  }
+
+  inverse() {
+    const det = this.a * this.d - this.b * this.c
+    return new Matrix(
+      this.d / det,
+      -this.b / det,
+      -this.c / det,
+      this.a / det,
+      (this.c * this.f - this.d * this.e) / det,
+      (this.b * this.e - this.a * this.f) / det,
+    )
+  }
+}
+
+class Point {
+  constructor(public x = 0, public y = 0) {}
+
+  matrixTransform(m: Matrix) {
+    return new Point(
+      this.x * m.a + this.y * m.c + m.e,
+      this.x * m.b + this.y * m.d + m.f,
+    )
+  }
+}
+
+describe('MyTransform', () => {
+  it('composes zoom and reference transforms and inverts them', () => {
+    const svg = {
+      createSVGMatrix: () => new Matrix(),
+      createSVGPoint: () => new Point(),
+    } as unknown as SVGSVGElement
+    const g = {} as unknown as SVGGElement
+    const mt = new MyTransform(svg, g)
+
+    mt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100))
+    mt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10))
+
+    // without zoom
+    expect(mt.fromScreenToModelX(50)).toBeCloseTo(5)
+    expect(mt.fromScreenToModelY(20)).toBeCloseTo(2)
+
+    // apply zoom: translate 10 and scale 2 on X
+    mt.onZoomPan({ x: 10, k: 2 } as any)
+    expect(mt.fromScreenToModelX(70)).toBeCloseTo(3)
+    // Y axis unaffected by zoom transform
+    expect(mt.fromScreenToModelY(20)).toBeCloseTo(2)
+  })
+})

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -29,9 +29,25 @@ test('SegmentTree operations', () => {
     expect(() => tree.update(5, { min: 0, max: 0 })).toThrow("Position is not valid");
 });
 
-test('SegmentTreeHalf operations', () => {
-    // ... (keep the existing SegmentTreeHalf test)
-});
+test('SegmentTreeHalf edge cases', () => {
+    const data = [1, 2, 3, 4, 5]
+    const sumOp = (a: number, b: number) => a + b
+    const tree = new SegmentTreeHalf(data, sumOp, 0)
+
+    // query single elements on boundaries
+    expect(tree.query(0, 0)).toBe(1)
+    expect(tree.query(data.length - 1, data.length - 1)).toBe(5)
+
+    // update boundary elements and verify queries
+    tree.update(0, 10)
+    tree.update(data.length - 1, 20)
+    expect(tree.query(0, 0)).toBe(10)
+    expect(tree.query(data.length - 1, data.length - 1)).toBe(20)
+    expect(tree.query(0, data.length - 1)).toBe(10 + 2 + 3 + 4 + 20)
+
+    // invalid range returns identity value
+    expect(tree.query(3, 2)).toBe(0)
+})
 
 test('SegmentTree with IMinMax', () => {
     const data = [

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AR1,
+  AR1Basis,
+  betweenTBasesAR1,
+  DirectProductBasis,
+  betweenTBasesDirectProduct
+} from './viewZoomTransform.ts'
+
+class Matrix {
+  constructor(
+    public a = 1,
+    public b = 0,
+    public c = 0,
+    public d = 1,
+    public e = 0,
+    public f = 0,
+  ) {}
+
+  multiply(m: Matrix) {
+    return new Matrix(
+      this.a * m.a + this.c * m.b,
+      this.b * m.a + this.d * m.b,
+      this.a * m.c + this.c * m.d,
+      this.b * m.c + this.d * m.d,
+      this.a * m.e + this.c * m.f + this.e,
+      this.b * m.e + this.d * m.f + this.f,
+    )
+  }
+
+  translate(tx: number, ty: number) {
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty))
+  }
+
+  scaleNonUniform(sx: number, sy: number) {
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0))
+  }
+}
+
+describe('AR1 and AR1Basis', () => {
+  it('composes and inverts transformations', () => {
+    const t1 = new AR1([2, 3])
+    const t2 = new AR1([4, 5])
+    const composed = t1.composeWith(t2)
+    expect(composed.applyToPoint(1)).toBeCloseTo(t2.applyToPoint(t1.applyToPoint(1)))
+
+    const identity = t1.composeWith(t1.inverse())
+    expect(identity.applyToPoint(7)).toBeCloseTo(7)
+  })
+
+  it('transforms bases and maps between them', () => {
+    const basis = new AR1Basis(0, 1)
+    const transform = new AR1([2, 3])
+    const transformed = basis.transformWith(transform)
+    expect(transformed.toArr()).toEqual([3, 5])
+    expect(transformed.getRange()).toBeCloseTo(2)
+
+    const target = new AR1Basis(10, 12)
+    const t = betweenTBasesAR1(basis, target)
+    expect(basis.transformWith(t).toArr()).toEqual(target.toArr())
+  })
+})
+
+describe('DirectProduct', () => {
+  it('applies independent transforms on axes', () => {
+    const identity = new Matrix()
+    const b1 = new DirectProductBasis([0, 0], [1, 1])
+    const b2 = new DirectProductBasis([10, 10], [20, 30])
+    const dp = betweenTBasesDirectProduct(b1, b2)
+    const m = dp.applyToMatrix(identity)
+
+    expect(m.a).toBeCloseTo(10)
+    expect(m.d).toBeCloseTo(20)
+    expect(m.e).toBeCloseTo(10)
+    expect(m.f).toBeCloseTo(10)
+  })
+})


### PR DESCRIPTION
## Summary
- expand SegmentTreeHalf coverage with boundary updates and invalid range queries
- add AR1/AR1Basis and DirectProduct tests to verify composition and basis mapping
- introduce MyTransform tests ensuring zoom and reference transforms invert correctly

## Testing
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688f697c2e74832b858f959c1530db8e