### PR TITLE
refactor: separate math utilities from DOM operations

### DIFF
--- a/svg-time-series/src/MyTransform.test.ts
+++ b/svg-time-series/src/MyTransform.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { MyTransform } from './MyTransform.ts'
-import { AR1Basis } from './viewZoomTransform.ts'
+import { AR1Basis } from './math/affine.ts'
 
 class Matrix {
   constructor(

--- a/svg-time-series/src/MyTransform.ts
+++ b/svg-time-series/src/MyTransform.ts
@@ -16,6 +16,12 @@ import {
   AR1Basis,
   betweenTBasesAR1,
   bPlaceholder,
+} from "./math/affine.ts";
+
+import {
+  applyAR1ToMatrixX,
+  applyAR1ToMatrixY,
+  updateNode,
 } from "./viewZoomTransform.ts";
 
 export class MyTransform {
@@ -53,8 +59,9 @@ export class MyTransform {
       this.referenceViewWindowPointsY,
       this.viewPortPointsY,
     );
-    this.referenceTransform = affY.applyToMatrixY(
-      affX.applyToMatrixX(this.identityTransform),
+    this.referenceTransform = applyAR1ToMatrixY(
+      affY,
+      applyAR1ToMatrixX(affX, this.identityTransform),
     );
   }
 
@@ -146,10 +153,4 @@ export class MyTransform {
     const [p1, p2] = b.toArr().map(transformPoint);
     return new AR1Basis(p1, p2);
   }
-}
-
-export function updateNode(n: SVGGraphicsElement, m: SVGMatrix) {
-  const svgTranformList = n.transform.baseVal;
-  const t = svgTranformList.createSVGTransformFromMatrix(m);
-  svgTranformList.initialize(t);
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -5,7 +5,8 @@ import { timeout as runTimeout } from "d3-timer";
 import { zoom as d3zoom, ZoomTransform } from "d3-zoom";
 
 import { MyAxis, Orientation } from "./axis.ts";
-import { MyTransform, updateNode } from "./MyTransform.ts";
+import { MyTransform } from "./MyTransform.ts";
+import { updateNode } from "./viewZoomTransform.ts";
 import { IMinMax, SegmentTree } from "./segmentTree.ts";
 import {
   AR1,
@@ -13,7 +14,7 @@ import {
   betweenTBasesAR1,
   bPlaceholder,
   bUnit,
-} from "./viewZoomTransform.ts";
+} from "./math/affine.ts";
 
 export type { IMinMax };
 

--- a/svg-time-series/src/math/affine.ts
+++ b/svg-time-series/src/math/affine.ts
@@ -1,0 +1,105 @@
+export class AR1 {
+  constructor(public m: [number, number]) {}
+
+  composeWith(a2: AR1): AR1 {
+    const [a0, b0] = this.m;
+    const [a1, b1] = a2.m;
+    return new AR1([a0 * a1, b0 * a1 + b1]);
+  }
+
+  inverse(): AR1 {
+    const [a, b] = this.m;
+    return new AR1([1 / a, -b / a]);
+  }
+
+  applyToPoint(p: number): number {
+    const [a, b] = this.m;
+    return a * p + b;
+  }
+}
+
+export class AR1Basis {
+  constructor(private p1: number, private p2: number) {}
+
+  toArr(): [number, number] {
+    return [this.p1, this.p2];
+  }
+
+  transformWith(transform: AR1): AR1Basis {
+    return new AR1Basis(
+      transform.applyToPoint(this.p1),
+      transform.applyToPoint(this.p2),
+    );
+  }
+
+  getRange(): number {
+    return Math.abs(this.p2 - this.p1);
+  }
+}
+
+export const bUnit = new AR1Basis(0, 1);
+export const bPlaceholder = bUnit;
+
+export function betweenBasesAR1(
+  b1: [number, number],
+  b2: [number, number],
+): AR1 {
+  const [b11, b12] = b1;
+  const [b21, b22] = b2;
+  return new AR1([
+    (b21 - b22) / (b11 - b12),
+    -(b12 * b21 - b11 * b22) / (b11 - b12),
+  ]);
+}
+
+export function betweenTBasesAR1(b1: AR1Basis, b2: AR1Basis): AR1 {
+  return betweenBasesAR1(b1.toArr(), b2.toArr());
+}
+
+export class DirectProduct {
+  constructor(public s1: AR1, public s2: AR1) {}
+}
+
+export class DirectProductBasis {
+  private p1: [number, number];
+  private p2: [number, number];
+
+  constructor(pp1: [number, number], pp2: [number, number]) {
+    this.p1 = pp1;
+    this.p2 = pp2;
+  }
+
+  x(): AR1Basis {
+    const [x1] = this.p1;
+    const [x2] = this.p2;
+    return new AR1Basis(x1, x2);
+  }
+
+  y(): AR1Basis {
+    const [, y1] = this.p1;
+    const [, y2] = this.p2;
+    return new AR1Basis(y1, y2);
+  }
+
+  toArr() {
+    return [this.x().toArr(), this.y().toArr()];
+  }
+
+  static fromProjections(b1: AR1Basis, b2: AR1Basis): DirectProductBasis {
+    const [b1x, b2x] = b1.toArr();
+    const [b1y, b2y] = b2.toArr();
+    return new DirectProductBasis([b1x, b1y], [b2x, b2y]);
+  }
+}
+
+export const dpbPlaceholder = new DirectProductBasis([0, 0], [1, 1]);
+
+export function betweenTBasesDirectProduct(
+  b1: DirectProductBasis,
+  b2: DirectProductBasis,
+): DirectProduct {
+  return new DirectProduct(
+    betweenTBasesAR1(b1.x(), b2.x()),
+    betweenTBasesAR1(b1.y(), b2.y()),
+  );
+}

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -4,8 +4,9 @@ import {
   AR1Basis,
   betweenTBasesAR1,
   DirectProductBasis,
-  betweenTBasesDirectProduct
-} from './viewZoomTransform.ts'
+  betweenTBasesDirectProduct,
+} from './math/affine.ts'
+import { applyDirectProductToMatrix } from './viewZoomTransform.ts'
 
 class Matrix {
   constructor(
@@ -67,7 +68,7 @@ describe('DirectProduct', () => {
     const b1 = new DirectProductBasis([0, 0], [1, 1])
     const b2 = new DirectProductBasis([10, 10], [20, 30])
     const dp = betweenTBasesDirectProduct(b1, b2)
-    const m = dp.applyToMatrix(identity)
+    const m = applyDirectProductToMatrix(dp, identity)
 
     expect(m.a).toBeCloseTo(10)
     expect(m.d).toBeCloseTo(20)

--- a/svg-time-series/src/viewZoomTransform.ts
+++ b/svg-time-series/src/viewZoomTransform.ts
@@ -1,195 +1,29 @@
-// По задумке этот модуль содержит различные аффинные пространства
-// A - аффинное пространство над векторным пространством над
-// R - множеством действительных чисел
-// 1 - в первой степени (числовая прямая)
+import { AR1, DirectProduct } from './math/affine.ts';
 
-// автоморфизмы числовой прямой
-export class AR1 {
-  // коэффициенты автоморфизма x' = x * m[0] + m[1]
-  public m: [number, number];
-
-  constructor(mm: [number, number]) {
-    this.m = mm;
-  }
-
-  public composeWith(a2: AR1): AR1 {
-    const [a0, b0] = this.m;
-    const [a1, b1] = a2.m;
-
-    return new AR1([a0 * a1, b0 * a1 + b1]);
-  }
-
-  // x1 = a * x + b; x = x1 / a - b / a
-  public inverse(): AR1 {
-    const [a, b] = this.m;
-    return new AR1([1 / a, -b / a]);
-  }
-
-  public applyToPoint(p: number): number {
-    const [a, b] = this.m;
-    return a * p + b;
-  }
-
-  public applyToMatrixX(sm: SVGMatrix): SVGMatrix {
-    const [a, b] = this.m;
-    return sm.translate(b, 0).scaleNonUniform(a, 1);
-  }
-
-  public applyToMatrixY(sm: SVGMatrix): SVGMatrix {
-    const [a, b] = this.m;
-    return sm.translate(0, b).scaleNonUniform(1, a);
-  }
+export interface MatrixLike {
+  translate(tx: number, ty: number): MatrixLike;
+  scaleNonUniform(sx: number, sy: number): MatrixLike;
 }
 
-// У N-мерного аффинного пространства базис N+1 точек
-// дополнительная точка даёт по сравнению с векторами
-// дополнительную возможность описывать параллельный
-// перенос (вектора - только повороты, растяжения,
-// перекосы и их комбинации)
-//
-// Преобразование однозначно определяется парой базисов.
-// На бытовом языке - два массива точек, притом первая точка
-// первого массива переходит в первую точку второго.
-//
-// Пространство AR1 одномерное, и точек в базисе две.
-//
-// Например, для аффинного преобразованияз цельсия в фаренгейт нужно
-// знать что в фаренгейте вода замерзает при 32 а кипит при 212
-// а в цельсии соответственно 0 и 100
-//
-// betweenBasesAR1([32, 212], [0, 100]) нам даст преобразование
-// из фаренгейта в цельсий. Не важно какая точка "меньше" -
-// betweenBasesAR1([212, 32], [100, 0]) это то же самое.
-//
-// Можно betweenBasesAR1([212, 32], [0, 100]) писать - это будет
-// перевод из фаренгейта в "обратный" цельсий, где вода
-// кипит при нуле, а замерзает при +100.
-// Интересно, что одно и то же преобразование получается из
-// бесконечно большого количества пар базисов - это и понятно,
-// перевод из цельсия в фаренгейты можно определить, зафиксировав
-// температуры плавления стали и горения бумаги и т п.
-//
-//
-//
-//		 b21 - b22        b12 b21 - b11 b22
-// [[a = ---------, b = - -----------------]]
-//  	 b11 - b12            b11 - b12
-export function betweenBasesAR1(b1: [number, number], b2: [number, number]): AR1 {
-  const [b11, b12] = b1;
-  const [b21, b22] = b2;
-  return new AR1([
-    (b21 - b22) / (b11 - b12),
-    -(b12 * b21 - b11 * b22) / (b11 - b12),
-  ]);
+export function applyAR1ToMatrixX<M extends MatrixLike>(transform: AR1, sm: M): M {
+  const [a, b] = transform.m;
+  return sm.translate(b, 0).scaleNonUniform(a, 1);
 }
 
-export class AR1Basis {
-  private p1: number;
-  private p2: number;
-
-  constructor(pp1: number, pp2: number) {
-    this.p1 = pp1;
-    this.p2 = pp2;
-  }
-
-  public toArr(): [number, number] {
-    return [this.p1, this.p2];
-  }
-
-  public transformWith(transform: AR1): AR1Basis {
-    return new AR1Basis(
-      transform.applyToPoint(this.p1),
-      transform.applyToPoint(this.p2),
-    );
-  }
-
-  public getRange(): number {
-    return Math.abs(this.p2 - this.p1);
-  }
+export function applyAR1ToMatrixY<M extends MatrixLike>(transform: AR1, sm: M): M {
+  const [a, b] = transform.m;
+  return sm.translate(0, b).scaleNonUniform(1, a);
 }
 
-// единичный базис
-export const bUnit = new AR1Basis(0, 1);
-
-// часто нужен хоть какой-то базис
-export const bPlaceholder = bUnit;
-
-// between typed bases
-export function betweenTBasesAR1(b1: AR1Basis, b2: AR1Basis): AR1 {
-  return betweenBasesAR1(b1.toArr(), b2.toArr());
+export function applyDirectProductToMatrix<M extends MatrixLike>(
+  dp: DirectProduct,
+  sm: M,
+): M {
+  return applyAR1ToMatrixY(dp.s2, applyAR1ToMatrixX(dp.s1, sm));
 }
 
-// пока это произведение конкретны[ пространств AR1 и AR1
-// но код обобщается на произвольные
-// при прямом произведении у нас трансформации в перемножаемых
-// пространствах независимые
-// на координатном языке это означает что трансформация по
-// оси Х не меняет координату Y
-// любопытно, что произведение пространств не влияет на количество
-// точек для определения трансформации. То есть наше пространство
-// переносов по двум осям как аффинное пространство - по-прежнему
-// одномерно, и точек по-прежнему две.
-// Только теперь точки "двойные".
-export class DirectProduct {
-  // multiplied spaces 1 and 2
-  private s1: AR1;
-  private s2: AR1;
-
-  constructor(ss1: AR1, ss2: AR1) {
-    this.s1 = ss1;
-    this.s2 = ss2;
-  }
-
-  public applyToMatrix(sm: SVGMatrix): SVGMatrix {
-    return this.s2.applyToMatrixY(this.s1.applyToMatrixX(sm));
-  }
-}
-
-export class DirectProductBasis {
-  private p1: [number, number];
-  private p2: [number, number];
-
-  constructor(pp1: [number, number], pp2: [number, number]) {
-    this.p1 = pp1;
-    this.p2 = pp2;
-  }
-
-  public x() {
-    const [x1, ] = this.p1;
-    const [x2, ] = this.p2;
-    return new AR1Basis(x1, x2);
-  }
-
-  public y() {
-    const [, y1] = this.p1;
-    const [, y2] = this.p2;
-    return new AR1Basis(y1, y2);
-  }
-
-  public toArr() {
-    return [this.x().toArr(), this.y().toArr()];
-  }
-
-  // здест по сути транспонирование матрицы 2х2
-  // непонятно как делать
-  public static fromProjections(
-    b1: AR1Basis,
-    b2: AR1Basis,
-  ): DirectProductBasis {
-    const [b1x, b2x] = b1.toArr();
-    const [b1y, b2y] = b2.toArr();
-    return new DirectProductBasis([b1x, b1y], [b2x, b2y]);
-  }
-}
-
-export const dpbPlaceholder = new DirectProductBasis([0, 0], [1, 1]);
-
-export function betweenTBasesDirectProduct(
-  b1: DirectProductBasis,
-  b2: DirectProductBasis,
-): DirectProduct {
-  return new DirectProduct(
-    betweenTBasesAR1(b1.x(), b2.x()),
-    betweenTBasesAR1(b1.y(), b2.y()),
-  );
+export function updateNode(n: SVGGraphicsElement, m: SVGMatrix) {
+  const svgTranformList = n.transform.baseVal;
+  const t = svgTranformList.createSVGTransformFromMatrix(m);
+  svgTranformList.initialize(t);
 }


### PR DESCRIPTION
## Summary
- extract AR1 and basis utilities into `src/math/affine.ts`
- add matrix helpers and `updateNode` to `viewZoomTransform.ts`
- update MyTransform and tests to use the new math module

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f75005e4c832bba591b4d51e9c239