### PR TITLE
Add bounds checks to SegmentTreeHalf query

### DIFF
--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -45,8 +45,8 @@ test('SegmentTreeHalf edge cases', () => {
     expect(tree.query(data.length - 1, data.length - 1)).toBe(20)
     expect(tree.query(0, data.length - 1)).toBe(10 + 2 + 3 + 4 + 20)
 
-    // invalid range returns identity value
-    expect(tree.query(3, 2)).toBe(0)
+    // invalid range throws an error
+    expect(() => tree.query(3, 2)).toThrow('Range is not valid')
 })
 
 test('SegmentTree with IMinMax', () => {

--- a/svg-time-series/src/segmentTreeHalf.test.ts
+++ b/svg-time-series/src/segmentTreeHalf.test.ts
@@ -78,15 +78,26 @@ describe('Segment Tree (Foo) Tests', () => {
 		expect(tree.query(5, 7)).toBe(21) // 6 + 7 + 8 = 21
 	})
 
-	it('should reflect updates to the last element in range queries', () => {
-		const data = [1, 2, 3, 4, 5, 6, 7, 8]
-		const sumOperator = (a: number, b: number) => a + b
-		const identity = 0
-		const tree = new SegmentTreeHalf(data, sumOperator, identity)
+        it('should reflect updates to the last element in range queries', () => {
+                const data = [1, 2, 3, 4, 5, 6, 7, 8]
+                const sumOperator = (a: number, b: number) => a + b
+                const identity = 0
+                const tree = new SegmentTreeHalf(data, sumOperator, identity)
 
-		tree.update(7, 10) // Update the last element (8 -> 10)
-		expect(tree.query(5, 7)).toBe(23) // 6 + 7 + 10 = 23
-		expect(tree.query(0, 7)).toBe(38) // Sum of all elements with updated last element
-	})
+                tree.update(7, 10) // Update the last element (8 -> 10)
+                expect(tree.query(5, 7)).toBe(23) // 6 + 7 + 10 = 23
+                expect(tree.query(0, 7)).toBe(38) // Sum of all elements with updated last element
+        })
+
+        it('should throw an error for invalid ranges', () => {
+                const data = [1, 2, 3, 4, 5]
+                const sumOperator = (a: number, b: number) => a + b
+                const identity = 0
+                const tree = new SegmentTreeHalf(data, sumOperator, identity)
+
+                expect(() => tree.query(3, 2)).toThrow('Range is not valid')
+                expect(() => tree.query(-1, 2)).toThrow('Range is not valid')
+                expect(() => tree.query(0, 5)).toThrow('Range is not valid')
+        })
 
 })

--- a/svg-time-series/src/segmentTreeHalf.ts
+++ b/svg-time-series/src/segmentTreeHalf.ts
@@ -35,6 +35,9 @@ export class SegmentTreeHalf<T> {
   }
 
   query(left: number, right: number): T {
+    if (left < 0 || right >= this.size || left > right) {
+      throw new Error('Range is not valid');
+    }
     left += this.size;
     right += this.size;
     let result = this.identity;


### PR DESCRIPTION
## Summary
- validate SegmentTreeHalf query ranges and enforce array bounds
- cover invalid query ranges in tests and expect failures

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688f7e14e018832ba35fc7d14d688626