### PR TITLE
Respect manual tick settings in axis helpers

### DIFF
--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -59,6 +59,10 @@ export class MyAxis {
     scale1: ScaleType,
     scale2?: ScaleType,
   ): [number, number | null][] {
+    if (this.tickValues != null) {
+      return this.tickValues.map((v) => [v, scale2 ? v : null]);
+    }
+
     const createValuesFromScale = (scale: ScaleType): number[] =>
       scale.ticks
         ? scale.ticks.apply(scale, this.tickArguments)
@@ -73,10 +77,14 @@ export class MyAxis {
     scale: ScaleType,
     columnIdx: number,
   ): (tuple: [number, number | null]) => string {
-    const formatValue = (scale: ScaleType): ((d: number) => string) =>
-      scale.tickFormat
+    const formatValue = (scale: ScaleType): ((d: number) => string) => {
+      if (this.tickFormat) {
+        return this.tickFormat;
+      }
+      return scale.tickFormat
         ? scale.tickFormat.apply(scale, this.tickArguments)
         : identity;
+    };
     return (tuple: [number, number | null]) =>
       formatValue(scale)(tuple[columnIdx]);
   }
@@ -177,7 +185,10 @@ export class MyAxis {
         this.orient === Orientation.Top || this.orient === Orientation.Left
           ? -1
           : 1;
-    let tick = context.selectAll(".tick").data(values, this.scale1).order(),
+    let tick = context
+        .selectAll(".tick")
+        .data(values, (d: any) => this.scale1(d[0]))
+        .order(),
       tickExit = tick.exit(),
       tickEnter = tick.enter().append("g").attr("class", "tick"),
       line = tick.select("line"),


### PR DESCRIPTION
## Summary
- allow providing explicit tick values via `MyAxis.setTickValues`
- respect custom tick formatting functions through `MyAxis.setTickFormat`
- fix `axisUp` data binding so custom ticks apply consistently

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f7e404710832bb696a9577d5ad79b