### PR TITLE
test: add coverage for affine and transforms

### DIFF
--- a/svg-time-series/src/MyTransform.test.ts
+++ b/svg-time-series/src/MyTransform.test.ts
@@ -77,4 +77,22 @@ describe('MyTransform', () => {
     // Y axis unaffected by zoom transform
     expect(mt.fromScreenToModelY(20)).toBeCloseTo(2)
   })
+
+  it('maps screen bases back to model bases through inverse transforms', () => {
+    const svg = {
+      createSVGMatrix: () => new Matrix(),
+      createSVGPoint: () => new Point(),
+    } as unknown as SVGSVGElement
+    const g = {} as unknown as SVGGElement
+    const mt = new MyTransform(svg, g)
+
+    mt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100))
+    mt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10))
+    mt.onZoomPan({ x: 10, k: 2 } as any)
+
+    const basis = mt.fromScreenToModelBasisX(new AR1Basis(20, 40))
+    const [p1, p2] = basis.toArr()
+    expect(p1).toBeCloseTo(0.5)
+    expect(p2).toBeCloseTo(1.5)
+  })
 })

--- a/svg-time-series/src/affine.test.ts
+++ b/svg-time-series/src/affine.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AR1,
+  AR1Basis,
+  DirectProductBasis,
+  betweenTBasesDirectProduct,
+} from './math/affine.ts'
+
+describe('AR1 and AR1Basis', () => {
+  it('composes and inverts AR1 transforms', () => {
+    const t0 = new AR1([2, 3])
+    const t1 = new AR1([4, -1])
+    const composed = t0.composeWith(t1)
+    expect(composed.applyToPoint(1)).toBeCloseTo(t1.applyToPoint(t0.applyToPoint(1)))
+
+    const inv = t0.inverse()
+    const identity = t0.composeWith(inv)
+    expect(identity.applyToPoint(5)).toBeCloseTo(5)
+  })
+
+  it('transforms AR1Basis and computes its range', () => {
+    const basis = new AR1Basis(0, 10)
+    const t = new AR1([2, 3])
+    const transformed = basis.transformWith(t)
+    expect(transformed.toArr()).toEqual([3, 23])
+    expect(transformed.getRange()).toBeCloseTo(20)
+  })
+})
+
+describe('DirectProduct', () => {
+  it('creates direct product transforms between bases and composes with inverses', () => {
+    const b1x = new AR1Basis(0, 10)
+    const b1y = new AR1Basis(0, 20)
+    const b2x = new AR1Basis(10, 20)
+    const b2y = new AR1Basis(20, 40)
+    const dpb1 = DirectProductBasis.fromProjections(b1x, b1y)
+    const dpb2 = DirectProductBasis.fromProjections(b2x, b2y)
+    const dp = betweenTBasesDirectProduct(dpb1, dpb2)
+
+    expect(dp.s1.applyToPoint(0)).toBeCloseTo(10)
+    expect(dp.s1.applyToPoint(10)).toBeCloseTo(20)
+    expect(dp.s2.applyToPoint(0)).toBeCloseTo(20)
+    expect(dp.s2.applyToPoint(20)).toBeCloseTo(40)
+
+    const s1Id = dp.s1.composeWith(dp.s1.inverse())
+    const s2Id = dp.s2.composeWith(dp.s2.inverse())
+    expect(s1Id.applyToPoint(5)).toBeCloseTo(5)
+    expect(s2Id.applyToPoint(15)).toBeCloseTo(15)
+  })
+})

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -43,10 +43,15 @@ test('SegmentTreeHalf edge cases', () => {
     tree.update(data.length - 1, 20)
     expect(tree.query(0, 0)).toBe(10)
     expect(tree.query(data.length - 1, data.length - 1)).toBe(20)
+    // unaffected middle range stays the same
+    expect(tree.query(1, 3)).toBe(2 + 3 + 4)
+    // full range reflects updates
     expect(tree.query(0, data.length - 1)).toBe(10 + 2 + 3 + 4 + 20)
 
-    // invalid range throws an error
+    // invalid ranges throw an error
     expect(() => tree.query(3, 2)).toThrow('Range is not valid')
+    expect(() => tree.query(-1, 2)).toThrow('Range is not valid')
+    expect(() => tree.query(0, data.length)).toThrow('Range is not valid')
 })
 
 test('SegmentTree with IMinMax', () => {


### PR DESCRIPTION
## Summary
- add AR1, AR1Basis, and DirectProduct tests
- expand SegmentTreeHalf edge case coverage
- verify MyTransform basis conversion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f8125f1e0832b8db8705efdd67219