### PR TITLE
Require inclusive end index in SegmentTree

### DIFF
--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -12,17 +12,18 @@ test('SegmentTree operations', () => {
     const tree = new SegmentTree(data, data.length, buildTuple);
 
     // Test initial state
-    expect(tree.getMinMax(0, 4)).toEqual({ min: 1, max: 5 });
+    expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 1, max: 5 });
     expect(tree.getMinMax(1, 3)).toEqual({ min: 2, max: 5 });
 
     // Test update
     tree.update(2, { min: 6, max: 6 });
-    expect(tree.getMinMax(0, 4)).toEqual({ min: 1, max: 6 });
-    expect(tree.getMinMax(2, 4)).toEqual({ min: 4, max: 6 });
+    expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 1, max: 6 });
+    expect(tree.getMinMax(2, data.length - 1)).toEqual({ min: 4, max: 6 });
 
     // Test invalid range
-    expect(() => tree.getMinMax(-1, 5)).toThrow("Range is not valid");
+    expect(() => tree.getMinMax(-1, data.length - 1)).toThrow("Range is not valid");
     expect(() => tree.getMinMax(3, 2)).toThrow("Range is not valid");
+    expect(() => tree.getMinMax(0, data.length)).toThrow("Range is not valid");
 
     // Test invalid update position
     expect(() => tree.update(-1, { min: 0, max: 0 })).toThrow("Position is not valid");
@@ -62,11 +63,11 @@ test('SegmentTree with IMinMax', () => {
     const tree = new SegmentTree(data, data.length, buildTuple);
 
     // Test initial state
-    expect(tree.getMinMax(0, 4)).toEqual({ min: 1, max: 7 });
+    expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 1, max: 7 });
     expect(tree.getMinMax(1, 3)).toEqual({ min: 2, max: 6 });
 
     // Test update
     tree.update(2, { min: 0, max: 8 });
-    expect(tree.getMinMax(0, 4)).toEqual({ min: 0, max: 8 });
-    expect(tree.getMinMax(2, 4)).toEqual({ min: 0, max: 8 });
+    expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 0, max: 8 });
+    expect(tree.getMinMax(2, data.length - 1)).toEqual({ min: 0, max: 8 });
 });

--- a/svg-time-series/src/segmentTree.ts
+++ b/svg-time-series/src/segmentTree.ts
@@ -41,7 +41,7 @@ export class SegmentTree<T = [number, number]> {
 
   getMinMax(fromPosition: number, toPosition: number): IMinMax {
     assertOk(
-      fromPosition >= 0 && toPosition <= this.size && fromPosition <= toPosition,
+      fromPosition >= 0 && toPosition < this.size && fromPosition <= toPosition,
       "Range is not valid",
     );
     return this.tree.query(fromPosition, toPosition);


### PR DESCRIPTION
## Summary
- fix `getMinMax` to disallow `toPosition` equal to size, enforcing inclusive 0-based end index
- adjust and expand `segmentTree` tests for the new boundary rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f81d49c1c832bb0eda72e53751d1f