### PR TITLE
refactor: use helper for tick translation

### DIFF
--- a/svg-time-series/src/axis.test.ts
+++ b/svg-time-series/src/axis.test.ts
@@ -53,4 +53,27 @@ describe('MyAxis tick creation', () => {
     )
     expect(labels).toEqual([0, 50, 100, 0, 0.5, 1])
   })
+
+  it('updates ticks for dual scales with axisUp', () => {
+    const { g } = createGroup()
+    const scale1 = scaleLinear().domain([0, 100]).range([0, 100])
+    const scale2 = scaleLinear().domain([0, 1]).range([0, 200])
+    const axis = new MyAxis(Orientation.Bottom, scale1, scale2).ticks(3)
+    axis.axis(select(g))
+
+    scale1.range([0, 200])
+    scale2.range([0, 400])
+    axis.setScale(scale1, scale2)
+    axis.axisUp(select(g))
+
+    const ticks = Array.from(g.querySelectorAll('.tick'))
+    expect(ticks.map((t) => t.getAttribute('transform'))).toEqual([
+      'translate(0,0)',
+      'translate(100,0)',
+      'translate(200,0)',
+      'translate(0,0)',
+      'translate(200,0)',
+      'translate(400,0)',
+    ])
+  })
 })

--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -55,6 +55,25 @@ export class MyAxis {
     this.tickPadding = 3;
   }
 
+  private primaryTickValue(d: any, active: number): number {
+    if (Array.isArray(d)) {
+      return d.length > 2 ? d[active] : d[0];
+    }
+    return d;
+  }
+
+  private tickTransformFn(
+    transform: (a: any, b: any, c: any) => string,
+    positions: ((d: any) => number)[],
+  ) {
+    return (d: any) => {
+      const active =
+        Array.isArray(d) && d.length === 2 && typeof d[1] === "number" ? d[1] : 0;
+      const pos = positions[active];
+      return transform(pos, pos, this.primaryTickValue(d, active));
+    };
+  }
+
   private createValues(
     scale1: ScaleType,
     scale2?: ScaleType,
@@ -150,10 +169,7 @@ export class MyAxis {
 
     tickExit.remove();
 
-    tick.attr("transform", (d: [number, number]) => {
-      const pos = positions[d[1]];
-      return transform(pos, pos, d[0]);
-    });
+    tick.attr("transform", this.tickTransformFn(transform, positions));
 
     line
       .attr(x + "2", k * this.tickSizeInner)
@@ -236,10 +252,7 @@ export class MyAxis {
 
     tickExit.remove();
 
-    tick.attr("transform", (d: [number, number]) => {
-      const pos = positions[d[1]];
-      return transform(pos, pos, d[0]);
-    });
+    tick.attr("transform", this.tickTransformFn(transform, positions));
 
     line
       .attr(x + "2", k * this.tickSizeInner)


### PR DESCRIPTION
## Summary
- replace fixed tuple index with helper extracting active scale value in tick transform
- share tick translation helper between axis and axisUp to support dual scales
- add regression test for dual-scale axis updates

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68904d8b34c0832ba5fbb2da6d535a1e