### PR TITLE
chore(samples): add Vite config and dev script

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -1,8 +1,9 @@
 {
   "name": "samples",
   "version": "1.0.0",
-  "main": "vite.config.js",
   "scripts": {
+    "dev": "vite",
+    "build": "vite build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "type": "module",

--- a/samples/vite.config.ts
+++ b/samples/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import { fileURLToPath, URL } from "node:url";
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  server: {
+    port: 5173,
+  },
+  build: {
+    outDir: "dist",
+  },
+  plugins: [],
+});


### PR DESCRIPTION
## Summary
- configure Vite for sample demos with root, dev server port and build output
- remove obsolete `main` field and add Vite dev/build scripts in samples package

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925186d634832b8d7a271d5edb7e97