### PR TITLE
chore: update rollup-plugin-node-externals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6645,9 +6645,9 @@
       }
     },
     "node_modules/rollup-plugin-node-externals": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-7.1.3.tgz",
-      "integrity": "sha512-RM+7tJAejAoRsCf93TptTSdqUhRA8S78DleihMiu54Kac+uLkd9VIegLPhGnaW3ehZTXh56+R301mFH6j2A7vw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-externals/-/rollup-plugin-node-externals-8.0.1.tgz",
+      "integrity": "sha512-j6uve/BPEyHCmQuXpu5/LT5qXw69QLIi6YnFrs6F7tmGFXjkFDT0zqZMt0KaMuWSvkcxJFBklsKfYYoKKEPwyw==",
       "dev": true,
       "funding": [
         {
@@ -6664,7 +6664,7 @@
         "node": ">= 21 || ^20.6.0 || ^18.19.0"
       },
       "peerDependencies": {
-        "rollup": "^3.0.0 || ^4.0.0"
+        "rollup": "^4.0.0"
       }
     },
     "node_modules/rrweb-cssom": {
@@ -7982,7 +7982,7 @@
         "eslint-config-prettier": "^10.1.8",
         "plotly.js": "^3.0.3",
         "prettier": "^3.6.2",
-        "rollup-plugin-node-externals": "^7.1.3",
+        "rollup-plugin-node-externals": "^8.0.1",
         "typescript": "^5.9.2",
         "typescript-eslint": "^8.39.0",
         "vite": "^7.0.6",

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -37,7 +37,7 @@
     "eslint-config-prettier": "^10.1.8",
     "plotly.js": "^3.0.3",
     "prettier": "^3.6.2",
-    "rollup-plugin-node-externals": "^7.1.3",
+    "rollup-plugin-node-externals": "^8.0.1",
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
     "vite": "^7.0.6",


### PR DESCRIPTION
## Summary
- update rollup-plugin-node-externals to latest version

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892564fbc48832b8bfa98bd8ecbba1b