### PR TITLE
fix: correct polyfill path in plotly sample

### DIFF
--- a/samples/competitors/d3-plotly/index-plotly.html
+++ b/samples/competitors/d3-plotly/index-plotly.html
@@ -6,7 +6,7 @@
   </head>
   <body>
     <div id="plotly-container"></div>
-    <script type="text/javascript" src="../path-data-polyfill.js"></script>
+    <script type="text/javascript" src="../../benchmarks/path-data-polyfill.js"></script>
     <script type="module" src="dom-d3-plotly.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- fix relative path to `path-data-polyfill.js` in Plotly competitor sample

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68927e590894832bb65c0d97fa090e57