### PR TITLE
refactor: derive Vite options from mode

### DIFF
--- a/svg-time-series/vite.config.ts
+++ b/svg-time-series/vite.config.ts
@@ -2,17 +2,22 @@ import { UserConfig, defineConfig } from "vite";
 import nodeExternals from "rollup-plugin-node-externals";
 import dts from "vite-plugin-dts";
 
-export default defineConfig({
-  build: {
-    lib: {
-      entry: "src/draw.ts",
-      fileName: "index",
-      formats: ["es"],
+export default defineConfig(({ mode }) => {
+  const isProd = mode === "production";
+
+  return {
+    build: {
+      lib: {
+        entry: "src/draw.ts",
+        fileName: "index",
+        formats: ["es"],
+      },
+      rollupOptions: {
+        plugins: [nodeExternals()],
+      },
+      sourcemap: !isProd,
+      minify: isProd ? "esbuild" : false,
     },
-    rollupOptions: {
-      plugins: [nodeExternals()],
-    },
-    sourcemap: true,
-  },
-  plugins: [dts({ rollupTypes: true })],
-}) satisfies UserConfig;
+    plugins: [dts({ rollupTypes: true })],
+  } satisfies UserConfig;
+});


### PR DESCRIPTION
## Summary
- make Vite config mode-aware to toggle build flags

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689254e93be4832b83bffefb3e81f777