### PR TITLE
Use misc common utilities in sine samples

### DIFF
--- a/samples/misc/sine-recreate-dom/dom-first-rendering.ts
+++ b/samples/misc/sine-recreate-dom/dom-first-rendering.ts
@@ -1,4 +1,4 @@
-import { f, svg } from "../../benchmarks/demo2-without-grid/common.ts";
+import { f, svg } from "../common.ts";
 
 function createTranslate(x: number, y: number) {
   const translateTransform = svg.createSVGTransform();

--- a/samples/misc/sine-transform-d3/dom-d3.ts
+++ b/samples/misc/sine-transform-d3/dom-d3.ts
@@ -1,7 +1,7 @@
 ﻿import { selectAll } from "d3-selection";
 import { line as d3_line } from "d3-shape";
 
-import { f, run } from "../../benchmarks/demo2-without-grid/common.ts";
+import { f, run } from "../common.ts";
 
 const delta = 0;
 const scale = 0.2;

--- a/samples/misc/sine-transform-dom/dom.ts
+++ b/samples/misc/sine-transform-dom/dom.ts
@@ -1,4 +1,4 @@
-import * as common from "../../benchmarks/demo2-without-grid/common.ts";
+import * as common from "../common.ts";
 
 function createTranslate(x: number, y: number) {
   const translateTransform = common.svg.createSVGTransform();


### PR DESCRIPTION
## Summary
- Point sine sample imports to misc common utilities
- Ensure misc common exports include svg, f, and run

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928a6cb8f0832b9fd0930c8be7557d