### PR TITLE
chore: add typecheck scripts and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,5 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+      - run: npm run typecheck
       - run: npm test

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "npm run build --workspace=svg-time-series",
     "dev": "npm run dev --workspace=samples",
     "lint": "npm run lint --workspace=svg-time-series",
+    "typecheck": "npm run typecheck --workspace=svg-time-series && npm run typecheck --workspace=samples",
     "test": "vitest run"
   },
   "type": "module",

--- a/samples/package.json
+++ b/samples/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "type": "module",

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -48,6 +48,7 @@
     "prepare": "npm run build",
     "build": "tsc && vite build",
     "lint": "eslint src",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   }
 }


### PR DESCRIPTION
## Summary
- add `typecheck` script using `tsc --noEmit` to both packages
- run type checking as part of CI workflow

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892dfc66f88832bbb09f19bc510f5f8