### PR TITLE
chore: simplify tsconfig excludes

### DIFF
--- a/samples/tsconfig.json
+++ b/samples/tsconfig.json
@@ -6,10 +6,5 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true
-  },
-  "exclude": [
-    "misc/sine-recreate-dom",
-    "misc/sine-transform-d3",
-    "misc/sine-transform-dom"
-  ]
+  }
 }

--- a/svg-time-series/tsconfig.json
+++ b/svg-time-series/tsconfig.json
@@ -18,5 +18,5 @@
     "declaration": true,
     "declarationDir": "dist"
   },
-  "exclude": ["node_modules", "vite.config.ts", "**/*.test.ts"]
+  "exclude": ["vite.config.ts", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- drop unused exclude list from samples tsconfig so all sample sources are checked
- trim library tsconfig exclude list to rely on default node_modules handling

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892e2906dac832baf61c2a21551dbb8