### PR TITLE
refactor: modularize chart rendering

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,0 +1,75 @@
+import { AR1, AR1Basis, betweenTBasesAR1, bUnit } from "../math/affine.ts";
+import { IMinMax, SegmentTree } from "../segmentTree.ts";
+
+export type { IMinMax };
+
+export class ChartData {
+  public data: Array<[number, number]>;
+  public treeNy: SegmentTree;
+  public treeSf: SegmentTree;
+  public idxToTime: AR1;
+  private idxShift: AR1;
+  public bIndexFull: AR1Basis;
+  private buildSegmentTreeTupleNy: (
+    index: number,
+    elements: ReadonlyArray<[number, number]>,
+  ) => IMinMax;
+  private buildSegmentTreeTupleSf: (
+    index: number,
+    elements: ReadonlyArray<[number, number]>,
+  ) => IMinMax;
+
+  constructor(
+    startTime: number,
+    timeStep: number,
+    data: Array<[number, number]>,
+    buildSegmentTreeTupleNy: (
+      index: number,
+      elements: ReadonlyArray<[number, number]>,
+    ) => IMinMax,
+    buildSegmentTreeTupleSf: (
+      index: number,
+      elements: ReadonlyArray<[number, number]>,
+    ) => IMinMax,
+  ) {
+    this.data = data;
+    this.buildSegmentTreeTupleNy = buildSegmentTreeTupleNy;
+    this.buildSegmentTreeTupleSf = buildSegmentTreeTupleSf;
+    this.idxToTime = betweenTBasesAR1(
+      bUnit,
+      new AR1Basis(startTime, startTime + timeStep),
+    );
+    this.idxShift = betweenTBasesAR1(new AR1Basis(1, 2), bUnit);
+    this.bIndexFull = new AR1Basis(0, data.length - 1);
+    this.rebuildSegmentTrees();
+  }
+
+  append(newData: [number, number]): void {
+    this.data.push(newData);
+    this.data.shift();
+    this.idxToTime = this.idxToTime.composeWith(this.idxShift);
+    this.rebuildSegmentTrees();
+  }
+
+  private rebuildSegmentTrees(): void {
+    this.treeNy = new SegmentTree(
+      this.data,
+      this.data.length,
+      this.buildSegmentTreeTupleNy,
+    );
+    this.treeSf = new SegmentTree(
+      this.data,
+      this.data.length,
+      this.buildSegmentTreeTupleSf,
+    );
+  }
+
+  bTemperatureVisible(bIndexVisible: AR1Basis, tree: SegmentTree): AR1Basis {
+    const [minIdxX, maxIdxX] = bIndexVisible.toArr();
+    const { min, max } = tree.getMinMax(
+      Math.round(minIdxX),
+      Math.round(maxIdxX),
+    );
+    return new AR1Basis(min, max);
+  }
+}

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -1,0 +1,134 @@
+import { BaseType, Selection, select } from "d3-selection";
+import { zoom as d3zoom, D3ZoomEvent, ZoomTransform } from "d3-zoom";
+import { timeout as runTimeout } from "d3-timer";
+
+import { updateNode } from "../viewZoomTransform.ts";
+import type { ChartData } from "./data.ts";
+import type { RenderState } from "./render.ts";
+import { refreshChart, renderPaths } from "./render.ts";
+
+function drawProc<T extends unknown[]>(f: (...args: T) => void): (...args: T) => void {
+  let requested = false;
+
+  return (...params: T) => {
+    if (!requested) {
+      requested = true;
+      runTimeout(() => {
+        requested = false;
+        f(...params);
+      });
+    }
+  };
+}
+
+export function setupInteraction(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  legend: Selection<BaseType, unknown, HTMLElement, unknown>,
+  state: RenderState,
+  data: ChartData,
+  zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
+  mouseMoveHandler: (event: MouseEvent) => void,
+) {
+  const legendTime = legend.select(".chart-legend__time");
+  const legendGreen = legend.select(".chart-legend__green_value");
+  const legendBlue = legend.select(".chart-legend__blue_value");
+
+  const zoomArea = svg
+    .append("rect")
+    .attr("class", "zoom")
+    .attr("width", state.width)
+    .attr("height", state.height)
+    .call(
+      d3zoom()
+        .scaleExtent([1, 40])
+        .translateExtent([
+          [0, 0],
+          [state.width, state.height],
+        ])
+        .on("zoom", (event: D3ZoomEvent<Element, unknown>) => {
+          zoomHandler(event);
+          zoom(event);
+        }),
+    );
+  zoomArea.on("mousemove", mouseMoveHandler);
+
+  let currentPanZoomTransformState: ZoomTransform = null;
+  const dotRadius = 3;
+  const makeDot = (view: SVGGElement) =>
+    select(view)
+      .append("circle")
+      .attr("cx", 0)
+      .attr("cy", 0)
+      .attr("r", 1)
+      .node() as SVGCircleElement;
+  const highlightedGreenDot = makeDot(state.viewNy);
+  const highlightedBlueDot = makeDot(state.viewSf);
+
+  const identityMatrix = document
+    .createElementNS("http://www.w3.org/2000/svg", "svg")
+    .createSVGMatrix();
+
+  let highlightedDataIdx = 0;
+
+  const scheduleRefresh = drawProc(() => {
+    if (currentPanZoomTransformState != null) {
+      d3zoom().transform(zoomArea, currentPanZoomTransformState);
+    }
+    refreshChart(state, data);
+  });
+
+  const schedulePointRefresh = drawProc(() => {
+    updateLegendAndDots();
+  });
+
+  function zoom(event: D3ZoomEvent<Element, unknown>) {
+    currentPanZoomTransformState = event.transform;
+    state.pathTransformNy.onZoomPan(event.transform);
+    state.pathTransformSf.onZoomPan(event.transform);
+    scheduleRefresh();
+    schedulePointRefresh();
+  }
+
+  function onHover(x: number) {
+    highlightedDataIdx = state.pathTransformNy.fromScreenToModelX(x);
+    schedulePointRefresh();
+  }
+
+  function updateLegendAndDots() {
+    const [greenData, blueData] = data.data[Math.round(highlightedDataIdx)];
+
+    legendTime.text(
+      new Date(data.idxToTime.applyToPoint(highlightedDataIdx)).toLocaleString(),
+    );
+
+    const dotScaleMatrixNy = state.pathTransformNy.dotScaleMatrix(dotRadius);
+    const dotScaleMatrixSf = state.pathTransformSf.dotScaleMatrix(dotRadius);
+    const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
+      isNaN(n) ? valueForNaN : n;
+    const updateDot = (
+      val: number,
+      legendSel: Selection<BaseType, unknown, HTMLElement, unknown>,
+      node: SVGGraphicsElement,
+      dotScaleMatrix: SVGMatrix,
+    ) => {
+      legendSel.text(fixNaN(val, " "));
+      updateNode(
+        node,
+        identityMatrix
+          .translate(highlightedDataIdx, fixNaN(val, 0))
+          .multiply(dotScaleMatrix),
+      );
+    };
+
+    updateDot(greenData, legendGreen, highlightedGreenDot, dotScaleMatrixNy);
+    updateDot(blueData, legendBlue, highlightedBlueDot, dotScaleMatrixSf);
+  }
+
+  function drawNewData() {
+    renderPaths(state, data.data);
+    scheduleRefresh();
+    schedulePointRefresh();
+  }
+
+  return { zoom, onHover, drawNewData };
+}

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -1,0 +1,189 @@
+import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
+import { BaseType, Selection, select } from "d3-selection";
+import { line } from "d3-shape";
+
+import { MyAxis, Orientation } from "../axis.ts";
+import { MyTransform } from "../MyTransform.ts";
+import { AR1Basis, bPlaceholder } from "../math/affine.ts";
+import { SegmentTree } from "../segmentTree.ts";
+import type { ChartData } from "./data.ts";
+
+function bindAxisToDom(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  axis: MyAxis,
+  scale1: ScaleLinear<number, number> | ScaleTime<number, number>,
+  scale2?: ScaleLinear<number, number> | ScaleTime<number, number>,
+) {
+  axis.setScale(scale1, scale2);
+  return svg.append("g").attr("class", "axis").call(axis.axis.bind(axis));
+}
+
+function updateScaleX(
+  x: ScaleTime<number, number>,
+  bIndexVisible: AR1Basis,
+  data: ChartData,
+) {
+  const bTimeVisible = bIndexVisible.transformWith(data.idxToTime);
+  x.domain(bTimeVisible.toArr());
+}
+
+function updateScaleY(
+  bIndexVisible: AR1Basis,
+  tree: SegmentTree,
+  pathTransform: MyTransform,
+  yScale: ScaleLinear<number, number>,
+  data: ChartData,
+) {
+  const bTemperatureVisible = data.bTemperatureVisible(bIndexVisible, tree);
+  pathTransform.onReferenceViewWindowResize(
+    data.bIndexFull,
+    bTemperatureVisible,
+  );
+  yScale.domain(bTemperatureVisible.toArr());
+}
+
+export interface RenderState {
+  x: ScaleTime<number, number>;
+  yNy: ScaleLinear<number, number>;
+  ySf: ScaleLinear<number, number>;
+  pathTransformNy: MyTransform;
+  pathTransformSf: MyTransform;
+  xAxis: MyAxis;
+  yAxis: MyAxis;
+  gX: Selection<SVGGElement, unknown, any, any>;
+  gY: Selection<SVGGElement, unknown, any, any>;
+  path: Selection<SVGPathElement, number, any, unknown>;
+  bScreenXVisible: AR1Basis;
+  width: number;
+  height: number;
+  viewNy: SVGGElement;
+  viewSf: SVGGElement;
+}
+
+export function setupRender(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  data: ChartData,
+): RenderState {
+  const node: SVGSVGElement = svg.node() as SVGSVGElement;
+  const div: HTMLElement = node.parentNode as HTMLElement;
+
+  const width = div.clientWidth;
+  const height = div.clientHeight;
+
+  svg.attr("width", width);
+  svg.attr("height", height);
+
+  const views = svg
+    .selectAll("g")
+    .data([0, 1])
+    .enter()
+    .append("g")
+    .attr("class", "view");
+  const [viewNy, viewSf] = views.nodes() as SVGGElement[];
+
+  const path = views.append("path");
+
+  const bScreenXVisible = new AR1Basis(0, width);
+  const bScreenYVisible = new AR1Basis(height, 0);
+
+  const x: ScaleTime<number, number> = scaleTime().range(
+    bScreenXVisible.toArr(),
+  );
+  const yNy: ScaleLinear<number, number> = scaleLinear().range(
+    bScreenYVisible.toArr(),
+  );
+  const ySf: ScaleLinear<number, number> = scaleLinear().range(
+    bScreenYVisible.toArr(),
+  );
+
+  const pathTransformNy = new MyTransform(
+    svg.node() as SVGSVGElement,
+    viewNy,
+  );
+  const pathTransformSf = new MyTransform(
+    svg.node() as SVGSVGElement,
+    viewSf,
+  );
+
+  updateScaleX(x, data.bIndexFull, data);
+  updateScaleY(data.bIndexFull, data.treeNy, pathTransformNy, yNy, data);
+  updateScaleY(data.bIndexFull, data.treeSf, pathTransformSf, ySf, data);
+
+  const xAxis = new MyAxis(Orientation.Bottom, x)
+    .ticks(4)
+    .setTickSize(height)
+    .setTickPadding(8 - height);
+
+  const yAxis = new MyAxis(Orientation.Right, yNy, ySf)
+    .ticks(4, "s")
+    .setTickSize(width)
+    .setTickPadding(2 - width);
+
+  const gX = bindAxisToDom(svg, xAxis, x);
+  const gY = bindAxisToDom(svg, yAxis, yNy, ySf);
+
+  pathTransformNy.onViewPortResize(bScreenXVisible, bScreenYVisible);
+  pathTransformSf.onViewPortResize(bScreenXVisible, bScreenYVisible);
+  pathTransformNy.onReferenceViewWindowResize(data.bIndexFull, bPlaceholder);
+  pathTransformSf.onReferenceViewWindowResize(data.bIndexFull, bPlaceholder);
+
+  return {
+    x,
+    yNy,
+    ySf,
+    pathTransformNy,
+    pathTransformSf,
+    xAxis,
+    yAxis,
+    gX,
+    gY,
+    path,
+    bScreenXVisible,
+    width,
+    height,
+    viewNy,
+    viewSf,
+  };
+}
+
+export function renderPaths(
+  state: RenderState,
+  dataArr: Array<[number, number]>,
+) {
+  const drawLine = (cityIdx: number) =>
+    line()
+      .defined((d: [number, number]) => {
+        return !(isNaN(d[cityIdx]) || d[cityIdx] == null);
+      })
+      .x((d: [number, number], i: number) => i)
+      .y((d: [number, number]) => d[cityIdx]);
+
+  state.path.attr("d", (cityIndex: number) =>
+    drawLine(cityIndex).call(null, dataArr),
+  );
+}
+
+export function refreshChart(state: RenderState, data: ChartData) {
+  const bIndexVisible = state.pathTransformNy.fromScreenToModelBasisX(
+    state.bScreenXVisible,
+  );
+  updateScaleX(state.x, bIndexVisible, data);
+  updateScaleY(
+    bIndexVisible,
+    data.treeNy,
+    state.pathTransformNy,
+    state.yNy,
+    data,
+  );
+  updateScaleY(
+    bIndexVisible,
+    data.treeSf,
+    state.pathTransformSf,
+    state.ySf,
+    data,
+  );
+  state.pathTransformNy.updateViewNode();
+  state.pathTransformSf.updateViewNode();
+  state.xAxis.axisUp(state.gX);
+  state.yAxis.axisUp(state.gY);
+}

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,91 +1,17 @@
-﻿import { ScaleLinear, scaleLinear, ScaleTime, scaleTime } from "d3-scale";
-import { BaseType, select, Selection } from "d3-selection";
-import { line } from "d3-shape";
-import { timeout as runTimeout } from "d3-timer";
-import { zoom as d3zoom, ZoomTransform, D3ZoomEvent } from "d3-zoom";
+import { BaseType, Selection } from "d3-selection";
+import { D3ZoomEvent } from "d3-zoom";
 
-import { MyAxis, Orientation } from "./axis.ts";
-import { MyTransform } from "./MyTransform.ts";
-import { updateNode } from "./viewZoomTransform.ts";
-import { IMinMax, SegmentTree } from "./segmentTree.ts";
-import {
-  AR1,
-  AR1Basis,
-  betweenTBasesAR1,
-  bPlaceholder,
-  bUnit,
-} from "./math/affine.ts";
+import { ChartData, IMinMax } from "./chart/data.ts";
+import { setupRender } from "./chart/render.ts";
+import { setupInteraction } from "./chart/interaction.ts";
 
-export type { IMinMax };
-
-function drawProc<T extends unknown[]>(f: (...args: T) => void): (...args: T) => void {
-  let requested = false;
-
-  return (...params: T) => {
-    if (!requested) {
-      requested = true;
-      runTimeout(() => {
-        requested = false;
-        f(...params);
-      });
-    }
-  };
-}
-
-function bindAxisToDom(
-  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
-  axis: MyAxis,
-  scale1: ScaleLinear<number, number> | ScaleTime<number, number>,
-  scale2?: ScaleLinear<number, number> | ScaleTime<number, number>,
-) {
-  axis.setScale(scale1, scale2);
-  return svg.append("g").attr("class", "axis").call(axis.axis.bind(axis));
-}
+export type { IMinMax } from "./chart/data.ts";
 
 export class TimeSeriesChart {
   public zoom: (event: D3ZoomEvent<Element, unknown>) => void;
   public onHover: (x: number) => void;
   private drawNewData: () => void;
-  private data: Array<[number, number]>;
-
-  // updated when a new point is added
-  private treeNy: SegmentTree;
-  private treeSf: SegmentTree;
-
-  // Updated when a new point is added
-  // used to convert indices to dates shown by X axis
-  // Date.now() style timestamp
-  private timeAtIdx0: number;
-
-  // Step by X axis
-  // Date.now() style timestamp delta
-  private timeStep: number;
-
-  // Affine transformation mapping index space to time space
-  private idxToTime: AR1;
-
-  // Shift within index space applied when a point is appended
-  private idxShift: AR1;
-
-  // Basis spanning the full index range
-  private bIndexFull: AR1Basis;
-
-  private buildSegmentTreeTupleNy: (
-    index: number,
-    elements: ReadonlyArray<[number, number]>,
-  ) => IMinMax;
-  private buildSegmentTreeTupleSf: (
-    index: number,
-    elements: ReadonlyArray<[number, number]>,
-  ) => IMinMax;
-  private zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void;
-  private mouseMoveHandler: (event: MouseEvent) => void;
-
-  private legendTime: Selection<BaseType, unknown, HTMLElement, unknown>;
-  private legendGreen: Selection<BaseType, unknown, HTMLElement, unknown>;
-  private legendBlue: Selection<BaseType, unknown, HTMLElement, unknown>;
-
-  private highlightedDataIdx: number;
+  private data: ChartData;
 
   constructor(
     svg: Selection<BaseType, unknown, HTMLElement, unknown>,
@@ -104,366 +30,34 @@ export class TimeSeriesChart {
     zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
     mouseMoveHandler: (event: MouseEvent) => void,
   ) {
-    this.legendTime = legend.select(".chart-legend__time");
-    this.legendGreen = legend.select(".chart-legend__green_value");
-    this.legendBlue = legend.select(".chart-legend__blue_value");
-
-    // The second basis is defined by a point and a vector.
-    // Equivalent to new AR1(startTime, timeStep) but avoids coordinate thinking.
-    this.idxToTime = betweenTBasesAR1(
-      bUnit,
-      new AR1Basis(startTime, startTime + timeStep),
+    this.data = new ChartData(
+      startTime,
+      timeStep,
+      data,
+      buildSegmentTreeTupleNy,
+      buildSegmentTreeTupleSf,
     );
 
-    // When a new point is added, elements 1 and 2 shift to positions 0 and 1
-    this.idxShift = betweenTBasesAR1(new AR1Basis(1, 2), bUnit);
-    this.buildSegmentTreeTupleNy = buildSegmentTreeTupleNy;
-    this.buildSegmentTreeTupleSf = buildSegmentTreeTupleSf;
-    this.zoomHandler = zoomHandler;
-    this.mouseMoveHandler = mouseMoveHandler;
-    this.bIndexFull = new AR1Basis(0, data.length - 1);
-    this.drawChart(svg, data);
+    const renderState = setupRender(svg, this.data);
+    const { zoom, onHover, drawNewData } = setupInteraction(
+      svg,
+      legend,
+      renderState,
+      this.data,
+      zoomHandler,
+      mouseMoveHandler,
+    );
+
+    this.zoom = zoom;
+    this.onHover = onHover;
+    this.drawNewData = drawNewData;
+
+    this.drawNewData();
+    this.onHover(renderState.width);
   }
 
   public updateChartWithNewData(newData: [number, number]) {
-    this.data.push(newData);
-    this.data.shift();
-
-    this.idxToTime = this.idxToTime.composeWith(this.idxShift);
-
+    this.data.append(newData);
     this.drawNewData();
-  }
-
-  private drawChart(
-    svg: Selection<BaseType, unknown, HTMLElement, unknown>,
-    data: Array<[number, number]>,
-  ) {
-    this.data = data;
-
-    const node: SVGSVGElement = svg.node() as SVGSVGElement;
-    const div: HTMLElement = node.parentNode as HTMLElement;
-
-    const width = div.clientWidth;
-    const height = div.clientHeight;
-
-    svg.attr("width", width);
-    svg.attr("height", height);
-
-    // Verbose way to append two <g> elements
-    // .enter() is D3's update helper; we handle updates manually
-    const views = svg
-      .selectAll("g")
-      .data([0, 1])
-      .enter()
-      .append("g")
-      .attr("class", "view");
-    const [viewNy, viewSf] = views.nodes() as SVGGElement[];
-
-    const path = views.append("path");
-
-    // The viewport is treated as a separate space.
-    // Y is inverted, so its basis is flipped relative to X.
-    const bScreenXVisible = new AR1Basis(0, width);
-    const bScreenYVisible = new AR1Basis(height, 0);
-
-    // Interface to legacy code; the verbosity is acceptable
-    const x: ScaleTime<number, number> = scaleTime().range(
-      bScreenXVisible.toArr(),
-    );
-    const yNy: ScaleLinear<number, number> = scaleLinear().range(
-      bScreenYVisible.toArr(),
-    );
-    const ySf: ScaleLinear<number, number> = scaleLinear().range(
-      bScreenYVisible.toArr(),
-    );
-
-    const pathTransformNy = new MyTransform(
-      svg.node() as SVGSVGElement,
-      viewNy,
-    );
-    const pathTransformSf = new MyTransform(
-      svg.node() as SVGSVGElement,
-      viewSf,
-    );
-
-    this.rebuildSegmentTrees();
-
-    // All data is initially visible; pass bIndexFull as bIndexVisible
-    this.updateScaleX(x, this.bIndexFull);
-    this.updateScaleY(
-      this.bIndexFull,
-      this.treeNy,
-      pathTransformNy,
-      yNy,
-    );
-    this.updateScaleY(
-      this.bIndexFull,
-      this.treeSf,
-      pathTransformSf,
-      ySf,
-    );
-
-    const xAxis = new MyAxis(Orientation.Bottom, x)
-      .ticks(4)
-      // Tick size must change when the window size changes
-      .setTickSize(height)
-      .setTickPadding(8 - height);
-
-    const yAxis = new MyAxis(Orientation.Right, yNy, ySf)
-      .ticks(4, "s")
-      .setTickSize(width)
-      .setTickPadding(2 - width);
-
-    const gX = bindAxisToDom(svg, xAxis, x);
-    const gY = bindAxisToDom(svg, yAxis, yNy, ySf);
-
-    const zoomArea = svg
-      .append("rect")
-      .attr("class", "zoom")
-      .attr("width", width)
-      .attr("height", height)
-      .call(
-        d3zoom()
-          .scaleExtent([1, 40])
-          // Eventually take extent from bScreenVisible, though axis order is unclear
-          .translateExtent([
-            [0, 0],
-            [width, height],
-          ])
-          .on("zoom", this.zoomHandler.bind(this)),
-      );
-    zoomArea.on("mousemove", this.mouseMoveHandler.bind(this));
-
-    let currentPanZoomTransformState: ZoomTransform = null;
-    const dotRadius = 3;
-    const makeDot = (view: SVGGElement) =>
-      select(view)
-        .append("circle")
-        .attr("cx", 0)
-        .attr("cy", 0)
-        .attr("r", 1)
-        .node() as SVGCircleElement;
-    const highlightedGreenDot = makeDot(viewNy);
-    const highlightedBlueDot = makeDot(viewSf);
-
-    const identityMatrix = document
-      .createElementNS("http://www.w3.org/2000/svg", "svg")
-      .createSVGMatrix();
-
-    // it's important that we have only 1 instance
-    // of drawProc and not one per event
-    // Called from zoom and drawNewData
-    const scheduleRefresh = drawProc(() =>
-      this.refreshChart(
-        zoomArea,
-        currentPanZoomTransformState,
-        bScreenXVisible,
-        pathTransformNy,
-        pathTransformSf,
-        x,
-        yNy,
-        ySf,
-        xAxis,
-        yAxis,
-        gX,
-        gY,
-      ),
-    );
-
-    const schedulePointRefresh = drawProc(() =>
-      this.updateLegendAndDots(
-        pathTransformNy,
-        pathTransformSf,
-        highlightedGreenDot,
-        highlightedBlueDot,
-        dotRadius,
-        identityMatrix,
-      ),
-    );
-
-    pathTransformNy.onViewPortResize(bScreenXVisible, bScreenYVisible);
-    pathTransformSf.onViewPortResize(bScreenXVisible, bScreenYVisible);
-    pathTransformNy.onReferenceViewWindowResize(this.bIndexFull, bPlaceholder);
-    pathTransformSf.onReferenceViewWindowResize(this.bIndexFull, bPlaceholder);
-
-    // Called here and by updateChartWithNewData();
-    // should probably live in common.ts
-    this.drawNewData = () => {
-      this.rebuildSegmentTrees();
-      this.renderPaths(path);
-      scheduleRefresh();
-      schedulePointRefresh();
-    };
-
-    this.drawNewData();
-
-    // Public method used to relay zoom events to multiple charts
-    this.zoom = (d3event: D3ZoomEvent<Element, unknown>) => {
-      currentPanZoomTransformState = d3event.transform;
-
-      pathTransformNy.onZoomPan(d3event.transform);
-      pathTransformSf.onZoomPan(d3event.transform);
-      scheduleRefresh();
-      schedulePointRefresh();
-    };
-
-    const highlight = (dataIdx: number) => {
-      this.highlightedDataIdx = dataIdx;
-    };
-
-    this.onHover = (x: number) => {
-      // Visible index is the same for NY and SF
-      highlight(pathTransformNy.fromScreenToModelX(x));
-      schedulePointRefresh();
-    };
-
-    this.onHover(width);
-  }
-
-  private updateScaleX(
-    x: ScaleTime<number, number>,
-    bIndexVisible: AR1Basis,
-  ) {
-    const bTimeVisible = bIndexVisible.transformWith(this.idxToTime);
-    x.domain(bTimeVisible.toArr());
-  }
-
-  private updateScaleY(
-    bIndexVisible: AR1Basis,
-    tree: SegmentTree,
-    pathTransform: MyTransform,
-    yScale: ScaleLinear<number, number>,
-  ) {
-    const bTemperatureVisible = this.bTemperatureVisible(bIndexVisible, tree);
-    pathTransform.onReferenceViewWindowResize(
-      this.bIndexFull,
-      bTemperatureVisible,
-    );
-
-    yScale.domain(bTemperatureVisible.toArr());
-  }
-
-  private refreshChart(
-    zoomArea: Selection<SVGRectElement, unknown, any, any>,
-    currentPanZoomTransformState: ZoomTransform,
-    bScreenXVisible: AR1Basis,
-    pathTransformNy: MyTransform,
-    pathTransformSf: MyTransform,
-    x: ScaleTime<number, number>,
-    yNy: ScaleLinear<number, number>,
-    ySf: ScaleLinear<number, number>,
-    xAxis: MyAxis,
-    yAxis: MyAxis,
-    gX: Selection<SVGGElement, unknown, any, any>,
-    gY: Selection<SVGGElement, unknown, any, any>,
-  ) {
-    if (currentPanZoomTransformState != null) {
-      d3zoom().transform(zoomArea, currentPanZoomTransformState);
-    }
-
-    const bIndexVisible =
-      pathTransformNy.fromScreenToModelBasisX(bScreenXVisible);
-
-    this.updateScaleX(x, bIndexVisible);
-    this.updateScaleY(bIndexVisible, this.treeNy, pathTransformNy, yNy);
-    this.updateScaleY(bIndexVisible, this.treeSf, pathTransformSf, ySf);
-
-    pathTransformNy.updateViewNode();
-    pathTransformSf.updateViewNode();
-
-    xAxis.axisUp(gX);
-    yAxis.axisUp(gY);
-  }
-
-  private rebuildSegmentTrees() {
-    this.treeNy = new SegmentTree(
-      this.data,
-      this.data.length,
-      this.buildSegmentTreeTupleNy,
-    );
-    this.treeSf = new SegmentTree(
-      this.data,
-      this.data.length,
-      this.buildSegmentTreeTupleSf,
-    );
-  }
-
-  private renderPaths(
-    path: Selection<SVGPathElement, number, any, unknown>,
-  ) {
-    const drawLine = (cityIdx: number) =>
-      line()
-        .defined((d: [number, number]) => {
-          return !(isNaN(d[cityIdx]) || d[cityIdx] == null);
-        })
-        .x((d: [number, number], i: number) => i)
-        .y((d: [number, number]) => d[cityIdx]);
-
-    path.attr("d", (cityIndex: number) =>
-      drawLine(cityIndex).call(null, this.data),
-    );
-  }
-
-  private updateLegendAndDots(
-    pathTransformNy: MyTransform,
-    pathTransformSf: MyTransform,
-    highlightedGreenDot: SVGCircleElement,
-    highlightedBlueDot: SVGCircleElement,
-    dotRadius: number,
-    identityMatrix: SVGMatrix,
-  ) {
-    const [greenData, blueData] =
-      this.data[Math.round(this.highlightedDataIdx)];
-
-    this.legendTime.text(
-      new Date(
-        this.idxToTime.applyToPoint(this.highlightedDataIdx),
-      ).toLocaleString(),
-    );
-
-    const dotScaleMatrixNy = pathTransformNy.dotScaleMatrix(dotRadius);
-    const dotScaleMatrixSf = pathTransformSf.dotScaleMatrix(dotRadius);
-    const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
-      isNaN(n) ? valueForNaN : n;
-    const updateDot = (
-      greenData: number,
-      legend: Selection<BaseType, unknown, HTMLElement, unknown>,
-      node: SVGGraphicsElement,
-      dotScaleMatrix: SVGMatrix,
-    ) => {
-      legend.text(fixNaN(greenData, " "));
-      updateNode(
-        node,
-        identityMatrix
-          .translate(this.highlightedDataIdx, fixNaN(greenData, 0))
-          .multiply(dotScaleMatrix),
-      );
-    };
-
-    updateDot(
-      greenData,
-      this.legendGreen,
-      highlightedGreenDot,
-      dotScaleMatrixNy,
-    );
-    updateDot(
-      blueData,
-      this.legendBlue,
-      highlightedBlueDot,
-      dotScaleMatrixSf,
-    );
-  }
-
-  private bTemperatureVisible(
-    bIndexVisible: AR1Basis,
-    tree: SegmentTree,
-  ): AR1Basis {
-    // Simple mapping between bases
-    const [minIdxX, maxIdxX] = bIndexVisible.toArr();
-    const { min, max } = tree.getMinMax(
-      Math.round(minIdxX),
-      Math.round(maxIdxX),
-    );
-    return new AR1Basis(min, max);
   }
 }


### PR DESCRIPTION
## Summary
- Move data bookkeeping (segment trees, index-time transforms) to `chart/data.ts`
- Move DOM scales, axes, and path rendering to `chart/render.ts`
- Extract zoom, hover, and legend handling into `chart/interaction.ts`
- Slim `TimeSeriesChart` to coordinate data, render, and interaction modules

## Testing
- `npx vitest`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892e58ce1d4832b93fc1bbd8081dc49