### PR TITLE
refactor: add toModelPoint helper for screen-to-model conversions

### DIFF
--- a/svg-time-series/src/MyTransform.test.ts
+++ b/svg-time-series/src/MyTransform.test.ts
@@ -98,4 +98,21 @@ describe("MyTransform", () => {
     expect(p1).toBeCloseTo(0.5);
     expect(p2).toBeCloseTo(1.5);
   });
+
+  it("converts screen points to model points", () => {
+    const svg = {
+      createSVGMatrix: () => new Matrix(),
+      createSVGPoint: () => new Point(),
+    } as unknown as SVGSVGElement;
+    const g = {} as unknown as SVGGElement;
+    const mt = new MyTransform(svg, g);
+
+    mt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
+    mt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    mt.onZoomPan({ x: 10, k: 2 } as any);
+
+    const p = (mt as any).toModelPoint(70, 20) as { x: number; y: number };
+    expect(p.x).toBeCloseTo(3);
+    expect(p.y).toBeCloseTo(2);
+  });
 });

--- a/svg-time-series/src/MyTransform.ts
+++ b/svg-time-series/src/MyTransform.ts
@@ -92,24 +92,22 @@ export class MyTransform {
       .scaleNonUniform(t.k, 1);
   }
 
-  public fromScreenToModelX(x: number) {
+  private toModelPoint(x: number, y: number) {
     const fwd = this.zoomTransform.multiply(this.referenceTransform);
     const bwd = fwd.inverse();
 
     const p = this.svgNode.createSVGPoint();
     p.x = x;
-    p.y = 0; // irrelevant
-    return p.matrixTransform(bwd).x;
+    p.y = y;
+    return p.matrixTransform(bwd);
+  }
+
+  public fromScreenToModelX(x: number) {
+    return this.toModelPoint(x, 0).x;
   }
 
   public fromScreenToModelY(y: number) {
-    const fwd = this.zoomTransform.multiply(this.referenceTransform);
-    const bwd = fwd.inverse();
-
-    const p = this.svgNode.createSVGPoint();
-    p.x = 0; // irrelevant
-    p.y = y;
-    return p.matrixTransform(bwd).y;
+    return this.toModelPoint(0, y).y;
   }
 
   public dotScaleMatrix(dotRadius: number) {
@@ -136,16 +134,7 @@ export class MyTransform {
   }
 
   public fromScreenToModelBasisX(b: AR1Basis) {
-    const fwd = this.zoomTransform.multiply(this.referenceTransform);
-    const bwd = fwd.inverse();
-
-    const p = this.svgNode.createSVGPoint();
-    p.y = 0; // irrelevant
-
-    const transformPoint = (x: number) => {
-      p.x = x;
-      return p.matrixTransform(bwd).x;
-    };
+    const transformPoint = (x: number) => this.toModelPoint(x, 0).x;
     const [p1, p2] = b.toArr().map(transformPoint);
     return new AR1Basis(p1, p2);
   }


### PR DESCRIPTION
## Summary
- add private `toModelPoint` helper to centralize screen-to-model conversion math
- refactor conversion helpers to use `toModelPoint`
- extend tests to cover `toModelPoint`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892ed76de6c832bb14930ec4c5586d5