### PR TITLE
refactor: extract segment tree to workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "svg-time-series-monorepo",
       "workspaces": [
+        "segment-tree-rmq",
         "svg-time-series",
         "samples"
       ],
@@ -6431,6 +6432,10 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/segment-tree-rmq": {
+      "resolved": "segment-tree-rmq",
+      "link": true
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -7487,6 +7492,19 @@
         "@types/plotly.js": "^3.0.3"
       }
     },
+    "segment-tree-rmq": {
+      "version": "0.1.0",
+      "license": "WTFPL",
+      "devDependencies": {
+        "@eslint/js": "^9.32.0",
+        "eslint": "^9.32.0",
+        "eslint-config-prettier": "^10.1.8",
+        "prettier": "^3.6.2",
+        "typescript": "^5.9.2",
+        "typescript-eslint": "^8.39.0",
+        "vitest": "^3.2.4"
+      }
+    },
     "svg-time-series": {
       "version": "0.1.0",
       "license": "WTFPL",
@@ -7495,7 +7513,8 @@
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
         "d3-timer": "^3.0.1",
-        "d3-zoom": "^3.0.0"
+        "d3-zoom": "^3.0.0",
+        "segment-tree-rmq": "^0.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,17 @@
   "name": "svg-time-series-monorepo",
   "private": true,
   "scripts": {
-    "build": "npm run build --workspace=svg-time-series",
+    "build": "npm run build --workspace=segment-tree-rmq && npm run build --workspace=svg-time-series",
     "dev": "npm run dev --workspace=samples",
-    "lint": "npm run lint --workspace=svg-time-series",
-    "typecheck": "npm run typecheck --workspace=svg-time-series && npm run typecheck --workspace=samples",
+    "lint": "npm run lint --workspace=segment-tree-rmq && npm run lint --workspace=svg-time-series",
+    "typecheck": "npm run typecheck --workspace=segment-tree-rmq && npm run typecheck --workspace=svg-time-series && npm run typecheck --workspace=samples",
     "test": "vitest run",
     "format": "prettier . --write",
     "format:check": "prettier . --check"
   },
   "type": "module",
   "workspaces": [
+    "segment-tree-rmq",
     "svg-time-series",
     "samples"
   ],

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "segment-tree-rmq",
+  "version": "0.1.0",
+  "description": "Generic segment tree implementation for range queries",
+  "license": "WTFPL",
+  "files": [
+    "src/*"
+  ],
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.32.0",
+    "eslint": "^9.32.0",
+    "eslint-config-prettier": "^10.1.8",
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.2",
+    "typescript-eslint": "^8.39.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -1,6 +1,6 @@
 export type Operator<T> = (a: T, b: T) => T;
 
-export class SegmentTreeHalf<T> {
+export class SegmentTree<T> {
   private size: number;
   private tree: T[];
   private op: Operator<T>;
@@ -12,7 +12,6 @@ export class SegmentTreeHalf<T> {
     this.op = op;
     this.identity = identity;
 
-    // Build the tree
     for (let i = 0; i < this.size; i++) {
       this.tree[this.size + i] = data[i];
     }

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -1,99 +1,100 @@
 import { describe, expect, it } from "vitest";
-import { SegmentTreeHalf } from "./segmentTreeHalf";
+import { SegmentTree } from "./index";
 
-describe("Segment Tree (Foo) Tests", () => {
+describe("Segment Tree Tests", () => {
   it("should return the correct value for single element queries", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(0, 0)).toBe(1); // First element
-    expect(tree.query(7, 7)).toBe(8); // Last element
+    expect(tree.query(0, 0)).toBe(1);
+    expect(tree.query(7, 7)).toBe(8);
   });
 
   it("should return the correct sum for the full range", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(0, 7)).toBe(36); // Sum of all elements
+    expect(tree.query(0, 7)).toBe(36);
   });
 
   it("should handle a query that includes the last element correctly", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(4, 7)).toBe(26); // 5 + 6 + 7 + 8 = 26
+    expect(tree.query(4, 7)).toBe(26);
   });
 
   it("should return the correct sum for a subset of the range", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(1, 3)).toBe(9); // 2 + 3 + 4 = 9
+    expect(tree.query(1, 3)).toBe(9);
   });
 
   it("should correctly update a value and reflect it in the queries", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    tree.update(3, 10); // Update value at index 3 (4 -> 10)
-    expect(tree.query(0, 7)).toBe(42); // Sum should now be 42
-    expect(tree.query(1, 3)).toBe(15); // 2 + 3 + 10 = 15
+    tree.update(3, 10);
+    expect(tree.query(0, 7)).toBe(42);
+    expect(tree.query(1, 3)).toBe(15);
   });
+
   it("should handle an odd-sized array correctly", () => {
     const data = [1, 3, 5, 7, 9];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(0, 4)).toBe(25); // Sum of all elements: 1 + 3 + 5 + 7 + 9 = 25
-    expect(tree.query(2, 4)).toBe(21); // Sum of last 3 elements: 5 + 7 + 9 = 21
-    expect(tree.query(1, 3)).toBe(15); // Sum of middle elements: 3 + 5 + 7 = 15
+    expect(tree.query(0, 4)).toBe(25);
+    expect(tree.query(2, 4)).toBe(21);
+    expect(tree.query(1, 3)).toBe(15);
   });
 
   it("should handle a single-element array", () => {
     const data = [42];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(0, 0)).toBe(42); // Querying the only element
+    expect(tree.query(0, 0)).toBe(42);
   });
 
   it("should handle a range that includes the very last element of the array", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(tree.query(5, 7)).toBe(21); // 6 + 7 + 8 = 21
+    expect(tree.query(5, 7)).toBe(21);
   });
 
   it("should reflect updates to the last element in range queries", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
-    tree.update(7, 10); // Update the last element (8 -> 10)
-    expect(tree.query(5, 7)).toBe(23); // 6 + 7 + 10 = 23
-    expect(tree.query(0, 7)).toBe(38); // Sum of all elements with updated last element
+    tree.update(7, 10);
+    expect(tree.query(5, 7)).toBe(23);
+    expect(tree.query(0, 7)).toBe(38);
   });
 
   it("should throw an error for invalid ranges", () => {
     const data = [1, 2, 3, 4, 5];
     const sumOperator = (a: number, b: number) => a + b;
     const identity = 0;
-    const tree = new SegmentTreeHalf(data, sumOperator, identity);
+    const tree = new SegmentTree(data, sumOperator, identity);
 
     expect(() => tree.query(3, 2)).toThrow("Range is not valid");
     expect(() => tree.query(-1, 2)).toThrow("Range is not valid");

--- a/segment-tree-rmq/tsconfig.json
+++ b/segment-tree-rmq/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "useDefineForClassFields": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "esModuleInterop": true,
+    "lib": ["dom", "es7"],
+    "target": "ES2022",
+    "noImplicitAny": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": false,
+    "sourceMap": true,
+    "outDir": "dist",
+    "declaration": true,
+    "declarationDir": "dist"
+  },
+  "exclude": ["**/*.test.ts"]
+}

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -19,7 +19,8 @@
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
     "d3-timer": "^3.0.1",
-    "d3-zoom": "^3.0.0"
+    "d3-zoom": "^3.0.0",
+    "segment-tree-rmq": "^0.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "vitest";
 import { SegmentTree, IMinMax } from "./segmentTree.ts";
-import { SegmentTreeHalf } from "./segmentTreeHalf.ts";
 
 test("SegmentTree operations", () => {
   const data = [1, 3, 2, 5, 4];
@@ -34,31 +33,6 @@ test("SegmentTree operations", () => {
   expect(() => tree.update(5, { min: 0, max: 0 })).toThrow(
     "Position is not valid",
   );
-});
-
-test("SegmentTreeHalf edge cases", () => {
-  const data = [1, 2, 3, 4, 5];
-  const sumOp = (a: number, b: number) => a + b;
-  const tree = new SegmentTreeHalf(data, sumOp, 0);
-
-  // query single elements on boundaries
-  expect(tree.query(0, 0)).toBe(1);
-  expect(tree.query(data.length - 1, data.length - 1)).toBe(5);
-
-  // update boundary elements and verify queries
-  tree.update(0, 10);
-  tree.update(data.length - 1, 20);
-  expect(tree.query(0, 0)).toBe(10);
-  expect(tree.query(data.length - 1, data.length - 1)).toBe(20);
-  // unaffected middle range stays the same
-  expect(tree.query(1, 3)).toBe(2 + 3 + 4);
-  // full range reflects updates
-  expect(tree.query(0, data.length - 1)).toBe(10 + 2 + 3 + 4 + 20);
-
-  // invalid ranges throw an error
-  expect(() => tree.query(3, 2)).toThrow("Range is not valid");
-  expect(() => tree.query(-1, 2)).toThrow("Range is not valid");
-  expect(() => tree.query(0, data.length)).toThrow("Range is not valid");
 });
 
 test("SegmentTree with IMinMax", () => {

--- a/svg-time-series/src/segmentTree.ts
+++ b/svg-time-series/src/segmentTree.ts
@@ -1,4 +1,4 @@
-import { SegmentTreeHalf } from "./segmentTreeHalf";
+import { SegmentTree as SegmentTreeCore } from "segment-tree-rmq";
 
 export interface IMinMax {
   readonly min: number;
@@ -25,7 +25,7 @@ function assertOk(cond: boolean, message: string): asserts cond {
 
 export class SegmentTree<T = [number, number]> {
   private readonly size: number;
-  private tree: SegmentTreeHalf<IMinMax>;
+  private tree: SegmentTreeCore<IMinMax>;
 
   constructor(
     data: ReadonlyArray<T>,
@@ -39,7 +39,7 @@ export class SegmentTree<T = [number, number]> {
       minMaxData[i] = buildTuple(i, data);
     }
 
-    this.tree = new SegmentTreeHalf(minMaxData, buildMinMax, minMaxIdentity);
+    this.tree = new SegmentTreeCore(minMaxData, buildMinMax, minMaxIdentity);
   }
 
   getMinMax(fromPosition: number, toPosition: number): IMinMax {


### PR DESCRIPTION
## Summary
- extract generic SegmentTree into new `segment-tree-rmq` package
- update svg-time-series to consume the new workspace
- wire workspace scripts for linting and type checking

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892f8557260832b8acbaa6226b6c675