### PR TITLE
test: cover drawProc debounce with fake timers

### DIFF
--- a/svg-time-series/src/chart/drawProc.test.ts
+++ b/svg-time-series/src/chart/drawProc.test.ts
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { drawProc } from "./interaction.ts";
+
+describe("drawProc", () => {
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("executes underlying function only once", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const wrapped = drawProc(fn);
+
+    wrapped();
+    wrapped();
+    wrapped();
+
+    expect(fn).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -7,7 +7,7 @@ import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
 import { refreshChart, renderPaths } from "./render.ts";
 
-function drawProc<T extends unknown[]>(
+export function drawProc<T extends unknown[]>(
   f: (...args: T) => void,
 ): (...args: T) => void {
   let requested = false;


### PR DESCRIPTION
## Summary
- export `drawProc` for direct testing
- add unit test verifying `drawProc` only invokes wrapped function once when called rapidly

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ffbe12ec832ba8dada1f6153fa39