### PR TITLE
test: ensure renderPaths skips NaN segments

### DIFF
--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { select } from "d3-selection";
+import { renderPaths, type RenderState } from "./render.ts";
+
+describe("renderPaths", () => {
+  it("skips segments for NaN values", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const pathSelection = select(svg)
+      .selectAll("path")
+      .data([0])
+      .enter()
+      .append("path");
+
+    const state = { path: pathSelection } as unknown as RenderState;
+    const data: Array<[number, number]> = [
+      [0, 0],
+      [NaN, NaN],
+      [2, 2],
+    ];
+
+    renderPaths(state, data);
+
+    const d = pathSelection.attr("d");
+    expect(d).not.toContain("1,");
+    expect(d.match(/M/g)?.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for renderPaths to ensure paths skip NaN values

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892ffa0c2d0832b972fcf00122ece74