### PR TITLE
test: cover multi-append and fractional ranges

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -40,6 +40,31 @@ describe("ChartData", () => {
     expect(cd.idxToTime.applyToPoint(1)).toBe(0);
   });
 
+  it("reflects latest window after multiple appends", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      buildNy,
+      buildSf,
+    );
+
+    cd.append([2, 2]);
+    cd.append([3, 3]);
+
+    expect(cd.data).toEqual([
+      [2, 2],
+      [3, 3],
+    ]);
+    expect(cd.idxToTime.applyToPoint(0)).toBe(-2);
+    expect(cd.idxToTime.applyToPoint(1)).toBe(-1);
+    expect(cd.treeNy.getMinMax(0, 1)).toEqual({ min: 2, max: 3 });
+    expect(cd.treeSf.getMinMax(0, 1)).toEqual({ min: 2, max: 3 });
+  });
+
   it("computes visible temperature bounds", () => {
     const cd = new ChartData(
       0,
@@ -55,5 +80,27 @@ describe("ChartData", () => {
     const range = new AR1Basis(0, 2);
     expect(cd.bTemperatureVisible(range, cd.treeNy).toArr()).toEqual([10, 50]);
     expect(cd.bTemperatureVisible(range, cd.treeSf).toArr()).toEqual([20, 60]);
+  });
+
+  it("rounds fractional bounds when computing temperature visibility", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ],
+      buildNy,
+      buildSf,
+    );
+
+    const fractionalRange = new AR1Basis(0.49, 1.49);
+    expect(cd.bTemperatureVisible(fractionalRange, cd.treeNy).toArr()).toEqual([
+      10, 30,
+    ]);
+    expect(cd.bTemperatureVisible(fractionalRange, cd.treeSf).toArr()).toEqual([
+      20, 40,
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- extend ChartData tests to verify structures after multiple appends
- add coverage for fractional index rounding in bTemperatureVisible

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893020a6058832b8f28285a76f35fe7