### PR TITLE
Add generic scale interface and enable strict typing

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -5,8 +5,8 @@ export type { IMinMax };
 
 export class ChartData {
   public data: Array<[number, number]>;
-  public treeNy: SegmentTree;
-  public treeSf: SegmentTree;
+  public treeNy!: SegmentTree;
+  public treeSf!: SegmentTree;
   public idxToTime: AR1;
   private idxShift: AR1;
   public bIndexFull: AR1Basis;

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -152,8 +152,9 @@ export function renderPaths(
       .x((d: [number, number], i: number) => i)
       .y((d: [number, number]) => d[cityIdx]);
 
-  state.path.attr("d", (cityIndex: number) =>
-    drawLine(cityIndex).call(null, dataArr),
+  state.path.attr(
+    "d",
+    (cityIndex: number) => drawLine(cityIndex)(dataArr) ?? "",
   );
 }
 

--- a/svg-time-series/src/scale.ts
+++ b/svg-time-series/src/scale.ts
@@ -1,0 +1,8 @@
+export interface Scale<Domain> {
+  (value: Domain): number;
+  ticks?: (count?: number) => ReadonlyArray<Domain>;
+  tickFormat?: (count?: number, specifier?: string) => (d: any) => string;
+  bandwidth?: () => number;
+  domain: () => ReadonlyArray<Domain>;
+  copy: () => Scale<Domain>;
+}

--- a/svg-time-series/tsconfig.json
+++ b/svg-time-series/tsconfig.json
@@ -12,7 +12,7 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "strict": false,
+    "strict": true,
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,


### PR DESCRIPTION
## Summary
- define a reusable `Scale` interface to describe shared scale methods
- refactor axis helpers to use typed generics
- enable strict TypeScript checks and resolve resulting type errors

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68930074d028832bafa74a6c6652e557