### PR TITLE
docs: rely on commit hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,6 @@
 
 - Use Node.js 20 or later.
 - Keep code formatted with `npm run format`.
-- Before committing, run:
-  - `npm run lint`
-  - `npm run typecheck`
-  - `npm test`
+- Git pre-commit hooks automatically run `npm run lint`, `npm run typecheck`, and `npm test`, so you don't need to run these commands separately. Commit your changes and ensure the hooks pass.
 - Place new code and tests under appropriate workspaces.
 - Use descriptive commit messages.


### PR DESCRIPTION
## Summary
- clarify that lint, typecheck, and tests run automatically via pre-commit hooks

## Testing
- `git commit -am "docs: rely on commit hooks"`

------
https://chatgpt.com/codex/tasks/task_e_6893109ea2c4832bb747431fd0975f6b