### PR TITLE
chore: hoist shared tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,11 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "eslint": "^9.32.0",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
+        "prettier": "^3.6.2",
+        "typescript": "^5.9.2",
         "vitest": "^3.2.4"
       }
     },
@@ -8576,12 +8579,8 @@
       "license": "WTFPL",
       "devDependencies": {
         "@eslint/js": "^9.32.0",
-        "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
-        "prettier": "^3.6.2",
-        "typescript": "^5.9.2",
-        "typescript-eslint": "^8.39.0",
-        "vitest": "^3.2.4"
+        "typescript-eslint": "^8.39.0"
       }
     },
     "svg-time-series": {
@@ -8602,15 +8601,11 @@
         "@types/d3-shape": "^3.1.7",
         "@types/d3-timer": "^3.0.2",
         "@types/d3-zoom": "^3.0.8",
-        "eslint": "^9.32.0",
         "eslint-config-prettier": "^10.1.8",
-        "prettier": "^3.6.2",
         "rollup-plugin-node-externals": "^8.0.1",
-        "typescript": "^5.9.2",
         "typescript-eslint": "^8.39.0",
         "vite": "^7.0.6",
-        "vite-plugin-dts": "^4.5.4",
-        "vitest": "^3.2.4"
+        "vite-plugin-dts": "^4.5.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,11 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
+    "eslint": "^9.32.0",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   }
 }

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -16,11 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
-    "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
-    "prettier": "^3.6.2",
-    "typescript": "^5.9.2",
-    "typescript-eslint": "^8.39.0",
-    "vitest": "^3.2.4"
+    "typescript-eslint": "^8.39.0"
   }
 }

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -29,15 +29,11 @@
     "@types/d3-shape": "^3.1.7",
     "@types/d3-timer": "^3.0.2",
     "@types/d3-zoom": "^3.0.8",
-    "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
-    "prettier": "^3.6.2",
     "rollup-plugin-node-externals": "^8.0.1",
-    "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0",
     "vite": "^7.0.6",
-    "vite-plugin-dts": "^4.5.4",
-    "vitest": "^3.2.4"
+    "vite-plugin-dts": "^4.5.4"
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
## Summary
- hoist vitest, eslint, prettier, and typescript to repo root
- rely on shared tooling across workspaces and refresh lockfile

## Testing
- `npm install`
- `git commit` (runs lint, typecheck, test)


------
https://chatgpt.com/codex/tasks/task_e_689315849ae0832b8404e5e5a375c83d