### PR TITLE
feat(segment-tree-rmq): reject empty data arrays

### DIFF
--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -6,7 +6,18 @@ export class SegmentTree<T> {
   private op: Operator<T>;
   private identity: T;
 
+  /**
+   * Creates a new segment tree.
+   *
+   * @param data - Initial array to build the tree from. Must contain at least one element.
+   * @param op - The associative operator used for combining values.
+   * @param identity - Identity value for the operator.
+   * @throws {Error} If `data` is empty.
+   */
   constructor(data: T[], op: Operator<T>, identity: T) {
+    if (data.length === 0) {
+      throw new Error("Data array must contain at least one element");
+    }
     this.size = data.length;
     this.tree = new Array(this.size * 2);
     this.op = op;

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -70,6 +70,14 @@ describe("Segment Tree Tests", () => {
     expect(tree.query(0, 0)).toBe(42);
   });
 
+  it("should throw an error when constructed with an empty array", () => {
+    const sumOperator = (a: number, b: number) => a + b;
+    const identity = 0;
+    expect(() => new SegmentTree([], sumOperator, identity)).toThrow(
+      "Data array must contain at least one element",
+    );
+  });
+
   it("should handle a range that includes the very last element of the array", () => {
     const data = [1, 2, 3, 4, 5, 6, 7, 8];
     const sumOperator = (a: number, b: number) => a + b;


### PR DESCRIPTION
## Summary
- throw an error when SegmentTree is constructed with an empty array
- document the non-empty requirement in constructor JSDoc
- test that constructing with an empty array fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68931d567064832b8c088ca69565e770