### PR TITLE
fix: clamp temperature visible indices

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -83,7 +83,7 @@ describe("ChartData", () => {
     expect(cd.bTemperatureVisible(range, cd.treeSf!).toArr()).toEqual([20, 60]);
   });
 
-  it("rounds fractional bounds when computing temperature visibility", () => {
+  it("floors and ceils fractional bounds when computing temperature visibility", () => {
     const cd = new ChartData(
       0,
       1,
@@ -98,14 +98,14 @@ describe("ChartData", () => {
 
     const fractionalRange = new AR1Basis(0.49, 1.49);
     expect(cd.bTemperatureVisible(fractionalRange, cd.treeNy).toArr()).toEqual([
-      10, 30,
+      10, 50,
     ]);
     expect(cd.bTemperatureVisible(fractionalRange, cd.treeSf!).toArr()).toEqual(
-      [20, 40],
+      [20, 60],
     );
   });
 
-  it("rounds up fractional bounds when computing temperature visibility", () => {
+  it("handles fractional bounds in the middle of the dataset", () => {
     const cd = new ChartData(
       0,
       1,
@@ -118,13 +118,37 @@ describe("ChartData", () => {
       buildSf,
     );
 
-    const fractionalRange = new AR1Basis(0.51, 1.51);
+    const fractionalRange = new AR1Basis(1.1, 1.7);
     expect(cd.bTemperatureVisible(fractionalRange, cd.treeNy).toArr()).toEqual([
       30, 50,
     ]);
     expect(cd.bTemperatureVisible(fractionalRange, cd.treeSf!).toArr()).toEqual(
       [40, 60],
     );
+  });
+
+  it("clamps bounds that extend past the data range", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ],
+      buildNy,
+      buildSf,
+    );
+
+    const outOfRange = new AR1Basis(-0.5, 3.5);
+    expect(() => cd.bTemperatureVisible(outOfRange, cd.treeNy)).not.toThrow();
+    expect(() => cd.bTemperatureVisible(outOfRange, cd.treeSf!)).not.toThrow();
+    expect(cd.bTemperatureVisible(outOfRange, cd.treeNy).toArr()).toEqual([
+      10, 50,
+    ]);
+    expect(cd.bTemperatureVisible(outOfRange, cd.treeSf!).toArr()).toEqual([
+      20, 60,
+    ]);
   });
 
   describe("single-axis", () => {

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -73,10 +73,9 @@ export class ChartData {
     tree: SegmentTree<[number, number?]>,
   ): AR1Basis {
     const [minIdxX, maxIdxX] = bIndexVisible.toArr();
-    const { min, max } = tree.getMinMax(
-      Math.round(minIdxX),
-      Math.round(maxIdxX),
-    );
+    const startIdx = Math.max(0, Math.floor(minIdxX));
+    const endIdx = Math.min(this.data.length - 1, Math.ceil(maxIdxX));
+    const { min, max } = tree.getMinMax(startIdx, endIdx);
     return new AR1Basis(min, max);
   }
 }


### PR DESCRIPTION
## Summary
- ensure temperature queries stay within dataset bounds by clamping and flooring/ceiling indices
- test fractional and out-of-range index handling for visible temperature calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68931d1e70a4832ba6b114b54fd11ea2