### PR TITLE
feat: validate non-empty dataset for ChartData

### DIFF
--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -29,6 +29,8 @@ const data: [number, number][] = [
   [11, 13],
 ];
 
+// The data array must contain at least one entry.
+
 const chart = new TimeSeriesChart(
   svg,
   legend,

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -12,6 +12,12 @@ describe("ChartData", () => {
     max: arr[i][1]!,
   });
 
+  it("throws if constructed with empty data", () => {
+    expect(() => new ChartData(0, 1, [], buildNy)).toThrow(
+      /non-empty data array/,
+    );
+  });
+
   it("updates data and time mapping on append", () => {
     const cd = new ChartData(
       0,

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -19,6 +19,11 @@ export class ChartData {
     elements: ReadonlyArray<[number, number?]>,
   ) => IMinMax;
 
+  /**
+   * Creates a new ChartData instance.
+   * @param data Initial dataset; must contain at least one point.
+   * @throws if `data` is empty.
+   */
   constructor(
     startTime: number,
     timeStep: number,
@@ -32,6 +37,9 @@ export class ChartData {
       elements: ReadonlyArray<[number, number?]>,
     ) => IMinMax,
   ) {
+    if (data.length === 0) {
+      throw new Error("ChartData requires a non-empty data array");
+    }
     this.data = data;
     this.buildSegmentTreeTupleNy = buildSegmentTreeTupleNy;
     this.buildSegmentTreeTupleSf = buildSegmentTreeTupleSf;


### PR DESCRIPTION
## Summary
- throw error when ChartData constructed with empty data array
- document non-empty requirement in README and constructor comments
- test empty dataset construction

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68931f7f2720832bbe2cf5d8709004e6