### PR TITLE
fix: clamp temperature range indices

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -157,6 +157,54 @@ describe("ChartData", () => {
     ]);
   });
 
+  it("clamps bounds completely to the left of the data range", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ],
+      buildNy,
+      buildSf,
+    );
+
+    const leftRange = new AR1Basis(-5, -1);
+    expect(() => cd.bTemperatureVisible(leftRange, cd.treeNy)).not.toThrow();
+    expect(() => cd.bTemperatureVisible(leftRange, cd.treeSf!)).not.toThrow();
+    expect(cd.bTemperatureVisible(leftRange, cd.treeNy).toArr()).toEqual([
+      10, 10,
+    ]);
+    expect(cd.bTemperatureVisible(leftRange, cd.treeSf!).toArr()).toEqual([
+      20, 20,
+    ]);
+  });
+
+  it("clamps bounds completely to the right of the data range", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ],
+      buildNy,
+      buildSf,
+    );
+
+    const rightRange = new AR1Basis(5, 10);
+    expect(() => cd.bTemperatureVisible(rightRange, cd.treeNy)).not.toThrow();
+    expect(() => cd.bTemperatureVisible(rightRange, cd.treeSf!)).not.toThrow();
+    expect(cd.bTemperatureVisible(rightRange, cd.treeNy).toArr()).toEqual([
+      50, 50,
+    ]);
+    expect(cd.bTemperatureVisible(rightRange, cd.treeSf!).toArr()).toEqual([
+      60, 60,
+    ]);
+  });
+
   describe("single-axis", () => {
     const buildNy = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
       min: arr[i][0],

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -81,8 +81,14 @@ export class ChartData {
     tree: SegmentTree<[number, number?]>,
   ): AR1Basis {
     const [minIdxX, maxIdxX] = bIndexVisible.toArr();
-    const startIdx = Math.max(0, Math.floor(minIdxX));
-    const endIdx = Math.min(this.data.length - 1, Math.ceil(maxIdxX));
+    let startIdx = Math.floor(minIdxX);
+    let endIdx = Math.ceil(maxIdxX);
+    const lastIdx = this.data.length - 1;
+    startIdx = Math.min(Math.max(startIdx, 0), lastIdx);
+    endIdx = Math.min(Math.max(endIdx, 0), lastIdx);
+    if (startIdx > endIdx) {
+      [startIdx, endIdx] = [endIdx, startIdx];
+    }
     const { min, max } = tree.getMinMax(startIdx, endIdx);
     return new AR1Basis(min, max);
   }


### PR DESCRIPTION
## Summary
- clamp visible temperature index bounds to dataset size and sort if reversed
- test out-of-range index bounds to ensure clamped min/max

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689325ca0634832b83271b5050e4ef7e