### PR TITLE
feat: add chart cleanup

### DIFF
--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -7,6 +7,7 @@ import { AR1Basis } from "../math/affine.ts";
 import { ChartData } from "./data.ts";
 import { setupRender } from "./render.ts";
 import { setupInteraction } from "./interaction.ts";
+import { TimeSeriesChart } from "../draw.ts";
 
 class Matrix {
   constructor(
@@ -259,5 +260,55 @@ describe("chart interaction", () => {
       createChart([]);
       vi.runAllTimers();
     }).toThrow();
+  });
+
+  it("dispose removes handlers and dom nodes", () => {
+    const data: Array<[number, number]> = [
+      [0, 0],
+      [1, 1],
+    ];
+    currentDataLength = data.length;
+    const parent = document.createElement("div");
+    Object.defineProperty(parent, "clientWidth", {
+      value: 1,
+      configurable: true,
+    });
+    Object.defineProperty(parent, "clientHeight", {
+      value: 50,
+      configurable: true,
+    });
+    const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    parent.appendChild(svgEl);
+    const legend = document.createElement("div");
+    legend.innerHTML =
+      '<span class="chart-legend__time"></span>' +
+      '<span class="chart-legend__green_value"></span>' +
+      '<span class="chart-legend__blue_value"></span>';
+    const mouseMoveHandler = vi.fn();
+    const chart = new TimeSeriesChart(
+      select(svgEl) as any,
+      select(legend) as any,
+      0,
+      1,
+      data,
+      (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
+      (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
+      () => {},
+      mouseMoveHandler,
+    );
+    vi.runAllTimers();
+    const zoomRect = svgEl.querySelector(".zoom") as SVGRectElement;
+    expect(zoomRect).not.toBeNull();
+
+    zoomRect.dispatchEvent(new MouseEvent("mousemove"));
+    expect(mouseMoveHandler).toHaveBeenCalledTimes(1);
+
+    chart.dispose();
+
+    expect(svgEl.querySelector(".zoom")).toBeNull();
+    expect(svgEl.querySelectorAll("circle").length).toBe(0);
+
+    zoomRect.dispatchEvent(new MouseEvent("mousemove"));
+    expect(mouseMoveHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -152,5 +152,15 @@ export function setupInteraction(
     schedulePointRefresh();
   }
 
-  return { zoom, onHover, drawNewData };
+  function destroy() {
+    zoomBehavior.on("zoom", null);
+    zoomArea.on("mousemove", null);
+    // remove all zoom listeners attached by the behavior
+    zoomArea.on(".zoom", null);
+    zoomArea.remove();
+    highlightedGreenDot.remove();
+    highlightedBlueDot?.remove();
+  }
+
+  return { zoom, onHover, drawNewData, destroy };
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -11,6 +11,7 @@ export class TimeSeriesChart {
   public zoom: (event: D3ZoomEvent<Element, unknown>) => void;
   public onHover: (x: number) => void;
   private drawNewData: () => void;
+  private destroy: () => void;
   private data: ChartData;
 
   constructor(
@@ -39,7 +40,7 @@ export class TimeSeriesChart {
     );
 
     const renderState = setupRender(svg, this.data);
-    const { zoom, onHover, drawNewData } = setupInteraction(
+    const { zoom, onHover, drawNewData, destroy } = setupInteraction(
       svg,
       legend,
       renderState,
@@ -51,6 +52,7 @@ export class TimeSeriesChart {
     this.zoom = zoom;
     this.onHover = onHover;
     this.drawNewData = drawNewData;
+    this.destroy = destroy;
 
     this.drawNewData();
     this.onHover(renderState.width - 1);
@@ -59,5 +61,9 @@ export class TimeSeriesChart {
   public updateChartWithNewData(newData: [number, number?]) {
     this.data.append(newData);
     this.drawNewData();
+  }
+
+  public dispose() {
+    this.destroy();
   }
 }


### PR DESCRIPTION
## Summary
- add cleanup support for interactions
- expose `dispose` on `TimeSeriesChart` to remove handlers
- ensure chart cleanup via tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689325d753ac832ba0bf508c89175966