### PR TITLE
fix: clamp hover index and test out-of-bounds hover

### DIFF
--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -189,6 +189,19 @@ describe("chart interaction single-axis", () => {
     expect(transform.ty).toBe(0);
   });
 
+  it("handles hover beyond chart width", () => {
+    const data: Array<[number]> = [[10], [30], [50]];
+    const { onHover, legend } = createChart(data);
+    vi.runAllTimers();
+
+    expect(() => onHover(data.length - 1 + 5)).not.toThrow();
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("50");
+  });
+
   it("throws on zero-length dataset", () => {
     expect(() => {
       createChart([]);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -254,6 +254,26 @@ describe("chart interaction", () => {
     expect(blueTransform.ty).toBe(60);
   });
 
+  it("handles hover beyond chart width", () => {
+    const data: Array<[number, number]> = [
+      [10, 20],
+      [30, 40],
+      [50, 60],
+    ];
+    const { onHover, legend } = createChart(data);
+    vi.runAllTimers();
+
+    expect(() => onHover(data.length - 1 + 5)).not.toThrow();
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("50");
+    expect(legend.querySelector(".chart-legend__blue_value")!.textContent).toBe(
+      "60",
+    );
+  });
+
   it("throws on zero-length dataset", () => {
     expect(() => {
       createChart([]);

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -101,7 +101,7 @@ export function setupInteraction(
 
   function onHover(x: number) {
     const idx = state.pathTransformNy.fromScreenToModelX(x);
-    highlightedDataIdx = Math.min(Math.max(idx, 0), data.data.length - 1);
+    highlightedDataIdx = Math.max(0, Math.min(idx, data.data.length - 1));
     schedulePointRefresh();
   }
 


### PR DESCRIPTION
## Summary
- clamp hover index to chart data bounds
- test legend behavior when hovering beyond chart width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689325f02cf8832bb22e17a672ade3b6