### PR TITLE
refactor: use DOMMatrix for transforms

### DIFF
--- a/svg-time-series/src/MyTransform.test.ts
+++ b/svg-time-series/src/MyTransform.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it } from "vitest";
-import { MyTransform } from "./MyTransform.ts";
+import { beforeAll, describe, expect, it } from "vitest";
 import { AR1Basis } from "./math/affine.ts";
 
 class Matrix {
@@ -27,7 +26,7 @@ class Matrix {
     return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
   }
 
-  scaleNonUniform(sx: number, sy: number) {
+  scale(sx: number, sy: number) {
     return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
   }
 
@@ -58,12 +57,17 @@ class Point {
   }
 }
 
+let MyTransform: typeof import("./MyTransform.ts").MyTransform;
+
+beforeAll(async () => {
+  (globalThis as any).DOMMatrix = Matrix;
+  (globalThis as any).DOMPoint = Point;
+  ({ MyTransform } = await import("./MyTransform.ts"));
+});
+
 describe("MyTransform", () => {
   it("composes zoom and reference transforms and inverts them", () => {
-    const svg = {
-      createSVGMatrix: () => new Matrix(),
-      createSVGPoint: () => new Point(),
-    } as unknown as SVGSVGElement;
+    const svg = {} as unknown as SVGSVGElement;
     const g = {} as unknown as SVGGElement;
     const mt = new MyTransform(svg, g);
 
@@ -82,10 +86,7 @@ describe("MyTransform", () => {
   });
 
   it("maps screen bases back to model bases through inverse transforms", () => {
-    const svg = {
-      createSVGMatrix: () => new Matrix(),
-      createSVGPoint: () => new Point(),
-    } as unknown as SVGSVGElement;
+    const svg = {} as unknown as SVGSVGElement;
     const g = {} as unknown as SVGGElement;
     const mt = new MyTransform(svg, g);
 
@@ -100,10 +101,7 @@ describe("MyTransform", () => {
   });
 
   it("converts screen points to model points", () => {
-    const svg = {
-      createSVGMatrix: () => new Matrix(),
-      createSVGPoint: () => new Point(),
-    } as unknown as SVGSVGElement;
+    const svg = {} as unknown as SVGSVGElement;
     const g = {} as unknown as SVGGElement;
     const mt = new MyTransform(svg, g);
 

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -38,7 +38,7 @@ class Matrix {
     return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
   }
 
-  scaleNonUniform(sx: number, sy: number) {
+  scale(sx: number, sy: number) {
     return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
   }
 }
@@ -71,7 +71,7 @@ describe("AR1 and AR1Basis", () => {
 
 describe("DirectProduct", () => {
   it("applies independent transforms on axes", () => {
-    const identity = new Matrix();
+    const identity = new Matrix() as unknown as DOMMatrix;
     const b1 = new DirectProductBasis([0, 0], [1, 1]);
     const b2 = new DirectProductBasis([10, 10], [20, 30]);
     const dp = betweenTBasesDirectProduct(b1, b2);
@@ -101,11 +101,17 @@ describe("DirectProductBasis utilities", () => {
 
 describe("viewZoomTransform helpers", () => {
   it("applies AR1 transforms along X and Y axes", () => {
-    const mx = applyAR1ToMatrixX(new AR1([2, 3]), new Matrix());
+    const mx = applyAR1ToMatrixX(
+      new AR1([2, 3]),
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(mx.a).toBeCloseTo(2);
     expect(mx.e).toBeCloseTo(3);
 
-    const my = applyAR1ToMatrixY(new AR1([3, 4]), new Matrix());
+    const my = applyAR1ToMatrixY(
+      new AR1([3, 4]),
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(my.d).toBeCloseTo(3);
     expect(my.f).toBeCloseTo(4);
   });
@@ -121,7 +127,7 @@ describe("viewZoomTransform helpers", () => {
     const node = {
       transform: { baseVal },
     } as unknown as SVGGraphicsElement;
-    const matrix = new Matrix(1, 0, 0, 1, 2, 3) as unknown as SVGMatrix;
+    const matrix = new Matrix(1, 0, 0, 1, 2, 3) as unknown as DOMMatrix;
 
     updateNode(node, matrix);
     expect(calls[0]).toBe(matrix);

--- a/svg-time-series/src/viewZoomTransform.ts
+++ b/svg-time-series/src/viewZoomTransform.ts
@@ -1,34 +1,23 @@
 import { AR1, DirectProduct } from "./math/affine.ts";
 
-export interface MatrixLike {
-  translate(tx: number, ty: number): this;
-  scaleNonUniform(sx: number, sy: number): this;
-}
-
-export function applyAR1ToMatrixX<M extends MatrixLike>(
-  transform: AR1,
-  sm: M,
-): M {
+export function applyAR1ToMatrixX(transform: AR1, sm: DOMMatrix): DOMMatrix {
   const [a, b] = transform.m;
-  return sm.translate(b, 0).scaleNonUniform(a, 1);
+  return sm.translate(b, 0).scale(a, 1);
 }
 
-export function applyAR1ToMatrixY<M extends MatrixLike>(
-  transform: AR1,
-  sm: M,
-): M {
+export function applyAR1ToMatrixY(transform: AR1, sm: DOMMatrix): DOMMatrix {
   const [a, b] = transform.m;
-  return sm.translate(0, b).scaleNonUniform(1, a);
+  return sm.translate(0, b).scale(1, a);
 }
 
-export function applyDirectProductToMatrix<M extends MatrixLike>(
+export function applyDirectProductToMatrix(
   dp: DirectProduct,
-  sm: M,
-): M {
+  sm: DOMMatrix,
+): DOMMatrix {
   return applyAR1ToMatrixY(dp.s2, applyAR1ToMatrixX(dp.s1, sm));
 }
 
-export function updateNode(n: SVGGraphicsElement, m: SVGMatrix) {
+export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
   const svgTranformList = n.transform.baseVal;
   const t = svgTranformList.createSVGTransformFromMatrix(m);
   svgTranformList.initialize(t);


### PR DESCRIPTION
## Summary
- replace SVGMatrix usage with DOMMatrix and add helpers for reference and zoom transforms
- remove manual inverse tracking in favor of DOMMatrix.inverse
- update matrix utilities and tests for DOMMatrix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689329019808832ba6804b370f4faec9