### PR TITLE
refactor: modularize render setup

### DIFF
--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -116,7 +116,7 @@ function createChart(data: Array<[number]>) {
   );
 
   drawNewData();
-  onHover(renderState.width);
+  onHover(renderState.dimensions.width);
 
   return { zoom, onHover, svgEl, legend };
 }

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -121,7 +121,7 @@ function createChart(data: Array<[number, number]>) {
   );
 
   drawNewData();
-  onHover(renderState.width);
+  onHover(renderState.dimensions.width);
 
   return { zoom, onHover, svgEl, legend };
 }

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -67,7 +67,7 @@ export class ChartInteraction {
       .scaleExtent([1, 40])
       .translateExtent([
         [0, 0],
-        [state.width, state.height],
+        [state.dimensions.width, state.dimensions.height],
       ])
       .on("zoom", (event: D3ZoomEvent<Element, unknown>) => {
         zoomHandler(event);
@@ -77,8 +77,8 @@ export class ChartInteraction {
     this.zoomArea = svg
       .append("rect")
       .attr("class", "zoom")
-      .attr("width", state.width)
-      .attr("height", state.height)
+      .attr("width", state.dimensions.width)
+      .attr("height", state.dimensions.height)
       .call(this.zoomBehavior);
     this.zoomArea.on("mousemove", mouseMoveHandler);
 
@@ -89,8 +89,10 @@ export class ChartInteraction {
         .attr("cy", 0)
         .attr("r", 1)
         .node() as SVGCircleElement;
-    this.highlightedGreenDot = makeDot(state.viewNy);
-    this.highlightedBlueDot = state.viewSf ? makeDot(state.viewSf) : null;
+    this.highlightedGreenDot = makeDot(state.paths.viewNy);
+    this.highlightedBlueDot = state.paths.viewSf
+      ? makeDot(state.paths.viewSf)
+      : null;
 
     this.scheduleRefresh = drawProc(() => {
       if (this.currentPanZoomTransformState != null) {
@@ -109,14 +111,14 @@ export class ChartInteraction {
 
   public zoom = (event: D3ZoomEvent<Element, unknown>) => {
     this.currentPanZoomTransformState = event.transform;
-    this.state.pathTransformNy.onZoomPan(event.transform);
-    this.state.pathTransformSf?.onZoomPan(event.transform);
+    this.state.transforms.ny.onZoomPan(event.transform);
+    this.state.transforms.sf?.onZoomPan(event.transform);
     this.scheduleRefresh();
     this.schedulePointRefresh();
   };
 
   public onHover = (x: number) => {
-    const idx = this.state.pathTransformNy.fromScreenToModelX(x);
+    const idx = this.state.transforms.ny.fromScreenToModelX(x);
     this.highlightedDataIdx = Math.min(
       Math.max(idx, 0),
       this.data.data.length - 1,
@@ -134,10 +136,10 @@ export class ChartInteraction {
       ).toLocaleString(),
     );
 
-    const dotScaleMatrixNy = this.state.pathTransformNy.dotScaleMatrix(
+    const dotScaleMatrixNy = this.state.transforms.ny.dotScaleMatrix(
       this.dotRadius,
     );
-    const dotScaleMatrixSf = this.state.pathTransformSf?.dotScaleMatrix(
+    const dotScaleMatrixSf = this.state.transforms.sf?.dotScaleMatrix(
       this.dotRadius,
     );
     const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
@@ -165,7 +167,7 @@ export class ChartInteraction {
       this.highlightedGreenDot,
       dotScaleMatrixNy,
     );
-    if (this.state.pathTransformSf) {
+    if (this.state.transforms.sf) {
       updateDot(
         blueData as number,
         this.legendBlue,

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -14,7 +14,7 @@ describe("renderPaths", () => {
       .enter()
       .append("path");
 
-    const state = { path: pathSelection } as unknown as RenderState;
+    const state = { paths: { path: pathSelection } } as unknown as RenderState;
     const data: Array<[number, number]> = [
       [0, 0],
       [NaN, NaN],

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -42,28 +42,9 @@ function updateScaleY(
   yScale.domain(bTemperatureVisible.toArr());
 }
 
-export interface RenderState {
-  x: ScaleTime<number, number>;
-  yNy: ScaleLinear<number, number>;
-  ySf?: ScaleLinear<number, number>;
-  pathTransformNy: MyTransform;
-  pathTransformSf?: MyTransform;
-  xAxis: MyAxis;
-  yAxis: MyAxis;
-  gX: Selection<SVGGElement, unknown, any, any>;
-  gY: Selection<SVGGElement, unknown, any, any>;
-  path: Selection<SVGPathElement, number, any, unknown>;
-  bScreenXVisible: AR1Basis;
-  width: number;
-  height: number;
-  viewNy: SVGGElement;
-  viewSf?: SVGGElement;
-}
-
-export function setupRender(
+function createDimensions(
   svg: Selection<BaseType, unknown, HTMLElement, unknown>,
-  data: ChartData,
-): RenderState {
+) {
   const node: SVGSVGElement = svg.node() as SVGSVGElement;
   const div: HTMLElement = node.parentNode as HTMLElement;
 
@@ -73,8 +54,16 @@ export function setupRender(
   svg.attr("width", width);
   svg.attr("height", height);
 
-  const hasSf = data.treeSf != null;
+  const bScreenXVisible = new AR1Basis(0, width);
+  const bScreenYVisible = new AR1Basis(height, 0);
 
+  return { width, height, bScreenXVisible, bScreenYVisible };
+}
+
+function initPaths(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  hasSf: boolean,
+): PathSet {
   const views = svg
     .selectAll("g")
     .data(hasSf ? [0, 1] : [0])
@@ -84,12 +73,15 @@ export function setupRender(
   const nodes = views.nodes() as SVGGElement[];
   const viewNy = nodes[0];
   const viewSf = hasSf ? nodes[1] : undefined;
-
   const path = views.append("path");
+  return { path, viewNy, viewSf };
+}
 
-  const bScreenXVisible = new AR1Basis(0, width);
-  const bScreenYVisible = new AR1Basis(height, 0);
-
+function createScales(
+  bScreenXVisible: AR1Basis,
+  bScreenYVisible: AR1Basis,
+  hasSf: boolean,
+): ScaleSet {
   const x: ScaleTime<number, number> = scaleTime().range(
     bScreenXVisible.toArr(),
   );
@@ -100,58 +92,129 @@ export function setupRender(
   if (hasSf) {
     ySf = scaleLinear().range(bScreenYVisible.toArr());
   }
+  return { x, yNy, ySf };
+}
 
-  const pathTransformNy = new MyTransform(svg.node() as SVGSVGElement, viewNy);
-  let pathTransformSf: MyTransform | undefined;
-  if (hasSf && viewSf) {
-    pathTransformSf = new MyTransform(svg.node() as SVGSVGElement, viewSf);
+function createTransforms(
+  svgNode: SVGSVGElement,
+  paths: PathSet,
+): { ny: MyTransform; sf?: MyTransform } {
+  const ny = new MyTransform(svgNode, paths.viewNy);
+  let sf: MyTransform | undefined;
+  if (paths.viewSf) {
+    sf = new MyTransform(svgNode, paths.viewSf);
   }
+  return { ny, sf };
+}
 
-  updateScaleX(x, data.bIndexFull, data);
-  updateScaleY(data.bIndexFull, data.treeNy, pathTransformNy, yNy, data);
-  if (hasSf && data.treeSf && pathTransformSf && ySf) {
-    updateScaleY(data.bIndexFull, data.treeSf, pathTransformSf, ySf, data);
-  }
-
-  const xAxis = new MyAxis(Orientation.Bottom, x)
+function setupAxes(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  scales: ScaleSet,
+  width: number,
+  height: number,
+): AxisSet {
+  const xAxis = new MyAxis(Orientation.Bottom, scales.x)
     .ticks(4)
     .setTickSize(height)
     .setTickPadding(8 - height);
 
-  const yAxis = new MyAxis(Orientation.Right, yNy, ySf)
+  const yAxis = new MyAxis(Orientation.Right, scales.yNy, scales.ySf)
     .ticks(4, "s")
     .setTickSize(width)
     .setTickPadding(2 - width);
 
-  const gX = bindAxisToDom(svg, xAxis, x);
-  const gY = bindAxisToDom(svg, yAxis, yNy, ySf);
+  const gX = bindAxisToDom(svg, xAxis, scales.x);
+  const gY = bindAxisToDom(svg, yAxis, scales.yNy, scales.ySf);
 
-  pathTransformNy.onViewPortResize(bScreenXVisible, bScreenYVisible);
-  if (pathTransformSf) {
-    pathTransformSf.onViewPortResize(bScreenXVisible, bScreenYVisible);
-  }
-  pathTransformNy.onReferenceViewWindowResize(data.bIndexFull, bPlaceholder);
-  if (pathTransformSf) {
-    pathTransformSf.onReferenceViewWindowResize(data.bIndexFull, bPlaceholder);
+  return { x: xAxis, y: yAxis, gX, gY };
+}
+
+interface ScaleSet {
+  x: ScaleTime<number, number>;
+  yNy: ScaleLinear<number, number>;
+  ySf?: ScaleLinear<number, number>;
+}
+
+interface AxisSet {
+  x: MyAxis;
+  y: MyAxis;
+  gX: Selection<SVGGElement, unknown, any, any>;
+  gY: Selection<SVGGElement, unknown, any, any>;
+}
+
+interface PathSet {
+  path: Selection<SVGPathElement, number, any, unknown>;
+  viewNy: SVGGElement;
+  viewSf?: SVGGElement;
+}
+
+interface TransformSet {
+  ny: MyTransform;
+  sf?: MyTransform;
+  bScreenXVisible: AR1Basis;
+}
+
+interface Dimensions {
+  width: number;
+  height: number;
+}
+
+export interface RenderState {
+  scales: ScaleSet;
+  axes: AxisSet;
+  paths: PathSet;
+  transforms: TransformSet;
+  dimensions: Dimensions;
+}
+
+export function setupRender(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  data: ChartData,
+): RenderState {
+  const hasSf = data.treeSf != null;
+
+  const { width, height, bScreenXVisible, bScreenYVisible } =
+    createDimensions(svg);
+  const paths = initPaths(svg, hasSf);
+  const scales = createScales(bScreenXVisible, bScreenYVisible, hasSf);
+  const transformsInner = createTransforms(svg.node() as SVGSVGElement, paths);
+
+  updateScaleX(scales.x, data.bIndexFull, data);
+  updateScaleY(
+    data.bIndexFull,
+    data.treeNy,
+    transformsInner.ny,
+    scales.yNy,
+    data,
+  );
+  if (hasSf && data.treeSf && transformsInner.sf && scales.ySf) {
+    updateScaleY(
+      data.bIndexFull,
+      data.treeSf,
+      transformsInner.sf,
+      scales.ySf,
+      data,
+    );
   }
 
-  return {
-    x,
-    yNy,
-    ySf,
-    pathTransformNy,
-    pathTransformSf,
-    xAxis,
-    yAxis,
-    gX,
-    gY,
-    path,
+  const axes = setupAxes(svg, scales, width, height);
+
+  transformsInner.ny.onViewPortResize(bScreenXVisible, bScreenYVisible);
+  transformsInner.sf?.onViewPortResize(bScreenXVisible, bScreenYVisible);
+  transformsInner.ny.onReferenceViewWindowResize(data.bIndexFull, bPlaceholder);
+  transformsInner.sf?.onReferenceViewWindowResize(
+    data.bIndexFull,
+    bPlaceholder,
+  );
+
+  const transforms: TransformSet = {
+    ny: transformsInner.ny,
+    sf: transformsInner.sf,
     bScreenXVisible,
-    width,
-    height,
-    viewNy,
-    viewSf,
   };
+  const dimensions: Dimensions = { width, height };
+
+  return { scales, axes, paths, transforms, dimensions };
 }
 
 export function renderPaths(
@@ -166,35 +229,35 @@ export function renderPaths(
       .x((d, i) => i)
       .y((d) => d[cityIdx]!);
 
-  state.path.attr(
+  state.paths.path.attr(
     "d",
     (cityIndex: number) => drawLine(cityIndex)(dataArr) ?? "",
   );
 }
 
 export function refreshChart(state: RenderState, data: ChartData) {
-  const bIndexVisible = state.pathTransformNy.fromScreenToModelBasisX(
-    state.bScreenXVisible,
+  const bIndexVisible = state.transforms.ny.fromScreenToModelBasisX(
+    state.transforms.bScreenXVisible,
   );
-  updateScaleX(state.x, bIndexVisible, data);
+  updateScaleX(state.scales.x, bIndexVisible, data);
   updateScaleY(
     bIndexVisible,
     data.treeNy,
-    state.pathTransformNy,
-    state.yNy,
+    state.transforms.ny,
+    state.scales.yNy,
     data,
   );
-  if (state.pathTransformSf && state.ySf && data.treeSf) {
+  if (state.transforms.sf && state.scales.ySf && data.treeSf) {
     updateScaleY(
       bIndexVisible,
       data.treeSf,
-      state.pathTransformSf,
-      state.ySf,
+      state.transforms.sf,
+      state.scales.ySf,
       data,
     );
-    state.pathTransformSf.updateViewNode();
+    state.transforms.sf.updateViewNode();
   }
-  state.pathTransformNy.updateViewNode();
-  state.xAxis.axisUp(state.gX);
-  state.yAxis.axisUp(state.gY);
+  state.transforms.ny.updateViewNode();
+  state.axes.x.axisUp(state.axes.gX);
+  state.axes.y.axisUp(state.axes.gY);
 }

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -7,7 +7,9 @@ let onHoverMock: ReturnType<typeof vi.fn>;
 let onHoverUsedData: Array<[number, number?]> | null;
 
 vi.mock("./chart/render.ts", () => ({
-  setupRender: vi.fn(() => ({ width: 100, height: 100 })),
+  setupRender: vi.fn(() => ({
+    dimensions: { width: 100, height: 100 },
+  })),
 }));
 
 vi.mock("./chart/interaction.ts", () => ({

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -55,7 +55,7 @@ export class TimeSeriesChart {
     this.destroyInteraction = destroy;
 
     this.drawNewData();
-    this.onHover(renderState.width - 1);
+    this.onHover(renderState.dimensions.width - 1);
   }
 
   public updateChartWithNewData(newData: [number, number?]) {


### PR DESCRIPTION
## Summary
- modularize chart rendering into dimensions, scales, transforms, axes, and paths
- expose new composite `RenderState` and adjust interaction helpers
- update chart initialization to use composed render state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68932feb4394832b8b1939f9af78f6d6