### PR TITLE
refactor: extract viewport transform

### DIFF
--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -5,7 +5,10 @@ import { timeout as runTimeout, timer as runTimer } from "d3-timer";
 import { zoomIdentity, zoom as d3zoom, ZoomTransform } from "d3-zoom";
 
 import { MyAxis, Orientation } from "../../../svg-time-series/src/axis.ts";
-import { MyTransform } from "../../../svg-time-series/src/MyTransform.ts";
+import {
+  ViewportTransform,
+  applyViewportTransform,
+} from "../../../svg-time-series/src/ViewportTransform.ts";
 import {
   IMinMax,
   SegmentTree,
@@ -198,10 +201,7 @@ export class TimeSeriesChart {
     const x = scaleTime().range(bScreenXVisible.toArr());
     const y = scaleLinear().range(bScreenYVisible.toArr());
     const viewNode: SVGGElement = view.node() as SVGGElement;
-    const pathTransform = new MyTransform(
-      svg.node() as SVGSVGElement,
-      viewNode,
-    );
+    const pathTransform = new ViewportTransform();
 
     // bIndexVisible is the visible ends of model
     // affine space at chart edges.
@@ -260,7 +260,7 @@ export class TimeSeriesChart {
       const bIndexVisible =
         pathTransform.fromScreenToModelBasisX(bScreenXVisible);
       updateScales(bIndexVisible);
-      pathTransform.updateViewNode();
+      applyViewportTransform(viewNode, pathTransform);
 
       xAxis.axisUp(gX);
       yAxis.axisUp(gY);

--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -57,59 +57,53 @@ class Point {
   }
 }
 
-let MyTransform: typeof import("./MyTransform.ts").MyTransform;
+let ViewportTransform: typeof import("./ViewportTransform.ts").ViewportTransform;
 
 beforeAll(async () => {
   (globalThis as any).DOMMatrix = Matrix;
   (globalThis as any).DOMPoint = Point;
-  ({ MyTransform } = await import("./MyTransform.ts"));
+  ({ ViewportTransform } = await import("./ViewportTransform.ts"));
 });
 
-describe("MyTransform", () => {
+describe("ViewportTransform", () => {
   it("composes zoom and reference transforms and inverts them", () => {
-    const svg = {} as unknown as SVGSVGElement;
-    const g = {} as unknown as SVGGElement;
-    const mt = new MyTransform(svg, g);
+    const vt = new ViewportTransform();
 
-    mt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
-    mt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    vt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
+    vt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
 
     // without zoom
-    expect(mt.fromScreenToModelX(50)).toBeCloseTo(5);
-    expect(mt.fromScreenToModelY(20)).toBeCloseTo(2);
+    expect(vt.fromScreenToModelX(50)).toBeCloseTo(5);
+    expect(vt.fromScreenToModelY(20)).toBeCloseTo(2);
 
     // apply zoom: translate 10 and scale 2 on X
-    mt.onZoomPan({ x: 10, k: 2 } as any);
-    expect(mt.fromScreenToModelX(70)).toBeCloseTo(3);
+    vt.onZoomPan({ x: 10, k: 2 } as any);
+    expect(vt.fromScreenToModelX(70)).toBeCloseTo(3);
     // Y axis unaffected by zoom transform
-    expect(mt.fromScreenToModelY(20)).toBeCloseTo(2);
+    expect(vt.fromScreenToModelY(20)).toBeCloseTo(2);
   });
 
   it("maps screen bases back to model bases through inverse transforms", () => {
-    const svg = {} as unknown as SVGSVGElement;
-    const g = {} as unknown as SVGGElement;
-    const mt = new MyTransform(svg, g);
+    const vt = new ViewportTransform();
 
-    mt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
-    mt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
-    mt.onZoomPan({ x: 10, k: 2 } as any);
+    vt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
+    vt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    vt.onZoomPan({ x: 10, k: 2 } as any);
 
-    const basis = mt.fromScreenToModelBasisX(new AR1Basis(20, 40));
+    const basis = vt.fromScreenToModelBasisX(new AR1Basis(20, 40));
     const [p1, p2] = basis.toArr();
     expect(p1).toBeCloseTo(0.5);
     expect(p2).toBeCloseTo(1.5);
   });
 
   it("converts screen points to model points", () => {
-    const svg = {} as unknown as SVGSVGElement;
-    const g = {} as unknown as SVGGElement;
-    const mt = new MyTransform(svg, g);
+    const vt = new ViewportTransform();
 
-    mt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
-    mt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
-    mt.onZoomPan({ x: 10, k: 2 } as any);
+    vt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
+    vt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    vt.onZoomPan({ x: 10, k: 2 } as any);
 
-    const p = (mt as any).toModelPoint(70, 20) as { x: number; y: number };
+    const p = (vt as any).toModelPoint(70, 20) as { x: number; y: number };
     expect(p.x).toBeCloseTo(3);
     expect(p.y).toBeCloseTo(2);
   });

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -21,29 +21,16 @@ export function composeZoomMatrix(t: ZoomTransform): DOMMatrix {
   return new DOMMatrix().translate(t.x, 0).scale(t.k, 1);
 }
 
-export class MyTransform {
-  private viewPortPointsX: AR1Basis;
-  private viewPortPointsY: AR1Basis;
+export class ViewportTransform {
+  private viewPortPointsX: AR1Basis = bPlaceholder;
+  private viewPortPointsY: AR1Basis = bPlaceholder;
 
-  private referenceViewWindowPointsX: AR1Basis;
-  private referenceViewWindowPointsY: AR1Basis;
+  private referenceViewWindowPointsX: AR1Basis = bPlaceholder;
+  private referenceViewWindowPointsY: AR1Basis = bPlaceholder;
 
-  private zoomTransform: DOMMatrix;
-  private referenceTransform: DOMMatrix;
-  private composedMatrix: DOMMatrix;
-
-  private viewNode: SVGGElement;
-
-  constructor(_svgNode: SVGSVGElement, viewNode: SVGGElement) {
-    this.viewNode = viewNode;
-    this.zoomTransform = new DOMMatrix();
-    this.referenceTransform = new DOMMatrix();
-    this.composedMatrix = new DOMMatrix();
-    this.viewPortPointsX = bPlaceholder;
-    this.viewPortPointsY = bPlaceholder;
-    this.referenceViewWindowPointsX = bPlaceholder;
-    this.referenceViewWindowPointsY = bPlaceholder;
-  }
+  private zoomTransform: DOMMatrix = new DOMMatrix();
+  private referenceTransform: DOMMatrix = new DOMMatrix();
+  private composedMatrix: DOMMatrix = new DOMMatrix();
 
   private updateReferenceTransform() {
     this.referenceTransform = composeReferenceMatrix(
@@ -77,10 +64,6 @@ export class MyTransform {
     this.updateReferenceTransform();
   }
 
-  public updateViewNode() {
-    updateNode(this.viewNode, this.composedMatrix);
-  }
-
   public onZoomPan(t: ZoomTransform): void {
     this.zoomTransform = composeZoomMatrix(t);
     this.updateComposedMatrix();
@@ -112,4 +95,15 @@ export class MyTransform {
     const [p1, p2] = b.toArr().map(transformPoint);
     return new AR1Basis(p1, p2);
   }
+
+  public get matrix(): DOMMatrix {
+    return this.composedMatrix;
+  }
+}
+
+export function applyViewportTransform(
+  node: SVGGraphicsElement,
+  transform: ViewportTransform,
+) {
+  updateNode(node, transform.matrix);
 }

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -2,11 +2,6 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select } from "d3-selection";
-import { AR1Basis } from "../math/affine.ts";
-import { ChartData } from "./data.ts";
-import { setupRender } from "./render.ts";
-import { setupInteraction } from "./interaction.ts";
 
 class Matrix {
   constructor(
@@ -33,22 +28,44 @@ vi.mock("../viewZoomTransform.ts", () => ({
 
 let currentDataLength = 0;
 const transformInstances: any[] = [];
-vi.mock("../MyTransform.ts", () => ({
-  MyTransform: class {
-    constructor(_svg: SVGSVGElement, _g: SVGGElement) {
-      transformInstances.push(this);
+let applyViewportTransform: any;
+function getApplyViewportTransform() {
+  if (!applyViewportTransform) {
+    applyViewportTransform = vi.fn();
+  }
+  return applyViewportTransform;
+}
+vi.mock("../ViewportTransform.ts", () => {
+  class MockBasis {
+    constructor(
+      public p1: number,
+      public p2: number,
+    ) {}
+    toArr() {
+      return [this.p1, this.p2];
     }
-    onZoomPan = vi.fn();
-    fromScreenToModelX = vi.fn((x: number) => x);
-    fromScreenToModelBasisX = vi.fn(
-      () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
-    );
-    dotScaleMatrix = vi.fn(() => new Matrix());
-    onViewPortResize = vi.fn();
-    onReferenceViewWindowResize = vi.fn();
-    updateViewNode = vi.fn();
-  },
-}));
+    transformWith() {
+      return this;
+    }
+  }
+  return {
+    ViewportTransform: class {
+      constructor() {
+        transformInstances.push(this);
+      }
+      onZoomPan = vi.fn();
+      fromScreenToModelX = vi.fn((x: number) => x);
+      fromScreenToModelBasisX = vi.fn(
+        () => new MockBasis(0, Math.max(currentDataLength - 1, 0)),
+      );
+      dotScaleMatrix = vi.fn(() => new Matrix());
+      onViewPortResize = vi.fn();
+      onReferenceViewWindowResize = vi.fn();
+    },
+    applyViewportTransform: (...args: any[]) =>
+      getApplyViewportTransform()(...args),
+  };
+});
 
 const axisInstances: any[] = [];
 vi.mock("../axis.ts", () => ({
@@ -79,6 +96,11 @@ vi.mock("d3-zoom", () => ({
     return behavior;
   },
 }));
+
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import { setupRender } from "./render.ts";
+import { setupInteraction } from "./interaction.ts";
 
 function createChart(data: Array<[number]>) {
   currentDataLength = data.length;
@@ -126,6 +148,7 @@ beforeEach(() => {
   nodeTransforms.clear();
   transformInstances.length = 0;
   axisInstances.length = 0;
+  getApplyViewportTransform().mockClear();
   (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
 });
 
@@ -150,7 +173,10 @@ describe("chart interaction single-axis", () => {
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(transformInstances.length).toBe(1);
-    expect(mtNy.updateViewNode).toHaveBeenCalled();
+    expect(getApplyViewportTransform()).toHaveBeenCalledWith(
+      expect.anything(),
+      mtNy,
+    );
     expect(xAxis.axisUpCalls).toBeGreaterThan(xCalls);
     expect(yAxis.axisUpCalls).toBeGreaterThan(yCalls);
   });


### PR DESCRIPTION
## Summary
- extract DOM-agnostic viewport logic into `ViewportTransform`
- add `applyViewportTransform` to update SVG nodes
- refactor rendering to use new transform API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68932d3e967c832b9d054bc0e6ba5e3b