### PR TITLE
refactor: remove MyTransform helper

### DIFF
--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -6,7 +6,7 @@ import { zoomIdentity, zoom as d3zoom, ZoomTransform } from "d3-zoom";
 
 import { MyAxis, Orientation } from "../../../svg-time-series/src/axis.ts";
 import { ViewportTransform } from "../../../svg-time-series/src/ViewportTransform.ts";
-import { applyViewportTransform } from "../../../svg-time-series/src/MyTransform.ts";
+import { updateNode } from "../../../svg-time-series/src/viewZoomTransform.ts";
 import {
   IMinMax,
   SegmentTree,
@@ -258,7 +258,7 @@ export class TimeSeriesChart {
       const bIndexVisible =
         pathTransform.fromScreenToModelBasisX(bScreenXVisible);
       updateScales(bIndexVisible);
-      applyViewportTransform(viewNode, pathTransform);
+      updateNode(viewNode, pathTransform.matrix);
 
       xAxis.axisUp(gX);
       yAxis.axisUp(gY);

--- a/svg-time-series/src/MyTransform.ts
+++ b/svg-time-series/src/MyTransform.ts
@@ -1,9 +1,0 @@
-import { ViewportTransform } from "./ViewportTransform.ts";
-import { updateNode } from "./viewZoomTransform.ts";
-
-export function applyViewportTransform(
-  node: SVGGraphicsElement,
-  transform: ViewportTransform,
-): void {
-  updateNode(node, transform.matrix);
-}

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -4,7 +4,7 @@ import { line } from "d3-shape";
 
 import { MyAxis, Orientation } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
-import { applyViewportTransform } from "../MyTransform.ts";
+import { updateNode } from "../viewZoomTransform.ts";
 import { AR1Basis, bPlaceholder } from "../math/affine.ts";
 import { SegmentTree } from "../segmentTree.ts";
 import type { ChartData } from "./data.ts";
@@ -256,9 +256,9 @@ export function refreshChart(state: RenderState, data: ChartData) {
       state.scales.ySf,
       data,
     );
-    applyViewportTransform(state.paths.viewSf!, state.transforms.sf);
+    updateNode(state.paths.viewSf!, state.transforms.sf.matrix);
   }
-  applyViewportTransform(state.paths.viewNy, state.transforms.ny);
+  updateNode(state.paths.viewNy, state.transforms.ny.matrix);
   state.axes.x.axisUp(state.axes.gX);
   state.axes.y.axisUp(state.axes.gY);
 }


### PR DESCRIPTION
## Summary
- call `updateNode` directly instead of `applyViewportTransform`
- remove redundant `MyTransform` module and update demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68933d7fef80832bbb7382d30fab0c65