### PR TITLE
feat: allow custom time formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,13 @@ const chart = new TimeSeriesChart(
   buildSegmentTreeTupleSf,
   onZoom,
   onMouseMove,
+  (ts) => new Date(ts).toISOString(),
 );
 ```
+
+The last argument, `formatTime`, is optional and lets you customize how
+timestamps are displayed in the legend. If omitted, timestamps are formatted
+with `toLocaleString`.
 
 For a single Y-axis, supply data with one value per point and omit the second builder:
 
@@ -77,6 +82,7 @@ const chartSingle = new TimeSeriesChart(
   undefined,
   onZoom,
   onMouseMove,
+  (ts) => new Date(ts).toISOString(),
 );
 ```
 

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -41,8 +41,12 @@ const chart = new TimeSeriesChart(
   (i, arr) => ({ min: arr[i][1], max: arr[i][1] }),
   () => {},
   () => {},
+  (ts) => new Date(ts).toISOString(),
 );
 ```
+
+The last parameter allows customizing how timestamps appear in the legend. If
+omitted, `TimeSeriesChart` uses `toLocaleString`.
 
 ## Demos
 

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -82,7 +82,10 @@ vi.mock("d3-zoom", () => ({
   },
 }));
 
-function createChart(data: Array<[number, number]>) {
+function createChart(
+  data: Array<[number, number]>,
+  formatTime?: (timestamp: number) => string,
+) {
   currentDataLength = data.length;
   const parent = document.createElement("div");
   const w = Math.max(currentDataLength - 1, 0);
@@ -119,6 +122,7 @@ function createChart(data: Array<[number, number]>) {
     chartData,
     () => {},
     () => {},
+    formatTime,
   );
 
   drawNewData();
@@ -192,6 +196,24 @@ describe("chart interaction", () => {
     expect(greenTransform.ty).toBe(30);
     expect(blueTransform.tx).toBe(1);
     expect(blueTransform.ty).toBe(40);
+  });
+
+  it("uses custom time formatter when provided", () => {
+    const data: Array<[number, number]> = [
+      [10, 20],
+      [30, 40],
+    ];
+    const formatter = vi.fn((ts: number) => `ts:${ts}`);
+    const { onHover, legend } = createChart(data, formatter);
+    vi.runAllTimers();
+
+    onHover(1);
+    vi.runAllTimers();
+
+    expect(legend.querySelector(".chart-legend__time")!.textContent).toBe(
+      "ts:1",
+    );
+    expect(formatter).toHaveBeenCalledWith(1);
   });
 
   it("handles NaN data", () => {

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -58,6 +58,8 @@ export class ChartInteraction {
     private data: ChartData,
     zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
     mouseMoveHandler: (event: MouseEvent) => void,
+    private formatTime: (timestamp: number) => string = (timestamp) =>
+      new Date(timestamp).toLocaleString(),
   ) {
     this.legendTime = legend.select(".chart-legend__time");
     this.legendGreen = legend.select(".chart-legend__green_value");
@@ -129,12 +131,8 @@ export class ChartInteraction {
   private updateLegendAndDots() {
     const [greenData, blueData] =
       this.data.data[Math.round(this.highlightedDataIdx)];
-
-    this.legendTime.text(
-      new Date(
-        this.data.idxToTime.applyToPoint(this.highlightedDataIdx),
-      ).toLocaleString(),
-    );
+    const timestamp = this.data.idxToTime.applyToPoint(this.highlightedDataIdx);
+    this.legendTime.text(this.formatTime(timestamp));
 
     const dotScaleMatrixNy = this.state.transforms.ny.dotScaleMatrix(
       this.dotRadius,
@@ -199,6 +197,8 @@ export function setupInteraction(
   data: ChartData,
   zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
   mouseMoveHandler: (event: MouseEvent) => void,
+  formatTime: (timestamp: number) => string = (timestamp) =>
+    new Date(timestamp).toLocaleString(),
 ) {
   const interaction = new ChartInteraction(
     svg,
@@ -207,6 +207,7 @@ export function setupInteraction(
     data,
     zoomHandler,
     mouseMoveHandler,
+    formatTime,
   );
 
   return {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -30,6 +30,8 @@ export class TimeSeriesChart {
     ) => IMinMax,
     zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
+    formatTime: (timestamp: number) => string = (timestamp) =>
+      new Date(timestamp).toLocaleString(),
   ) {
     this.data = new ChartData(
       startTime,
@@ -47,6 +49,7 @@ export class TimeSeriesChart {
       this.data,
       zoomHandler,
       mouseMoveHandler,
+      formatTime,
     );
 
     this.zoom = zoom;


### PR DESCRIPTION
## Summary
- allow `TimeSeriesChart` consumers to supply a custom `formatTime` callback
- use custom formatter in `ChartInteraction` and default to `toLocaleString`
- document the new `formatTime` option and add unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893419eab44832b93d69706c38cdce4