### PR TITLE
refactor: derive SegmentTree from core

### DIFF
--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -28,10 +28,10 @@ test("SegmentTree operations", () => {
 
   // Test invalid update position
   expect(() => tree.update(-1, { min: 0, max: 0 })).toThrow(
-    "Position is not valid",
+    "Index is out of range",
   );
   expect(() => tree.update(5, { min: 0, max: 0 })).toThrow(
-    "Position is not valid",
+    "Index is out of range",
   );
 });
 

--- a/svg-time-series/src/segmentTree.ts
+++ b/svg-time-series/src/segmentTree.ts
@@ -17,45 +17,28 @@ const minMaxIdentity: IMinMax = {
   max: -Infinity,
 };
 
-function assertOk(cond: boolean, message: string): asserts cond {
-  if (!cond) {
-    throw new Error(message);
-  }
-}
-
-export class SegmentTree<T = [number, number]> {
-  private readonly size: number;
-  private tree: SegmentTreeCore<IMinMax>;
-
+export class SegmentTree<
+  T = [number, number],
+> extends SegmentTreeCore<IMinMax> {
   constructor(
     data: ReadonlyArray<T>,
     dataSize: number,
     buildTuple: (elementIndex: number, elements: ReadonlyArray<T>) => IMinMax,
   ) {
-    this.size = dataSize;
-    const minMaxData: IMinMax[] = new Array(this.size);
+    const minMaxData: IMinMax[] = new Array(dataSize);
 
-    for (let i = 0; i < this.size; i++) {
+    for (let i = 0; i < dataSize; i++) {
       minMaxData[i] = buildTuple(i, data);
     }
 
-    this.tree = new SegmentTreeCore(minMaxData, buildMinMax, minMaxIdentity);
+    super(minMaxData, buildMinMax, minMaxIdentity);
   }
 
   getMinMax(fromPosition: number, toPosition: number): IMinMax {
-    assertOk(
-      fromPosition >= 0 && toPosition < this.size && fromPosition <= toPosition,
-      "Range is not valid",
-    );
-    return this.tree.query(fromPosition, toPosition);
+    return super.query(fromPosition, toPosition);
   }
 
   update(positionToUpdate: number, newValue: Readonly<IMinMax>): void {
-    assertOk(
-      positionToUpdate >= 0 && positionToUpdate < this.size,
-      "Position is not valid",
-    );
-
-    this.tree.update(positionToUpdate, newValue);
+    super.update(positionToUpdate, newValue);
   }
 }


### PR DESCRIPTION
## Summary
- refactor SegmentTree wrapper to extend core SegmentTree
- drop custom assertions and rely on core validation
- adjust tests for new error messaging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68934f15a9d8832b95a65d5b0e999f9c