### PR TITLE
refactor: use options object for chart

### DIFF
--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -305,20 +305,27 @@ describe("chart interaction", () => {
       '<span class="chart-legend__blue_value"></span>';
 
     const mouseMoveHandler = vi.fn();
-
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       select(legend) as any,
-      0,
-      1,
-      [
-        [0, 0],
-        [1, 1],
-      ],
-      (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
-      (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
-      () => {},
-      mouseMoveHandler,
+      {
+        startTime: 0,
+        timeStep: 1,
+        data: [
+          [0, 0],
+          [1, 1],
+        ],
+        buildSegmentTreeTupleNy: (i, arr) => ({
+          min: arr[i][0],
+          max: arr[i][0],
+        }),
+        buildSegmentTreeTupleSf: (i, arr) => ({
+          min: arr[i][1]!,
+          max: arr[i][1]!,
+        }),
+        zoomHandler: () => {},
+        mouseMoveHandler,
+      },
     );
 
     const zoomRect = svgEl.querySelector("rect.zoom") as SVGRectElement;

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -54,17 +54,15 @@ function createChart(initialData: Array<[number, number?]>) {
 
   const buildTuple = () => ({ min: 0, max: 0 });
 
-  const chart = new TimeSeriesChart(
-    svgSel,
-    legendSel,
-    0,
-    1,
-    initialData,
-    buildTuple,
-    buildTuple,
-    vi.fn(),
-    vi.fn(),
-  );
+  const chart = new TimeSeriesChart(svgSel, legendSel, {
+    startTime: 0,
+    timeStep: 1,
+    data: initialData,
+    buildSegmentTreeTupleNy: buildTuple,
+    buildSegmentTreeTupleSf: buildTuple,
+    zoomHandler: vi.fn(),
+    mouseMoveHandler: vi.fn(),
+  });
 
   appendSpy.mockClear();
   drawNewDataMock.mockClear();

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -7,6 +7,23 @@ import { setupInteraction } from "./chart/interaction.ts";
 
 export type { IMinMax } from "./chart/data.ts";
 
+export interface TimeSeriesChartOptions {
+  startTime: number;
+  timeStep: number;
+  data: Array<[number, number?]>;
+  buildSegmentTreeTupleNy: (
+    index: number,
+    elements: ReadonlyArray<[number, number?]>,
+  ) => IMinMax;
+  buildSegmentTreeTupleSf?: (
+    index: number,
+    elements: ReadonlyArray<[number, number?]>,
+  ) => IMinMax;
+  zoomHandler?: (event: D3ZoomEvent<Element, unknown>) => void;
+  mouseMoveHandler?: (event: MouseEvent) => void;
+  formatTime?: (timestamp: number) => string;
+}
+
 export class TimeSeriesChart {
   public zoom: (event: D3ZoomEvent<Element, unknown>) => void;
   public onHover: (x: number) => void;
@@ -17,22 +34,19 @@ export class TimeSeriesChart {
   constructor(
     svg: Selection<BaseType, unknown, HTMLElement, unknown>,
     legend: Selection<BaseType, unknown, HTMLElement, unknown>,
-    startTime: number,
-    timeStep: number,
-    data: Array<[number, number?]>,
-    buildSegmentTreeTupleNy: (
-      index: number,
-      elements: ReadonlyArray<[number, number?]>,
-    ) => IMinMax,
-    buildSegmentTreeTupleSf?: (
-      index: number,
-      elements: ReadonlyArray<[number, number?]>,
-    ) => IMinMax,
-    zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void = () => {},
-    mouseMoveHandler: (event: MouseEvent) => void = () => {},
-    formatTime: (timestamp: number) => string = (timestamp) =>
-      new Date(timestamp).toLocaleString(),
+    options: TimeSeriesChartOptions,
   ) {
+    const {
+      startTime,
+      timeStep,
+      data,
+      buildSegmentTreeTupleNy,
+      buildSegmentTreeTupleSf,
+      zoomHandler = () => {},
+      mouseMoveHandler = () => {},
+      formatTime = (timestamp: number) => new Date(timestamp).toLocaleString(),
+    } = options;
+
     this.data = new ChartData(
       startTime,
       timeStep,


### PR DESCRIPTION
## Summary
- group chart constructor settings into a `TimeSeriesChartOptions` interface
- update `TimeSeriesChart` constructor to accept options object
- adjust chart tests to instantiate with new options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68934f8b7534832bb92465e776132d80