### PR TITLE
refactor: rename SegmentTree.getMinMax to query

### DIFF
--- a/samples/benchmarks/demo2-without-grid/draw.ts
+++ b/samples/benchmarks/demo2-without-grid/draw.ts
@@ -102,7 +102,7 @@ export class TimeSeriesChart {
         domainX,
         this.chart.data[0].values.length,
       );
-      const minMax = this.tree.getMinMax(ySubInterval[0], ySubInterval[1]);
+      const minMax = this.tree.query(ySubInterval[0], ySubInterval[1]);
       const domainY = [minMax.min, minMax.max];
       const newRangeY = [this.chart.y(domainY[0]), this.chart.y(domainY[1])];
       const oldRangeY = this.chart.y.range();
@@ -145,7 +145,7 @@ export class TimeSeriesChart {
     );
 
     x.domain([this.minX, this.maxX]);
-    const minMax = this.tree.getMinMax(0, cities[0].values.length - 1);
+    const minMax = this.tree.query(0, cities[0].values.length - 1);
     y.domain([minMax.min, minMax.max]);
 
     const view = svg

--- a/samples/benchmarks/segment-tree-queries/draw.ts
+++ b/samples/benchmarks/segment-tree-queries/draw.ts
@@ -36,7 +36,7 @@ export class TimeSeriesChart {
     animateBench((elapsed: number) => {
       const minX = animateCosDown(dataLength / 2, 0, elapsed);
       const maxX = minX + dataLength / 2;
-      const { min, max } = tree.getMinMax(minX, maxX);
+      const { min, max } = tree.query(minX, maxX);
       t.setViewWindow(minX, maxX, min, max);
     });
   }

--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -348,7 +348,7 @@ export class TimeSeriesChart {
   private bTemperatureVisible(bIndexVisible: AR1Basis): AR1Basis {
     // ������ ������� ����� ��������
     const [minIdxX, maxIdxX] = bIndexVisible.toArr();
-    const { min, max } = this.tree.getMinMax(minIdxX, maxIdxX);
+    const { min, max } = this.tree.query(minIdxX, maxIdxX);
     return new AR1Basis(min, max);
   }
 }

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -68,8 +68,8 @@ describe("ChartData", () => {
     ]);
     expect(cd.idxToTime.applyToPoint(0)).toBe(-3);
     expect(cd.idxToTime.applyToPoint(1)).toBe(-2);
-    expect(cd.treeNy.getMinMax(0, 1)).toEqual({ min: 3, max: 4 });
-    expect(cd.treeSf!.getMinMax(0, 1)).toEqual({ min: 3, max: 4 });
+    expect(cd.treeNy.query(0, 1)).toEqual({ min: 3, max: 4 });
+    expect(cd.treeSf!.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
 
   it("computes visible temperature bounds", () => {
@@ -217,7 +217,7 @@ describe("ChartData", () => {
       expect(cd.data).toEqual([[0], [1]]);
       cd.append([2]);
       expect(cd.data).toEqual([[1], [2]]);
-      expect(cd.treeNy.getMinMax(0, 1)).toEqual({ min: 1, max: 2 });
+      expect(cd.treeNy.query(0, 1)).toEqual({ min: 1, max: 2 });
     });
   });
 });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -89,7 +89,7 @@ export class ChartData {
     if (startIdx > endIdx) {
       [startIdx, endIdx] = [endIdx, startIdx];
     }
-    const { min, max } = tree.getMinMax(startIdx, endIdx);
+    const { min, max } = tree.query(startIdx, endIdx);
     return new AR1Basis(min, max);
   }
 }

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -11,20 +11,18 @@ test("SegmentTree operations", () => {
   const tree = new SegmentTree(data, data.length, buildTuple);
 
   // Test initial state
-  expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 1, max: 5 });
-  expect(tree.getMinMax(1, 3)).toEqual({ min: 2, max: 5 });
+  expect(tree.query(0, data.length - 1)).toEqual({ min: 1, max: 5 });
+  expect(tree.query(1, 3)).toEqual({ min: 2, max: 5 });
 
   // Test update
   tree.update(2, { min: 6, max: 6 });
-  expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 1, max: 6 });
-  expect(tree.getMinMax(2, data.length - 1)).toEqual({ min: 4, max: 6 });
+  expect(tree.query(0, data.length - 1)).toEqual({ min: 1, max: 6 });
+  expect(tree.query(2, data.length - 1)).toEqual({ min: 4, max: 6 });
 
   // Test invalid range
-  expect(() => tree.getMinMax(-1, data.length - 1)).toThrow(
-    "Range is not valid",
-  );
-  expect(() => tree.getMinMax(3, 2)).toThrow("Range is not valid");
-  expect(() => tree.getMinMax(0, data.length)).toThrow("Range is not valid");
+  expect(() => tree.query(-1, data.length - 1)).toThrow("Range is not valid");
+  expect(() => tree.query(3, 2)).toThrow("Range is not valid");
+  expect(() => tree.query(0, data.length)).toThrow("Range is not valid");
 
   // Test invalid update position
   expect(() => tree.update(-1, { min: 0, max: 0 })).toThrow(
@@ -49,11 +47,11 @@ test("SegmentTree with IMinMax", () => {
   const tree = new SegmentTree(data, data.length, buildTuple);
 
   // Test initial state
-  expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 1, max: 7 });
-  expect(tree.getMinMax(1, 3)).toEqual({ min: 2, max: 6 });
+  expect(tree.query(0, data.length - 1)).toEqual({ min: 1, max: 7 });
+  expect(tree.query(1, 3)).toEqual({ min: 2, max: 6 });
 
   // Test update
   tree.update(2, { min: 0, max: 8 });
-  expect(tree.getMinMax(0, data.length - 1)).toEqual({ min: 0, max: 8 });
-  expect(tree.getMinMax(2, data.length - 1)).toEqual({ min: 0, max: 8 });
+  expect(tree.query(0, data.length - 1)).toEqual({ min: 0, max: 8 });
+  expect(tree.query(2, data.length - 1)).toEqual({ min: 0, max: 8 });
 });

--- a/svg-time-series/src/segmentTree.ts
+++ b/svg-time-series/src/segmentTree.ts
@@ -34,7 +34,7 @@ export class SegmentTree<
     super(minMaxData, buildMinMax, minMaxIdentity);
   }
 
-  getMinMax(fromPosition: number, toPosition: number): IMinMax {
+  query(fromPosition: number, toPosition: number): IMinMax {
     return super.query(fromPosition, toPosition);
   }
 


### PR DESCRIPTION
## Summary
- rename SegmentTree.getMinMax to query
- update ChartData, tests, and samples to use new method

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689351d7b794832b9439566b8eabcaab