### PR TITLE
refactor(chart): centralize segment tree creation

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -19,6 +19,15 @@ export class ChartData {
     elements: ReadonlyArray<[number, number?]>,
   ) => IMinMax;
 
+  private createSegmentTree(
+    builder: (
+      index: number,
+      elements: ReadonlyArray<[number, number?]>,
+    ) => IMinMax,
+  ): SegmentTree<[number, number?]> {
+    return new SegmentTree(this.data, this.data.length, builder);
+  }
+
   /**
    * Creates a new ChartData instance.
    * @param data Initial dataset; must contain at least one point.
@@ -60,20 +69,10 @@ export class ChartData {
   }
 
   private rebuildSegmentTrees(): void {
-    this.treeNy = new SegmentTree(
-      this.data,
-      this.data.length,
-      this.buildSegmentTreeTupleNy,
-    );
-    if (this.buildSegmentTreeTupleSf) {
-      this.treeSf = new SegmentTree(
-        this.data,
-        this.data.length,
-        this.buildSegmentTreeTupleSf,
-      );
-    } else {
-      this.treeSf = undefined;
-    }
+    this.treeNy = this.createSegmentTree(this.buildSegmentTreeTupleNy);
+    this.treeSf = this.buildSegmentTreeTupleSf
+      ? this.createSegmentTree(this.buildSegmentTreeTupleSf)
+      : undefined;
   }
 
   bTemperatureVisible(


### PR DESCRIPTION
## Summary
- add helper to create `SegmentTree` instances in `ChartData`
- use new helper to build segment trees for both data series

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689357a2a268832bb504ab5bf0b939bc