### PR TITLE
refactor: modularize chart rendering helpers

### DIFF
--- a/svg-time-series/src/chart/render/dimensions.ts
+++ b/svg-time-series/src/chart/render/dimensions.ts
@@ -1,0 +1,20 @@
+import { BaseType, Selection } from "d3-selection";
+import { AR1Basis } from "../../math/affine.ts";
+
+export function createDimensions(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+) {
+  const node: SVGSVGElement = svg.node() as SVGSVGElement;
+  const div: HTMLElement = node.parentNode as HTMLElement;
+
+  const width = div.clientWidth;
+  const height = div.clientHeight;
+
+  svg.attr("width", width);
+  svg.attr("height", height);
+
+  const bScreenXVisible = new AR1Basis(0, width);
+  const bScreenYVisible = new AR1Basis(height, 0);
+
+  return { width, height, bScreenXVisible, bScreenYVisible };
+}

--- a/svg-time-series/src/chart/render/paths.ts
+++ b/svg-time-series/src/chart/render/paths.ts
@@ -1,0 +1,39 @@
+import { BaseType, Selection } from "d3-selection";
+import { ViewportTransform } from "../../ViewportTransform.ts";
+
+export interface PathSet {
+  path: Selection<SVGPathElement, number, any, unknown>;
+  viewNy: SVGGElement;
+  viewSf?: SVGGElement;
+}
+
+export interface TransformPair {
+  ny: ViewportTransform;
+  sf?: ViewportTransform;
+}
+
+export function initPaths(
+  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  hasSf: boolean,
+): PathSet {
+  const views = svg
+    .selectAll("g")
+    .data(hasSf ? [0, 1] : [0])
+    .enter()
+    .append("g")
+    .attr("class", "view");
+  const nodes = views.nodes() as SVGGElement[];
+  const viewNy = nodes[0];
+  const viewSf = hasSf ? nodes[1] : undefined;
+  const path = views.append("path");
+  return { path, viewNy, viewSf };
+}
+
+export function createTransforms(paths: PathSet): TransformPair {
+  const ny = new ViewportTransform();
+  let sf: ViewportTransform | undefined;
+  if (paths.viewSf) {
+    sf = new ViewportTransform();
+  }
+  return { ny, sf };
+}

--- a/svg-time-series/src/chart/render/scales.ts
+++ b/svg-time-series/src/chart/render/scales.ts
@@ -1,0 +1,53 @@
+import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
+import { AR1Basis } from "../../math/affine.ts";
+import { SegmentTree } from "../../segmentTree.ts";
+import { ViewportTransform } from "../../ViewportTransform.ts";
+import type { ChartData } from "../data.ts";
+
+export interface ScaleSet {
+  x: ScaleTime<number, number>;
+  yNy: ScaleLinear<number, number>;
+  ySf?: ScaleLinear<number, number>;
+}
+
+export function createScales(
+  bScreenXVisible: AR1Basis,
+  bScreenYVisible: AR1Basis,
+  hasSf: boolean,
+): ScaleSet {
+  const x: ScaleTime<number, number> = scaleTime().range(
+    bScreenXVisible.toArr(),
+  );
+  const yNy: ScaleLinear<number, number> = scaleLinear().range(
+    bScreenYVisible.toArr(),
+  );
+  let ySf: ScaleLinear<number, number> | undefined;
+  if (hasSf) {
+    ySf = scaleLinear().range(bScreenYVisible.toArr());
+  }
+  return { x, yNy, ySf };
+}
+
+export function updateScaleX(
+  x: ScaleTime<number, number>,
+  bIndexVisible: AR1Basis,
+  data: ChartData,
+) {
+  const bTimeVisible = bIndexVisible.transformWith(data.idxToTime);
+  x.domain(bTimeVisible.toArr());
+}
+
+export function updateScaleY(
+  bIndexVisible: AR1Basis,
+  tree: SegmentTree,
+  pathTransform: ViewportTransform,
+  yScale: ScaleLinear<number, number>,
+  data: ChartData,
+) {
+  const bTemperatureVisible = data.bTemperatureVisible(bIndexVisible, tree);
+  pathTransform.onReferenceViewWindowResize(
+    data.bIndexFull,
+    bTemperatureVisible,
+  );
+  yScale.domain(bTemperatureVisible.toArr());
+}


### PR DESCRIPTION
## Summary
- factor out dimension calculations into `render/dimensions.ts`
- move scale setup and update helpers into `render/scales.ts`
- extract path initialization and transform creation to `render/paths.ts`
- streamline `render.ts` to orchestrate setup using these helpers

## Testing
- `npm run format`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689357a822b4832b927f5963500f05fd