### PR TITLE
refactor: construct ChartInteraction directly

### DIFF
--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -6,7 +6,7 @@ import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData } from "./data.ts";
 import { setupRender } from "./render.ts";
-import { setupInteraction } from "./interaction.ts";
+import { ChartInteraction } from "./interaction.ts";
 
 class Matrix {
   constructor(
@@ -107,7 +107,7 @@ function createChart(data: Array<[number]>) {
   }));
 
   const renderState = setupRender(select(svgEl) as any, chartData);
-  const { zoom, onHover, drawNewData } = setupInteraction(
+  const interaction = new ChartInteraction(
     select(svgEl) as any,
     select(legend) as any,
     renderState,
@@ -116,10 +116,15 @@ function createChart(data: Array<[number]>) {
     () => {},
   );
 
-  drawNewData();
-  onHover(renderState.dimensions.width);
+  interaction.drawNewData();
+  interaction.onHover(renderState.dimensions.width);
 
-  return { zoom, onHover, svgEl, legend };
+  return {
+    zoom: interaction.zoom,
+    onHover: interaction.onHover,
+    svgEl,
+    legend,
+  };
 }
 
 beforeEach(() => {

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -6,7 +6,7 @@ import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData } from "./data.ts";
 import { setupRender } from "./render.ts";
-import { setupInteraction } from "./interaction.ts";
+import { ChartInteraction } from "./interaction.ts";
 import { TimeSeriesChart } from "../draw.ts";
 
 class Matrix {
@@ -115,7 +115,7 @@ function createChart(
   );
 
   const renderState = setupRender(select(svgEl) as any, chartData);
-  const { zoom, onHover, drawNewData } = setupInteraction(
+  const interaction = new ChartInteraction(
     select(svgEl) as any,
     select(legend) as any,
     renderState,
@@ -125,10 +125,15 @@ function createChart(
     formatTime,
   );
 
-  drawNewData();
-  onHover(renderState.dimensions.width);
+  interaction.drawNewData();
+  interaction.onHover(renderState.dimensions.width);
 
-  return { zoom, onHover, svgEl, legend };
+  return {
+    zoom: interaction.zoom,
+    onHover: interaction.onHover,
+    svgEl,
+    legend,
+  };
 }
 
 beforeEach(() => {

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -189,31 +189,3 @@ export class ChartInteraction {
     this.highlightedBlueDot?.remove();
   };
 }
-
-export function setupInteraction(
-  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
-  legend: Selection<BaseType, unknown, HTMLElement, unknown>,
-  state: RenderState,
-  data: ChartData,
-  zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
-  mouseMoveHandler: (event: MouseEvent) => void,
-  formatTime: (timestamp: number) => string = (timestamp) =>
-    new Date(timestamp).toLocaleString(),
-) {
-  const interaction = new ChartInteraction(
-    svg,
-    legend,
-    state,
-    data,
-    zoomHandler,
-    mouseMoveHandler,
-    formatTime,
-  );
-
-  return {
-    zoom: interaction.zoom,
-    onHover: interaction.onHover,
-    drawNewData: interaction.drawNewData,
-    destroy: interaction.destroy,
-  };
-}

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -5,6 +5,8 @@ import { select } from "d3-selection";
 let drawNewDataMock: ReturnType<typeof vi.fn>;
 let onHoverMock: ReturnType<typeof vi.fn>;
 let onHoverUsedData: Array<[number, number?]> | null;
+// eslint-disable-next-line no-var
+var ChartInteractionMock: ReturnType<typeof vi.fn>;
 
 vi.mock("./chart/render.ts", () => ({
   setupRender: vi.fn(() => ({
@@ -12,8 +14,8 @@ vi.mock("./chart/render.ts", () => ({
   })),
 }));
 
-vi.mock("./chart/interaction.ts", () => ({
-  setupInteraction: vi.fn(
+vi.mock("./chart/interaction.ts", () => {
+  ChartInteractionMock = vi.fn(
     (
       _svg: unknown,
       _legend: unknown,
@@ -28,10 +30,12 @@ vi.mock("./chart/interaction.ts", () => ({
         zoom: vi.fn(),
         onHover: onHoverMock,
         drawNewData: drawNewDataMock,
+        destroy: vi.fn(),
       };
     },
-  ),
-}));
+  );
+  return { ChartInteraction: ChartInteractionMock };
+});
 
 import { TimeSeriesChart } from "./draw.ts";
 import { ChartData } from "./chart/data.ts";

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -3,7 +3,7 @@ import { D3ZoomEvent } from "d3-zoom";
 
 import { ChartData, IMinMax } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
-import { setupInteraction } from "./chart/interaction.ts";
+import { ChartInteraction } from "./chart/interaction.ts";
 
 export type { IMinMax } from "./chart/data.ts";
 
@@ -42,7 +42,7 @@ export class TimeSeriesChart {
     );
 
     const renderState = setupRender(svg, this.data);
-    const { zoom, onHover, drawNewData, destroy } = setupInteraction(
+    const interaction = new ChartInteraction(
       svg,
       legend,
       renderState,
@@ -52,10 +52,10 @@ export class TimeSeriesChart {
       formatTime,
     );
 
-    this.zoom = zoom;
-    this.onHover = onHover;
-    this.drawNewData = drawNewData;
-    this.destroyInteraction = destroy;
+    this.zoom = interaction.zoom;
+    this.onHover = interaction.onHover;
+    this.drawNewData = interaction.drawNewData;
+    this.destroyInteraction = interaction.destroy;
 
     this.drawNewData();
     this.onHover(renderState.dimensions.width - 1);


### PR DESCRIPTION
## Summary
- instantiate `ChartInteraction` in `TimeSeriesChart` instead of using `setupInteraction`
- remove obsolete `setupInteraction` helper
- update tests to construct `ChartInteraction` directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935dd20898832b823f601b3a971691