### PR TITLE
refactor: separate path rendering helper

### DIFF
--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -10,7 +10,8 @@ import { timeout as runTimeout } from "d3-timer";
 import { updateNode } from "../viewZoomTransform.ts";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
-import { refreshChart, renderPaths } from "./render.ts";
+import { refreshChart } from "./render.ts";
+import { renderPaths } from "./render/paths.ts";
 
 export function drawProc<T extends unknown[]>(
   f: (...args: T) => void,

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -3,7 +3,8 @@
  */
 import { describe, it, expect } from "vitest";
 import { select } from "d3-selection";
-import { renderPaths, type RenderState } from "./render.ts";
+import { renderPaths } from "./render/paths.ts";
+import type { RenderState } from "./render.ts";
 
 describe("renderPaths", () => {
   it("skips segments for NaN values", () => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -1,6 +1,5 @@
 import { ScaleLinear, ScaleTime } from "d3-scale";
 import { BaseType, Selection } from "d3-selection";
-import { line } from "d3-shape";
 
 import { MyAxis, Orientation } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
@@ -122,24 +121,6 @@ export function setupRender(
   const dimensions: Dimensions = { width, height };
 
   return { scales, axes, paths, transforms, dimensions };
-}
-
-export function renderPaths(
-  state: RenderState,
-  dataArr: Array<[number, number?]>,
-) {
-  const drawLine = (cityIdx: number) =>
-    line<[number, number?]>()
-      .defined((d) => {
-        return !(isNaN(d[cityIdx]!) || d[cityIdx] == null);
-      })
-      .x((d, i) => i)
-      .y((d) => d[cityIdx]!);
-
-  state.paths.path.attr(
-    "d",
-    (cityIndex: number) => drawLine(cityIndex)(dataArr) ?? "",
-  );
 }
 
 export function refreshChart(state: RenderState, data: ChartData) {

--- a/svg-time-series/src/chart/render/paths.ts
+++ b/svg-time-series/src/chart/render/paths.ts
@@ -1,5 +1,7 @@
 import { BaseType, Selection } from "d3-selection";
+import { line } from "d3-shape";
 import { ViewportTransform } from "../../ViewportTransform.ts";
+import type { RenderState } from "../render.ts";
 
 export interface PathSet {
   path: Selection<SVGPathElement, number, any, unknown>;
@@ -36,4 +38,20 @@ export function createTransforms(paths: PathSet): TransformPair {
     sf = new ViewportTransform();
   }
   return { ny, sf };
+}
+
+export function renderPaths(
+  state: RenderState,
+  dataArr: Array<[number, number?]>,
+) {
+  const drawLine = (cityIdx: number) =>
+    line<[number, number?]>()
+      .defined((d) => !(isNaN(d[cityIdx]!) || d[cityIdx] == null))
+      .x((_, i) => i)
+      .y((d) => d[cityIdx]!);
+
+  state.paths.path.attr(
+    "d",
+    (cityIndex: number) => drawLine(cityIndex)(dataArr) ?? "",
+  );
 }


### PR DESCRIPTION
## Summary
- move renderPaths to render/paths module
- update consumers to import renderPaths from new location

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935f24bc50832b847465713b1f8efb