### PR TITLE
refactor: extract drawProc into utility

### DIFF
--- a/svg-time-series/src/chart/drawProc.test.ts
+++ b/svg-time-series/src/chart/drawProc.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { drawProc } from "./interaction.ts";
+import { drawProc } from "../utils/drawProc.ts";
 
 describe("drawProc", () => {
   afterEach(() => {

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -5,29 +5,12 @@ import {
   ZoomTransform,
   ZoomBehavior,
 } from "d3-zoom";
-import { timeout as runTimeout } from "d3-timer";
-
+import { drawProc } from "../utils/drawProc.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
 import { refreshChart } from "./render.ts";
 import { renderPaths } from "./render/paths.ts";
-
-export function drawProc<T extends unknown[]>(
-  f: (...args: T) => void,
-): (...args: T) => void {
-  let requested = false;
-
-  return (...params: T) => {
-    if (!requested) {
-      requested = true;
-      runTimeout(() => {
-        requested = false;
-        f(...params);
-      });
-    }
-  };
-}
 
 export class ChartInteraction {
   private legendTime: Selection<BaseType, unknown, HTMLElement, unknown>;

--- a/svg-time-series/src/utils/drawProc.ts
+++ b/svg-time-series/src/utils/drawProc.ts
@@ -1,0 +1,17 @@
+import { timeout as runTimeout } from "d3-timer";
+
+export function drawProc<T extends unknown[]>(
+  f: (...args: T) => void,
+): (...args: T) => void {
+  let requested = false;
+
+  return (...params: T) => {
+    if (!requested) {
+      requested = true;
+      runTimeout(() => {
+        requested = false;
+        f(...params);
+      });
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- move drawProc to utils and export it
- update chart interaction to import drawProc
- fix test to import drawProc from new location

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689362c117a4832ba75c26520b1d36f2