### PR TITLE
refactor: inline viewport transforms

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -13,7 +13,7 @@ import {
   updateScaleY,
   type ScaleSet,
 } from "./render/scales.ts";
-import { initPaths, createTransforms, type PathSet } from "./render/paths.ts";
+import { initPaths, type PathSet } from "./render/paths.ts";
 
 function bindAxisToDom(
   svg: Selection<BaseType, unknown, HTMLElement, unknown>,
@@ -83,7 +83,10 @@ export function setupRender(
     createDimensions(svg);
   const paths = initPaths(svg, hasSf);
   const scales = createScales(bScreenXVisible, bScreenYVisible, hasSf);
-  const transformsInner = createTransforms(paths);
+  const transformsInner = {
+    ny: new ViewportTransform(),
+    sf: paths.viewSf ? new ViewportTransform() : undefined,
+  };
 
   updateScaleX(scales.x, data.bIndexFull, data);
   updateScaleY(

--- a/svg-time-series/src/chart/render/paths.ts
+++ b/svg-time-series/src/chart/render/paths.ts
@@ -31,15 +31,6 @@ export function initPaths(
   return { path, viewNy, viewSf };
 }
 
-export function createTransforms(paths: PathSet): TransformPair {
-  const ny = new ViewportTransform();
-  let sf: ViewportTransform | undefined;
-  if (paths.viewSf) {
-    sf = new ViewportTransform();
-  }
-  return { ny, sf };
-}
-
 export function renderPaths(
   state: RenderState,
   dataArr: Array<[number, number?]>,


### PR DESCRIPTION
## Summary
- remove unused `createTransforms` helper from path utilities
- inline `ViewportTransform` instantiation in `setupRender`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689366496234832b9e98f40359f00355