### PR TITLE
refactor: extract legend controller

### DIFF
--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection, select } from "d3-selection";
+import { BaseType, Selection } from "d3-selection";
 import {
   zoom as d3zoom,
   D3ZoomEvent,
@@ -6,34 +6,20 @@ import {
   ZoomBehavior,
 } from "d3-zoom";
 import { drawProc } from "../utils/drawProc.ts";
-import { updateNode } from "../utils/domNodeTransform.ts";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
 import { refreshChart } from "./render.ts";
 import { renderPaths } from "./render/paths.ts";
+import { LegendController } from "./legend.ts";
 
 export class ChartInteraction {
-  private legendTime: Selection<BaseType, unknown, HTMLElement, unknown>;
-  private legendGreen: Selection<BaseType, unknown, HTMLElement, unknown>;
-  private legendBlue: Selection<BaseType, unknown, HTMLElement, unknown>;
-
   private zoomBehavior: ZoomBehavior<SVGRectElement, unknown>;
   private zoomArea: Selection<SVGRectElement, unknown, BaseType, unknown>;
 
   private currentPanZoomTransformState: ZoomTransform | null = null;
 
-  private readonly dotRadius = 3;
-  private highlightedGreenDot: SVGCircleElement;
-  private highlightedBlueDot: SVGCircleElement | null;
-
-  private identityMatrix = document
-    .createElementNS("http://www.w3.org/2000/svg", "svg")
-    .createSVGMatrix();
-
-  private highlightedDataIdx = 0;
-
   private scheduleRefresh: () => void;
-  private schedulePointRefresh: () => void;
+  private legendController: LegendController;
 
   constructor(
     svg: Selection<BaseType, unknown, HTMLElement, unknown>,
@@ -42,13 +28,9 @@ export class ChartInteraction {
     private data: ChartData,
     zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
     mouseMoveHandler: (event: MouseEvent) => void,
-    private formatTime: (timestamp: number) => string = (timestamp) =>
+    formatTime: (timestamp: number) => string = (timestamp) =>
       new Date(timestamp).toLocaleString(),
   ) {
-    this.legendTime = legend.select(".chart-legend__time");
-    this.legendGreen = legend.select(".chart-legend__green_value");
-    this.legendBlue = legend.select(".chart-legend__blue_value");
-
     this.zoomBehavior = d3zoom<SVGRectElement, unknown>()
       .scaleExtent([1, 40])
       .translateExtent([
@@ -67,19 +49,6 @@ export class ChartInteraction {
       .attr("height", state.dimensions.height)
       .call(this.zoomBehavior);
     this.zoomArea.on("mousemove", mouseMoveHandler);
-
-    const makeDot = (view: SVGGElement) =>
-      select(view)
-        .append("circle")
-        .attr("cx", 0)
-        .attr("cy", 0)
-        .attr("r", 1)
-        .node() as SVGCircleElement;
-    this.highlightedGreenDot = makeDot(state.paths.viewNy);
-    this.highlightedBlueDot = state.paths.viewSf
-      ? makeDot(state.paths.viewSf)
-      : null;
-
     this.scheduleRefresh = drawProc(() => {
       if (this.currentPanZoomTransformState != null) {
         this.zoomBehavior.transform(
@@ -90,9 +59,12 @@ export class ChartInteraction {
       refreshChart(this.state, this.data);
     });
 
-    this.schedulePointRefresh = drawProc(() => {
-      this.updateLegendAndDots();
-    });
+    this.legendController = new LegendController(
+      legend,
+      state,
+      data,
+      formatTime,
+    );
   }
 
   public zoom = (event: D3ZoomEvent<Element, unknown>) => {
@@ -100,76 +72,24 @@ export class ChartInteraction {
     this.state.transforms.ny.onZoomPan(event.transform);
     this.state.transforms.sf?.onZoomPan(event.transform);
     this.scheduleRefresh();
-    this.schedulePointRefresh();
+    this.legendController.refresh();
   };
 
   public onHover = (x: number) => {
     const idx = this.state.transforms.ny.fromScreenToModelX(x);
-    this.highlightedDataIdx = Math.min(
-      Math.max(idx, 0),
-      this.data.data.length - 1,
-    );
-    this.schedulePointRefresh();
+    this.legendController.onHover(idx);
   };
-
-  private updateLegendAndDots() {
-    const [greenData, blueData] =
-      this.data.data[Math.round(this.highlightedDataIdx)];
-    const timestamp = this.data.idxToTime.applyToPoint(this.highlightedDataIdx);
-    this.legendTime.text(this.formatTime(timestamp));
-
-    const dotScaleMatrixNy = this.state.transforms.ny.dotScaleMatrix(
-      this.dotRadius,
-    );
-    const dotScaleMatrixSf = this.state.transforms.sf?.dotScaleMatrix(
-      this.dotRadius,
-    );
-    const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
-      isNaN(n) ? valueForNaN : n;
-    const updateDot = (
-      val: number,
-      legendSel: Selection<BaseType, unknown, HTMLElement, unknown>,
-      node: SVGGraphicsElement | null,
-      dotScaleMatrix?: SVGMatrix,
-    ) => {
-      legendSel.text(fixNaN(val, " "));
-      if (node && dotScaleMatrix) {
-        updateNode(
-          node,
-          this.identityMatrix
-            .translate(this.highlightedDataIdx, fixNaN(val, 0))
-            .multiply(dotScaleMatrix),
-        );
-      }
-    };
-
-    updateDot(
-      greenData,
-      this.legendGreen,
-      this.highlightedGreenDot,
-      dotScaleMatrixNy,
-    );
-    if (this.state.transforms.sf) {
-      updateDot(
-        blueData as number,
-        this.legendBlue,
-        this.highlightedBlueDot,
-        dotScaleMatrixSf,
-      );
-    }
-  }
 
   public drawNewData = () => {
     renderPaths(this.state, this.data.data);
     this.scheduleRefresh();
-    this.schedulePointRefresh();
+    this.legendController.refresh();
   };
 
   public destroy = () => {
     this.zoomBehavior.on("zoom", null);
     this.zoomArea.on("mousemove", null);
     this.zoomArea.remove();
-    this.highlightedGreenDot.remove();
-    this.highlightedBlueDot?.remove();
+    this.legendController.destroy();
   };
 }

--- a/svg-time-series/src/chart/legend.single.test.ts
+++ b/svg-time-series/src/chart/legend.single.test.ts
@@ -1,0 +1,180 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { select } from "d3-selection";
+import { AR1Basis } from "../math/affine.ts";
+import { ChartData } from "./data.ts";
+import { setupRender } from "./render.ts";
+import { LegendController } from "./legend.ts";
+
+class Matrix {
+  constructor(
+    public tx = 0,
+    public ty = 0,
+  ) {}
+  translate(tx: number, ty: number) {
+    return new Matrix(this.tx + tx, this.ty + ty);
+  }
+  scaleNonUniform(_sx: number, _sy: number) {
+    return this;
+  }
+  multiply(_m: Matrix) {
+    return this;
+  }
+}
+
+const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
+let updateNodeCalls = 0;
+vi.mock("../utils/domNodeTransform.ts", () => ({
+  updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
+    updateNodeCalls++;
+    nodeTransforms.set(node, matrix);
+  },
+}));
+
+let currentDataLength = 0;
+const transformInstances: any[] = [];
+vi.mock("../ViewportTransform.ts", () => ({
+  ViewportTransform: class {
+    constructor() {
+      transformInstances.push(this);
+    }
+    onZoomPan = vi.fn();
+    fromScreenToModelX = vi.fn((x: number) => x);
+    fromScreenToModelBasisX = vi.fn(
+      () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
+    );
+    dotScaleMatrix = vi.fn(() => new Matrix());
+    onViewPortResize = vi.fn();
+    onReferenceViewWindowResize = vi.fn();
+  },
+}));
+
+const axisInstances: any[] = [];
+vi.mock("../axis.ts", () => ({
+  Orientation: { Bottom: 0, Right: 1 },
+  MyAxis: class {
+    axisUpCalls = 0;
+    constructor() {
+      axisInstances.push(this);
+    }
+    setScale = vi.fn(() => this);
+    axis = vi.fn();
+    axisUp = vi.fn(() => {
+      this.axisUpCalls++;
+    });
+    ticks = vi.fn(() => this);
+    setTickSize = vi.fn(() => this);
+    setTickPadding = vi.fn(() => this);
+  },
+}));
+
+function createLegend(data: Array<[number]>) {
+  currentDataLength = data.length;
+  const parent = document.createElement("div");
+  const w = Math.max(currentDataLength - 1, 0);
+  Object.defineProperty(parent, "clientWidth", {
+    value: w,
+    configurable: true,
+  });
+  Object.defineProperty(parent, "clientHeight", {
+    value: 50,
+    configurable: true,
+  });
+  const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  parent.appendChild(svgEl);
+
+  const legend = document.createElement("div");
+  legend.innerHTML =
+    '<span class="chart-legend__time"></span>' +
+    '<span class="chart-legend__green_value"></span>';
+
+  const chartData = new ChartData(0, 1, data, (i, arr) => ({
+    min: arr[i][0],
+    max: arr[i][0],
+  }));
+
+  const renderState = setupRender(select(svgEl) as any, chartData);
+  const controller = new LegendController(
+    select(legend) as any,
+    renderState,
+    chartData,
+  );
+
+  return { controller, svgEl, legend };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  nodeTransforms.clear();
+  updateNodeCalls = 0;
+  transformInstances.length = 0;
+  axisInstances.length = 0;
+  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+});
+
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+});
+
+describe("legend controller single-axis", () => {
+  it("onHover updates legend text and dot position", () => {
+    const data: Array<[number]> = [[10], [30]];
+    const { controller, svgEl, legend } = createLegend(data);
+    vi.runAllTimers();
+
+    controller.onHover(1);
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("30");
+    const circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    const transform = nodeTransforms.get(circle)!;
+    expect(transform.tx).toBe(1);
+    expect(transform.ty).toBe(30);
+  });
+
+  it("handles NaN data", () => {
+    const { controller, svgEl, legend } = createLegend([[NaN]]);
+    vi.runAllTimers();
+
+    controller.onHover(0);
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe(" ");
+    const circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    const transform = nodeTransforms.get(circle)!;
+    expect(transform.ty).toBe(0);
+  });
+
+  it("clamps hover index to data bounds", () => {
+    const data: Array<[number]> = [[10], [30]];
+    const { controller, svgEl, legend } = createLegend(data);
+    vi.runAllTimers();
+
+    controller.onHover(-100);
+    vi.runAllTimers();
+    let circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    let transform = nodeTransforms.get(circle)!;
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("10");
+    expect(transform.tx).toBe(0);
+    expect(transform.ty).toBe(10);
+
+    controller.onHover(100);
+    vi.runAllTimers();
+    circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    transform = nodeTransforms.get(circle)!;
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("30");
+    expect(transform.tx).toBe(1);
+    expect(transform.ty).toBe(30);
+  });
+});

--- a/svg-time-series/src/chart/legend.test.ts
+++ b/svg-time-series/src/chart/legend.test.ts
@@ -1,0 +1,238 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { select } from "d3-selection";
+import { AR1Basis } from "../math/affine.ts";
+import { ChartData } from "./data.ts";
+import { setupRender } from "./render.ts";
+import { LegendController } from "./legend.ts";
+
+class Matrix {
+  constructor(
+    public tx = 0,
+    public ty = 0,
+  ) {}
+  translate(tx: number, ty: number) {
+    return new Matrix(this.tx + tx, this.ty + ty);
+  }
+  scaleNonUniform(_sx: number, _sy: number) {
+    return this;
+  }
+  multiply(_m: Matrix) {
+    return this;
+  }
+}
+
+const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
+let updateNodeCalls = 0;
+vi.mock("../utils/domNodeTransform.ts", () => ({
+  updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
+    updateNodeCalls++;
+    nodeTransforms.set(node, matrix);
+  },
+}));
+
+let currentDataLength = 0;
+const transformInstances: any[] = [];
+vi.mock("../ViewportTransform.ts", () => ({
+  ViewportTransform: class {
+    constructor() {
+      transformInstances.push(this);
+    }
+    onZoomPan = vi.fn();
+    fromScreenToModelX = vi.fn((x: number) => x);
+    fromScreenToModelBasisX = vi.fn(
+      () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
+    );
+    dotScaleMatrix = vi.fn(() => new Matrix());
+    onViewPortResize = vi.fn();
+    onReferenceViewWindowResize = vi.fn();
+  },
+}));
+
+const axisInstances: any[] = [];
+vi.mock("../axis.ts", () => ({
+  Orientation: { Bottom: 0, Right: 1 },
+  MyAxis: class {
+    axisUpCalls = 0;
+    constructor() {
+      axisInstances.push(this);
+    }
+    setScale = vi.fn(() => this);
+    axis = vi.fn();
+    axisUp = vi.fn(() => {
+      this.axisUpCalls++;
+    });
+    ticks = vi.fn(() => this);
+    setTickSize = vi.fn(() => this);
+    setTickPadding = vi.fn(() => this);
+  },
+}));
+
+function createLegend(
+  data: Array<[number, number]>,
+  formatTime?: (timestamp: number) => string,
+) {
+  currentDataLength = data.length;
+  const parent = document.createElement("div");
+  const w = Math.max(currentDataLength - 1, 0);
+  Object.defineProperty(parent, "clientWidth", {
+    value: w,
+    configurable: true,
+  });
+  Object.defineProperty(parent, "clientHeight", {
+    value: 50,
+    configurable: true,
+  });
+  const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  parent.appendChild(svgEl);
+
+  const legend = document.createElement("div");
+  legend.innerHTML =
+    '<span class="chart-legend__time"></span>' +
+    '<span class="chart-legend__green_value"></span>' +
+    '<span class="chart-legend__blue_value"></span>';
+
+  const chartData = new ChartData(
+    0,
+    1,
+    data,
+    (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
+    (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
+  );
+
+  const renderState = setupRender(select(svgEl) as any, chartData);
+  const controller = new LegendController(
+    select(legend) as any,
+    renderState,
+    chartData,
+    formatTime,
+  );
+
+  return { controller, svgEl, legend };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  nodeTransforms.clear();
+  updateNodeCalls = 0;
+  transformInstances.length = 0;
+  axisInstances.length = 0;
+  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+});
+
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+});
+
+describe("legend controller", () => {
+  it("onHover updates legend text and dot position", () => {
+    const data: Array<[number, number]> = [
+      [10, 20],
+      [30, 40],
+    ];
+    const { controller, svgEl, legend } = createLegend(data);
+    vi.runAllTimers();
+
+    controller.onHover(1);
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("30");
+    expect(legend.querySelector(".chart-legend__blue_value")!.textContent).toBe(
+      "40",
+    );
+
+    const circles = svgEl.querySelectorAll("circle");
+    const greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
+    const blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
+    expect(greenTransform.tx).toBe(1);
+    expect(greenTransform.ty).toBe(30);
+    expect(blueTransform.tx).toBe(1);
+    expect(blueTransform.ty).toBe(40);
+  });
+
+  it("uses custom time formatter when provided", () => {
+    const data: Array<[number, number]> = [
+      [10, 20],
+      [30, 40],
+    ];
+    const formatter = vi.fn((ts: number) => `ts:${ts}`);
+    const { controller, legend } = createLegend(data, formatter);
+    vi.runAllTimers();
+
+    controller.onHover(1);
+    vi.runAllTimers();
+
+    expect(legend.querySelector(".chart-legend__time")!.textContent).toBe(
+      "ts:1",
+    );
+    expect(formatter).toHaveBeenCalledWith(1);
+  });
+
+  it("handles NaN data", () => {
+    const { controller, svgEl, legend } = createLegend([[NaN, NaN]]);
+    vi.runAllTimers();
+
+    controller.onHover(0);
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe(" ");
+    expect(legend.querySelector(".chart-legend__blue_value")!.textContent).toBe(
+      " ",
+    );
+
+    const circles = svgEl.querySelectorAll("circle");
+    const greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
+    const blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
+    expect(greenTransform.ty).toBe(0);
+    expect(blueTransform.ty).toBe(0);
+  });
+
+  it("clamps hover index to data bounds", () => {
+    const data: Array<[number, number]> = [
+      [10, 20],
+      [30, 40],
+      [50, 60],
+    ];
+    const { controller, svgEl, legend } = createLegend(data);
+    vi.runAllTimers();
+
+    controller.onHover(-100);
+    vi.runAllTimers();
+    let circles = svgEl.querySelectorAll("circle");
+    let greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
+    let blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("10");
+    expect(legend.querySelector(".chart-legend__blue_value")!.textContent).toBe(
+      "20",
+    );
+    expect(greenTransform.tx).toBe(0);
+    expect(greenTransform.ty).toBe(10);
+    expect(blueTransform.tx).toBe(0);
+    expect(blueTransform.ty).toBe(20);
+
+    controller.onHover(100);
+    vi.runAllTimers();
+    circles = svgEl.querySelectorAll("circle");
+    greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
+    blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("50");
+    expect(legend.querySelector(".chart-legend__blue_value")!.textContent).toBe(
+      "60",
+    );
+    expect(greenTransform.tx).toBe(2);
+    expect(greenTransform.ty).toBe(50);
+    expect(blueTransform.tx).toBe(2);
+    expect(blueTransform.ty).toBe(60);
+  });
+});

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,0 +1,114 @@
+import { BaseType, Selection, select } from "d3-selection";
+import { drawProc } from "../utils/drawProc.ts";
+import { updateNode } from "../utils/domNodeTransform.ts";
+import type { ChartData } from "./data.ts";
+import type { RenderState } from "./render.ts";
+
+export class LegendController {
+  private legendTime: Selection<BaseType, unknown, HTMLElement, unknown>;
+  private legendGreen: Selection<BaseType, unknown, HTMLElement, unknown>;
+  private legendBlue: Selection<BaseType, unknown, HTMLElement, unknown>;
+
+  private readonly dotRadius = 3;
+  private highlightedGreenDot: SVGCircleElement;
+  private highlightedBlueDot: SVGCircleElement | null;
+
+  private identityMatrix = document
+    .createElementNS("http://www.w3.org/2000/svg", "svg")
+    .createSVGMatrix();
+
+  private highlightedDataIdx = 0;
+  private scheduleRefresh: () => void;
+
+  constructor(
+    legend: Selection<BaseType, unknown, HTMLElement, unknown>,
+    private state: RenderState,
+    private data: ChartData,
+    private formatTime: (timestamp: number) => string = (timestamp) =>
+      new Date(timestamp).toLocaleString(),
+  ) {
+    this.legendTime = legend.select(".chart-legend__time");
+    this.legendGreen = legend.select(".chart-legend__green_value");
+    this.legendBlue = legend.select(".chart-legend__blue_value");
+
+    const makeDot = (view: SVGGElement) =>
+      select(view)
+        .append("circle")
+        .attr("cx", 0)
+        .attr("cy", 0)
+        .attr("r", 1)
+        .node() as SVGCircleElement;
+    this.highlightedGreenDot = makeDot(state.paths.viewNy);
+    this.highlightedBlueDot = state.paths.viewSf
+      ? makeDot(state.paths.viewSf)
+      : null;
+
+    this.scheduleRefresh = drawProc(() => {
+      this.update();
+    });
+  }
+
+  public onHover = (idx: number) => {
+    this.highlightedDataIdx = Math.min(
+      Math.max(idx, 0),
+      this.data.data.length - 1,
+    );
+    this.scheduleRefresh();
+  };
+
+  public refresh = () => {
+    this.scheduleRefresh();
+  };
+
+  private update() {
+    const [greenData, blueData] =
+      this.data.data[Math.round(this.highlightedDataIdx)];
+    const timestamp = this.data.idxToTime.applyToPoint(this.highlightedDataIdx);
+    this.legendTime.text(this.formatTime(timestamp));
+
+    const dotScaleMatrixNy = this.state.transforms.ny.dotScaleMatrix(
+      this.dotRadius,
+    );
+    const dotScaleMatrixSf = this.state.transforms.sf?.dotScaleMatrix(
+      this.dotRadius,
+    );
+    const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
+      isNaN(n) ? valueForNaN : n;
+    const updateDot = (
+      val: number,
+      legendSel: Selection<BaseType, unknown, HTMLElement, unknown>,
+      node: SVGGraphicsElement | null,
+      dotScaleMatrix?: SVGMatrix,
+    ) => {
+      legendSel.text(fixNaN(val, " "));
+      if (node && dotScaleMatrix) {
+        updateNode(
+          node,
+          this.identityMatrix
+            .translate(this.highlightedDataIdx, fixNaN(val, 0))
+            .multiply(dotScaleMatrix),
+        );
+      }
+    };
+
+    updateDot(
+      greenData,
+      this.legendGreen,
+      this.highlightedGreenDot,
+      dotScaleMatrixNy,
+    );
+    if (this.state.transforms.sf) {
+      updateDot(
+        blueData as number,
+        this.legendBlue,
+        this.highlightedBlueDot,
+        dotScaleMatrixSf,
+      );
+    }
+  }
+
+  public destroy = () => {
+    this.highlightedGreenDot.remove();
+    this.highlightedBlueDot?.remove();
+  };
+}


### PR DESCRIPTION
## Summary
- extract legend handling into LegendController for legend text and highlighted dot positioning
- delegate legend updates from ChartInteraction to LegendController
- add unit tests for LegendController, including single-axis scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689365af9980832b8e410cd88c4af194