### PR TITLE
feat: add segment tree manager helpers

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,5 +1,6 @@
 import { AR1, AR1Basis, betweenTBasesAR1, bUnit } from "../math/affine.ts";
 import { IMinMax, SegmentTree } from "../segmentTree.ts";
+import { rebuildSegmentTrees } from "./segmentTreeManager.ts";
 
 export type { IMinMax };
 
@@ -49,29 +50,26 @@ export class ChartData {
     );
     this.idxShift = betweenTBasesAR1(new AR1Basis(1, 2), bUnit);
     this.bIndexFull = new AR1Basis(0, data.length - 1);
-    this.rebuildSegmentTrees();
+    const { treeNy, treeSf } = rebuildSegmentTrees(
+      this.data,
+      this.buildSegmentTreeTupleNy,
+      this.buildSegmentTreeTupleSf,
+    );
+    this.treeNy = treeNy;
+    this.treeSf = treeSf;
   }
 
   append(newData: [number, number?]): void {
     this.data.push(newData);
     this.data.shift();
     this.idxToTime = this.idxToTime.composeWith(this.idxShift);
-    this.rebuildSegmentTrees();
-  }
-
-  private rebuildSegmentTrees(): void {
-    this.treeNy = new SegmentTree(
+    const { treeNy, treeSf } = rebuildSegmentTrees(
       this.data,
-      this.data.length,
       this.buildSegmentTreeTupleNy,
+      this.buildSegmentTreeTupleSf,
     );
-    this.treeSf = this.buildSegmentTreeTupleSf
-      ? new SegmentTree(
-          this.data,
-          this.data.length,
-          this.buildSegmentTreeTupleSf,
-        )
-      : undefined;
+    this.treeNy = treeNy;
+    this.treeSf = treeSf;
   }
 
   bTemperatureVisible(

--- a/svg-time-series/src/chart/segmentTreeManager.test.ts
+++ b/svg-time-series/src/chart/segmentTreeManager.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildNySegmentTree,
+  buildSfSegmentTree,
+  rebuildSegmentTrees,
+} from "./segmentTreeManager.ts";
+
+const buildNy = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
+  min: arr[i][0],
+  max: arr[i][0],
+});
+
+const buildSf = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
+  min: arr[i][1]!,
+  max: arr[i][1]!,
+});
+
+describe("segmentTreeManager", () => {
+  const data: Array<[number, number?]> = [
+    [10, 20],
+    [30, 40],
+    [50, 60],
+  ];
+
+  it("builds Ny segment tree", () => {
+    const tree = buildNySegmentTree(data, buildNy);
+    expect(tree.query(0, 2)).toEqual({ min: 10, max: 50 });
+  });
+
+  it("builds Sf segment tree", () => {
+    const tree = buildSfSegmentTree(data, buildSf)!;
+    expect(tree.query(0, 2)).toEqual({ min: 20, max: 60 });
+  });
+
+  it("rebuilds both segment trees", () => {
+    const { treeNy, treeSf } = rebuildSegmentTrees(data, buildNy, buildSf);
+    expect(treeNy.query(0, 2)).toEqual({ min: 10, max: 50 });
+    expect(treeSf!.query(0, 2)).toEqual({ min: 20, max: 60 });
+  });
+
+  it("handles missing Sf builder", () => {
+    const { treeNy, treeSf } = rebuildSegmentTrees(data, buildNy);
+    expect(treeNy.query(0, 2)).toEqual({ min: 10, max: 50 });
+    expect(treeSf).toBeUndefined();
+  });
+});

--- a/svg-time-series/src/chart/segmentTreeManager.ts
+++ b/svg-time-series/src/chart/segmentTreeManager.ts
@@ -1,0 +1,43 @@
+import { IMinMax, SegmentTree } from "../segmentTree.ts";
+
+export function buildNySegmentTree(
+  data: ReadonlyArray<[number, number?]>,
+  buildTuple: (
+    index: number,
+    elements: ReadonlyArray<[number, number?]>,
+  ) => IMinMax,
+): SegmentTree<[number, number?]> {
+  return new SegmentTree(data, data.length, buildTuple);
+}
+
+export function buildSfSegmentTree(
+  data: ReadonlyArray<[number, number?]>,
+  buildTuple?: (
+    index: number,
+    elements: ReadonlyArray<[number, number?]>,
+  ) => IMinMax,
+): SegmentTree<[number, number?]> | undefined {
+  return buildTuple
+    ? new SegmentTree(data, data.length, buildTuple)
+    : undefined;
+}
+
+export function rebuildSegmentTrees(
+  data: ReadonlyArray<[number, number?]>,
+  buildSegmentTreeTupleNy: (
+    index: number,
+    elements: ReadonlyArray<[number, number?]>,
+  ) => IMinMax,
+  buildSegmentTreeTupleSf?: (
+    index: number,
+    elements: ReadonlyArray<[number, number?]>,
+  ) => IMinMax,
+): {
+  treeNy: SegmentTree<[number, number?]>;
+  treeSf?: SegmentTree<[number, number?]>;
+} {
+  return {
+    treeNy: buildNySegmentTree(data, buildSegmentTreeTupleNy),
+    treeSf: buildSfSegmentTree(data, buildSegmentTreeTupleSf),
+  };
+}


### PR DESCRIPTION
## Summary
- extract segment tree builder and rebuild helpers into `segmentTreeManager`
- refactor `ChartData` to use segmentTree helpers
- add tests for new segmentTreeManager helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936b4d05a4832b9cbfbd24b16192a4