### PR TITLE
feat: add legend helpers and tests

### DIFF
--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,6 +1,6 @@
 import { BaseType, Selection, select } from "d3-selection";
 import { drawProc } from "../utils/drawProc.ts";
-import { updateNode } from "../utils/domNodeTransform.ts";
+import { fixNaN, updateDot } from "./legendHelpers.ts";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
 
@@ -72,37 +72,28 @@ export class LegendController {
     const dotScaleMatrixSf = this.state.transforms.sf?.dotScaleMatrix(
       this.dotRadius,
     );
-    const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
-      isNaN(n) ? valueForNaN : n;
-    const updateDot = (
-      val: number,
-      legendSel: Selection<BaseType, unknown, HTMLElement, unknown>,
-      node: SVGGraphicsElement | null,
-      dotScaleMatrix?: SVGMatrix,
-    ) => {
-      legendSel.text(fixNaN(val, " "));
-      if (node && dotScaleMatrix) {
-        updateNode(
-          node,
-          this.identityMatrix
-            .translate(this.highlightedDataIdx, fixNaN(val, 0))
-            .multiply(dotScaleMatrix),
-        );
-      }
-    };
 
+    const greenText = fixNaN(greenData, " ");
+    const greenVal = fixNaN(greenData, 0);
+    this.legendGreen.text(String(greenText));
     updateDot(
-      greenData,
-      this.legendGreen,
+      greenVal as number,
+      this.highlightedDataIdx,
       this.highlightedGreenDot,
       dotScaleMatrixNy,
+      this.identityMatrix,
     );
+
     if (this.state.transforms.sf) {
+      const blueText = fixNaN(blueData as number, " ");
+      const blueVal = fixNaN(blueData as number, 0);
+      this.legendBlue.text(String(blueText));
       updateDot(
-        blueData as number,
-        this.legendBlue,
+        blueVal,
+        this.highlightedDataIdx,
         this.highlightedBlueDot,
         dotScaleMatrixSf,
+        this.identityMatrix,
       );
     }
   }

--- a/svg-time-series/src/chart/legendHelpers.test.ts
+++ b/svg-time-series/src/chart/legendHelpers.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { fixNaN, updateDot } from "./legendHelpers.ts";
+
+class Matrix {
+  constructor(
+    public tx = 0,
+    public ty = 0,
+  ) {}
+  translate(tx: number, ty: number) {
+    return new Matrix(this.tx + tx, this.ty + ty);
+  }
+  multiply(m: Matrix) {
+    return new Matrix(this.tx + m.tx, this.ty + m.ty);
+  }
+}
+
+const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
+vi.mock("../utils/domNodeTransform.ts", () => ({
+  updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
+    nodeTransforms.set(node, matrix);
+  },
+}));
+
+beforeEach(() => {
+  nodeTransforms.clear();
+});
+
+describe("legend helpers", () => {
+  it("fixNaN replaces NaN values", () => {
+    expect(fixNaN(NaN, 5)).toBe(5);
+    expect(fixNaN(3, 5)).toBe(3);
+  });
+
+  it("updateDot applies node transform", () => {
+    const node = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "circle",
+    );
+    updateDot(42, 7, node, new Matrix() as any, new Matrix() as any);
+    const transform = nodeTransforms.get(node)!;
+    expect(transform.tx).toBe(7);
+    expect(transform.ty).toBe(42);
+  });
+
+  it("updateDot works with sanitized NaN values", () => {
+    const node = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "circle",
+    );
+    const val = fixNaN(NaN, 0);
+    updateDot(val, 3, node, new Matrix() as any, new Matrix() as any);
+    const transform = nodeTransforms.get(node)!;
+    expect(transform.tx).toBe(3);
+    expect(transform.ty).toBe(0);
+  });
+});

--- a/svg-time-series/src/chart/legendHelpers.ts
+++ b/svg-time-series/src/chart/legendHelpers.ts
@@ -1,0 +1,19 @@
+import { updateNode } from "../utils/domNodeTransform.ts";
+
+export const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
+  isNaN(n) ? valueForNaN : n;
+
+export const updateDot = (
+  val: number,
+  idx: number,
+  node: SVGGraphicsElement | null,
+  dotScaleMatrix: SVGMatrix | undefined,
+  identityMatrix: SVGMatrix,
+) => {
+  if (node && dotScaleMatrix) {
+    updateNode(
+      node,
+      identityMatrix.translate(idx, val).multiply(dotScaleMatrix),
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- extract `fixNaN` and `updateDot` into reusable `legendHelpers`
- refactor `LegendController` to use helpers
- add tests for helper utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936b62cb98832bbc9520bdf7e72c3f