### PR TITLE
feat: extract zoom logic into state class

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { select } from "d3-selection";
+
+vi.mock("d3-zoom", () => {
+  const behavior: any = () => {};
+  behavior.scaleExtent = () => behavior;
+  behavior.translateExtent = () => behavior;
+  behavior.on = () => behavior;
+  behavior.transform = vi.fn();
+  return { zoom: () => behavior };
+});
+
+import { ZoomState } from "./zoomState.ts";
+
+describe("ZoomState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("updates transforms and triggers refresh on zoom", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const ny = { onZoomPan: vi.fn() };
+    const sf = { onZoomPan: vi.fn() };
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny, sf },
+    };
+    const refresh = vi.fn();
+    const zoomCb = vi.fn();
+    const zs = new ZoomState(rect as any, state, refresh, zoomCb);
+
+    const event = { transform: { x: 5, k: 2 } } as any;
+    zs.zoom(event);
+    vi.runAllTimers();
+
+    expect(ny.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(sf.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(zoomCb).toHaveBeenCalledWith(event);
+  });
+
+  it("refresh re-applies transform and triggers refresh callback", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const ny = { onZoomPan: vi.fn() };
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny },
+    };
+    const refresh = vi.fn();
+    const zs = new ZoomState(rect as any, state, refresh);
+
+    zs.zoom({ transform: { x: 1, k: 1 } } as any);
+    vi.runAllTimers();
+
+    const transformSpy = zs.zoomBehavior.transform as any;
+    transformSpy.mockClear();
+    refresh.mockClear();
+
+    zs.refresh();
+    vi.runAllTimers();
+
+    expect(transformSpy).toHaveBeenCalled();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,0 +1,64 @@
+import { BaseType, Selection } from "d3-selection";
+import {
+  zoom as d3zoom,
+  D3ZoomEvent,
+  ZoomBehavior,
+  ZoomTransform,
+} from "d3-zoom";
+import { drawProc } from "../utils/drawProc.ts";
+import type { RenderState } from "./render.ts";
+
+export class ZoomState {
+  public zoomBehavior: ZoomBehavior<SVGRectElement, unknown>;
+  private currentPanZoomTransformState: ZoomTransform | null = null;
+  private scheduleRefresh: () => void;
+
+  constructor(
+    private zoomArea: Selection<SVGRectElement, unknown, BaseType, unknown>,
+    private state: RenderState,
+    private refreshChart: () => void,
+    private zoomCallback: (
+      event: D3ZoomEvent<Element, unknown>,
+    ) => void = () => {},
+  ) {
+    this.zoomBehavior = d3zoom<SVGRectElement, unknown>()
+      .scaleExtent([1, 40])
+      .translateExtent([
+        [0, 0],
+        [state.dimensions.width, state.dimensions.height],
+      ])
+      .on("zoom", (event: D3ZoomEvent<Element, unknown>) => {
+        this.zoom(event);
+      });
+
+    this.zoomArea.call(this.zoomBehavior);
+
+    this.scheduleRefresh = drawProc(() => {
+      if (this.currentPanZoomTransformState != null) {
+        this.zoomBehavior.transform(
+          this.zoomArea,
+          this.currentPanZoomTransformState,
+        );
+      }
+      this.refreshChart();
+    });
+  }
+
+  public zoom = (event: D3ZoomEvent<Element, unknown>) => {
+    this.currentPanZoomTransformState = event.transform;
+    this.state.transforms.ny.onZoomPan(event.transform);
+    this.state.transforms.sf?.onZoomPan(event.transform);
+    this.scheduleRefresh();
+    this.zoomCallback(event);
+  };
+
+  public refresh = () => {
+    this.scheduleRefresh();
+  };
+
+  public destroy = () => {
+    this.zoomBehavior.on("zoom", null);
+  };
+}
+
+export type { D3ZoomEvent };


### PR DESCRIPTION
## Summary
- introduce `ZoomState` to encapsulate zoom behavior, transforms, and refresh scheduling
- delegate `ChartInteraction` zoom operations to `ZoomState` while keeping legend/hover logic intact
- add unit tests covering transform propagation and refresh triggering in `ZoomState`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68936b5dea18832bbd4ebbecfff911fd