### PR TITLE
refactor: consolidate DOM transform utilities

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -1,6 +1,6 @@
 import { ZoomTransform } from "d3-zoom";
 import { AR1Basis, betweenTBasesAR1, bPlaceholder } from "./math/affine.ts";
-import { applyAR1ToMatrixX, applyAR1ToMatrixY } from "./utils/domMatrix.ts";
+import { applyAR1ToMatrixX, applyAR1ToMatrixY } from "./utils/transform.ts";
 
 export class ViewportTransform {
   private viewPortPointsX: AR1Basis = bPlaceholder;

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -26,7 +26,7 @@ class Matrix {
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;
-vi.mock("../utils/domNodeTransform.ts", () => ({
+vi.mock("../utils/transform.ts", () => ({
   updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
     updateNodeCalls++;
     nodeTransforms.set(node, matrix);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -27,7 +27,7 @@ class Matrix {
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;
-vi.mock("../utils/domNodeTransform.ts", () => ({
+vi.mock("../utils/transform.ts", () => ({
   updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
     updateNodeCalls++;
     nodeTransforms.set(node, matrix);

--- a/svg-time-series/src/chart/legend.single.test.ts
+++ b/svg-time-series/src/chart/legend.single.test.ts
@@ -26,7 +26,7 @@ class Matrix {
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;
-vi.mock("../utils/domNodeTransform.ts", () => ({
+vi.mock("../utils/transform.ts", () => ({
   updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
     updateNodeCalls++;
     nodeTransforms.set(node, matrix);

--- a/svg-time-series/src/chart/legend.test.ts
+++ b/svg-time-series/src/chart/legend.test.ts
@@ -26,7 +26,7 @@ class Matrix {
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;
-vi.mock("../utils/domNodeTransform.ts", () => ({
+vi.mock("../utils/transform.ts", () => ({
   updateNode: (node: SVGGraphicsElement, matrix: Matrix) => {
     updateNodeCalls++;
     nodeTransforms.set(node, matrix);

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,6 +1,6 @@
 import { BaseType, Selection, select } from "d3-selection";
 import { drawProc } from "../utils/drawProc.ts";
-import { updateNode } from "../utils/domNodeTransform.ts";
+import { updateNode } from "../utils/transform.ts";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
 

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -2,7 +2,7 @@ import { BaseType, Selection } from "d3-selection";
 
 import { MyAxis, Orientation } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
-import { updateNode } from "../utils/domNodeTransform.ts";
+import { updateNode } from "../utils/transform.ts";
 import { AR1Basis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData } from "./data.ts";
 import { createDimensions } from "./render/dimensions.ts";

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -1,5 +1,0 @@
-export function updateNode(n: SVGGraphicsElement, m: DOMMatrix | SVGMatrix) {
-  const svgTransformList = n.transform.baseVal;
-  const t = svgTransformList.createSVGTransformFromMatrix(m);
-  svgTransformList.initialize(t);
-}

--- a/svg-time-series/src/utils/transform.ts
+++ b/svg-time-series/src/utils/transform.ts
@@ -16,3 +16,9 @@ export function applyDirectProductToMatrix(
 ): DOMMatrix {
   return applyAR1ToMatrixY(dp.s2, applyAR1ToMatrixX(dp.s1, sm));
 }
+
+export function updateNode(n: SVGGraphicsElement, m: DOMMatrix | SVGMatrix) {
+  const svgTransformList = n.transform.baseVal;
+  const t = svgTransformList.createSVGTransformFromMatrix(m);
+  svgTransformList.initialize(t);
+}

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -10,8 +10,8 @@ import {
   applyAR1ToMatrixX,
   applyAR1ToMatrixY,
   applyDirectProductToMatrix,
-} from "./utils/domMatrix.ts";
-import { updateNode } from "./utils/domNodeTransform.ts";
+  updateNode,
+} from "./utils/transform.ts";
 
 class Matrix {
   constructor(

--- a/svg-time-series/src/viewZoomTransform.ts
+++ b/svg-time-series/src/viewZoomTransform.ts
@@ -2,5 +2,5 @@ export {
   applyAR1ToMatrixX,
   applyAR1ToMatrixY,
   applyDirectProductToMatrix,
-} from "./utils/domMatrix.ts";
-export { updateNode } from "./utils/domNodeTransform.ts";
+  updateNode,
+} from "./utils/transform.ts";


### PR DESCRIPTION
## Summary
- move DOM matrix and node transformation helpers into new `utils/transform.ts`
- update chart and view modules to import from `utils/transform`
- remove obsolete `domMatrix` and `domNodeTransform` modules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689372d580c8832baeecd5fa58f13d6d