### PR TITLE
refactor: remove redundant viewZoomTransform

### DIFF
--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -6,8 +6,8 @@ import { betweenBasesAR1 } from "../../../svg-time-series/src/math/affine.ts";
 import {
   applyAR1ToMatrixX,
   applyAR1ToMatrixY,
-  updateNode,
-} from "../../../svg-time-series/src/viewZoomTransform.ts";
+} from "../../../svg-time-series/src/utils/domMatrix.ts";
+import { updateNode } from "../../../svg-time-series/src/utils/domNodeTransform.ts";
 
 const svg = select("svg"),
   width = +svg.attr("width"),

--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -6,7 +6,7 @@ import { zoomIdentity, zoom as d3zoom, ZoomTransform } from "d3-zoom";
 
 import { MyAxis, Orientation } from "../../../svg-time-series/src/axis.ts";
 import { ViewportTransform } from "../../../svg-time-series/src/ViewportTransform.ts";
-import { updateNode } from "../../../svg-time-series/src/viewZoomTransform.ts";
+import { updateNode } from "../../../svg-time-series/src/utils/domNodeTransform.ts";
 import {
   IMinMax,
   SegmentTree,

--- a/svg-time-series/src/viewZoomTransform.ts
+++ b/svg-time-series/src/viewZoomTransform.ts
@@ -1,6 +1,0 @@
-export {
-  applyAR1ToMatrixX,
-  applyAR1ToMatrixY,
-  applyDirectProductToMatrix,
-} from "./utils/domMatrix.ts";
-export { updateNode } from "./utils/domNodeTransform.ts";


### PR DESCRIPTION
## Summary
- drop viewZoomTransform.ts re-export helper
- update sample imports to pull from utility modules directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68937713c2d0832bb87c31f4aa3f27f5