### PR TITLE
feat: add optional dual Y axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ work is possible. Keep watching!
 
 ## Y-axis modes
 
-Charts can display one or two data series. `TimeSeriesChart` accepts `data: Array<[number]>` for a single Y-axis or `data: Array<[number, number]>` for dual axes. Two helpers, `buildSegmentTreeTupleNy` and optionally `buildSegmentTreeTupleSf`, read the first and second values respectively and feed independent segment trees, providing scales for each series.
+Charts can display one or two data series. By default, all series share a single
+Y-axis whose scale is computed from the combined minimum and maximum of every
+series. To draw series with different units, pass `true` for the `dualYAxis`
+parameter of `TimeSeriesChart`, which enables independent left and right Y
+scales.
 
 ```ts
 import { TimeSeriesChart, IMinMax } from "svg-time-series";
@@ -59,6 +63,7 @@ const chart = new TimeSeriesChart(
   data,
   buildSegmentTreeTupleNy,
   buildSegmentTreeTupleSf,
+  true, // enable dual Y axes
   onZoom,
   onMouseMove,
   (ts) => new Date(ts).toISOString(),
@@ -69,7 +74,7 @@ The last argument, `formatTime`, is optional and lets you customize how
 timestamps are displayed in the legend. If omitted, timestamps are formatted
 with `toLocaleString`.
 
-For a single Y-axis, supply data with one value per point and omit the second builder:
+For two series sharing a single Y-axis, pass `false` for `dualYAxis`:
 
 ```ts
 const chartSingle = new TimeSeriesChart(
@@ -77,16 +82,18 @@ const chartSingle = new TimeSeriesChart(
   legend,
   startTime,
   timeStep,
-  singleData,
+  data,
   buildSegmentTreeTupleNy,
-  undefined,
+  buildSegmentTreeTupleSf,
+  false, // series share one axis
   onZoom,
   onMouseMove,
   (ts) => new Date(ts).toISOString(),
 );
 ```
 
-The chart will only build the second axis, path, and legend entries when a second series is provided.
+If you only have one series, supply data with a single value per point and omit
+the second builder; the chart will render a single path and axis.
 
 ## Secrets of Speed
 

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -48,6 +48,7 @@ export function drawCharts(data: [number, number][]) {
       data.map((_) => _),
       buildSegmentTreeTupleNy,
       buildSegmentTreeTupleSf,
+      false,
       onZoom,
       onMouseMove,
     );

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -39,6 +39,7 @@ const chart = new TimeSeriesChart(
   data,
   (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
   (i, arr) => ({ min: arr[i][1], max: arr[i][1] }),
+  true, // enable dual Y axes
   () => {},
   () => {},
   (ts) => new Date(ts).toISOString(),

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -106,7 +106,7 @@ function createChart(data: Array<[number]>) {
     max: arr[i][0],
   }));
 
-  const renderState = setupRender(select(svgEl) as any, chartData);
+  const renderState = setupRender(select(svgEl) as any, chartData, false);
   const interaction = new ChartInteraction(
     select(svgEl) as any,
     select(legend) as any,

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -114,7 +114,7 @@ function createChart(
     (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
   );
 
-  const renderState = setupRender(select(svgEl) as any, chartData);
+  const renderState = setupRender(select(svgEl) as any, chartData, true);
   const interaction = new ChartInteraction(
     select(svgEl) as any,
     select(legend) as any,
@@ -322,6 +322,7 @@ describe("chart interaction", () => {
       ],
       (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
       (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
+      true,
       () => {},
       mouseMoveHandler,
     );

--- a/svg-time-series/src/chart/legend.single.test.ts
+++ b/svg-time-series/src/chart/legend.single.test.ts
@@ -95,7 +95,7 @@ function createLegend(data: Array<[number]>) {
     max: arr[i][0],
   }));
 
-  const renderState = setupRender(select(svgEl) as any, chartData);
+  const renderState = setupRender(select(svgEl) as any, chartData, false);
   const controller = new LegendController(
     select(legend) as any,
     renderState,

--- a/svg-time-series/src/chart/legend.test.ts
+++ b/svg-time-series/src/chart/legend.test.ts
@@ -102,7 +102,7 @@ function createLegend(
     (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
   );
 
-  const renderState = setupRender(select(svgEl) as any, chartData);
+  const renderState = setupRender(select(svgEl) as any, chartData, true);
   const controller = new LegendController(
     select(legend) as any,
     renderState,

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { JSDOM } from "jsdom";
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import { setupRender } from "./render.ts";
+
+class Matrix {
+  constructor(
+    public a = 1,
+    public b = 0,
+    public c = 0,
+    public d = 1,
+    public e = 0,
+    public f = 0,
+  ) {}
+
+  multiply(m: Matrix) {
+    return new Matrix(
+      this.a * m.a + this.c * m.b,
+      this.b * m.a + this.d * m.b,
+      this.a * m.c + this.c * m.d,
+      this.b * m.c + this.d * m.d,
+      this.a * m.e + this.c * m.f + this.e,
+      this.b * m.e + this.d * m.f + this.f,
+    );
+  }
+
+  translate(tx: number, ty: number) {
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
+  }
+
+  scale(sx: number, sy: number) {
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
+  }
+
+  inverse() {
+    const det = this.a * this.d - this.b * this.c;
+    return new Matrix(
+      this.d / det,
+      -this.b / det,
+      -this.c / det,
+      this.a / det,
+      (this.c * this.f - this.d * this.e) / det,
+      (this.b * this.e - this.a * this.f) / det,
+    );
+  }
+}
+
+class Point {
+  constructor(
+    public x = 0,
+    public y = 0,
+  ) {}
+
+  matrixTransform(m: Matrix) {
+    return new Point(
+      this.x * m.a + this.y * m.c + m.e,
+      this.x * m.b + this.y * m.d + m.f,
+    );
+  }
+}
+
+beforeAll(() => {
+  (globalThis as any).DOMMatrix = Matrix;
+  (globalThis as any).DOMPoint = Point;
+});
+
+const buildNy = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
+  min: arr[i][0],
+  max: arr[i][0],
+});
+const buildSf = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
+  min: arr[i][1]!,
+  max: arr[i][1]!,
+});
+
+function createSvg() {
+  const dom = new JSDOM(`<div id="c"><svg><g class="view"></g></svg></div>`, {
+    pretendToBeVisual: true,
+    contentType: "text/html",
+  });
+  const div = dom.window.document.getElementById("c") as any;
+  Object.defineProperty(div, "clientWidth", { value: 100 });
+  Object.defineProperty(div, "clientHeight", { value: 100 });
+  return select(div).select("svg");
+}
+
+describe("setupRender Y-axis modes", () => {
+  it("combines series when dualYAxis is false", () => {
+    const svg = createSvg();
+    const data = new ChartData(
+      0,
+      1,
+      [
+        [1, 10],
+        [2, 20],
+        [3, 30],
+      ],
+      buildNy,
+      buildSf,
+    );
+    const state = setupRender(svg as any, data, false);
+    expect(state.scales.yNy.domain()).toEqual([1, 30]);
+    expect(state.scales.ySf).toBeUndefined();
+  });
+
+  it("separates scales when dualYAxis is true", () => {
+    const svg = createSvg();
+    const data = new ChartData(
+      0,
+      1,
+      [
+        [1, 10],
+        [2, 20],
+        [3, 30],
+      ],
+      buildNy,
+      buildSf,
+    );
+    const state = setupRender(svg as any, data, true);
+    expect(state.scales.yNy.domain()).toEqual([1, 3]);
+    expect(state.scales.ySf!.domain()).toEqual([10, 30]);
+  });
+});

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -34,7 +34,7 @@ export interface ScaleSet {
 export function createScales(
   bScreenXVisible: AR1Basis,
   bScreenYVisible: AR1Basis,
-  hasSf: boolean,
+  dualAxis: boolean,
 ): ScaleSet {
   const x: ScaleTime<number, number> = scaleTime().range(
     bScreenXVisible.toArr(),
@@ -43,7 +43,7 @@ export function createScales(
     bScreenYVisible.toArr(),
   );
   let ySf: ScaleLinear<number, number> | undefined;
-  if (hasSf) {
+  if (dualAxis) {
     ySf = scaleLinear().range(bScreenYVisible.toArr());
   }
   return { x, yNy, ySf };

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -66,6 +66,7 @@ function createChart(initialData: Array<[number, number?]>) {
     initialData,
     buildTuple,
     buildTuple,
+    false,
     vi.fn(),
     vi.fn(),
   );

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -28,6 +28,7 @@ export class TimeSeriesChart {
       index: number,
       elements: ReadonlyArray<[number, number?]>,
     ) => IMinMax,
+    dualYAxis = false,
     zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
     formatTime: (timestamp: number) => string = (timestamp) =>
@@ -41,7 +42,7 @@ export class TimeSeriesChart {
       buildSegmentTreeTupleSf,
     );
 
-    const renderState = setupRender(svg, this.data);
+    const renderState = setupRender(svg, this.data, dualYAxis);
     const interaction = new ChartInteraction(
       svg,
       legend,


### PR DESCRIPTION
## Summary
- allow charts to separate data series into left and right y-axes or share a single axis
- document `dualYAxis` option and update demos
- cover single vs dual axis scaling in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893804009b4832bb8630a0571105dd0