### PR TITLE
feat: configure axis modes for demos

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -23,7 +23,7 @@ function buildSegmentTreeTupleSf(
   return { min: sfMinValue, max: sfMaxValue };
 }
 
-export function drawCharts(data: [number, number][]) {
+export function drawCharts(data: [number, number][], dualYAxis = false) {
   const charts: TimeSeriesChart[] = [];
 
   const onZoom = (event: D3ZoomEvent<Element, unknown>) =>
@@ -48,7 +48,7 @@ export function drawCharts(data: [number, number][]) {
       data.map((_) => _),
       buildSegmentTreeTupleNy,
       buildSegmentTreeTupleSf,
-      false,
+      dualYAxis,
       onZoom,
       onMouseMove,
     );
@@ -92,9 +92,9 @@ interface Resize {
 
 const resize: Resize = { interval: 60, request: null, timer: null, eval: null };
 
-export function loadAndDraw() {
+export function loadAndDraw(dualYAxis = false) {
   onCsv((data: [number, number][]) => {
-    drawCharts(data);
+    drawCharts(data, dualYAxis);
 
     resize.request = function () {
       resize.timer && clearTimeout(resize.timer);
@@ -106,7 +106,7 @@ export function loadAndDraw() {
         .append("svg")
         .append("g")
         .attr("class", "view");
-      drawCharts(data);
+      drawCharts(data, dualYAxis);
     };
   });
 }

--- a/samples/demos/demo1.html
+++ b/samples/demos/demo1.html
@@ -19,5 +19,5 @@
     </div>
   </div>
 </div>
-<script type="module" src="index.ts"></script>
+<script type="module" src="demo1.ts"></script>
 <link href="index.css" type="text/css" rel="stylesheet" />

--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,0 +1,3 @@
+import { loadAndDraw } from "./common.ts";
+
+loadAndDraw(true);

--- a/samples/demos/demo2.html
+++ b/samples/demos/demo2.html
@@ -67,5 +67,5 @@
     </div>
   </div>
 </div>
-<script type="module" src="index.ts"></script>
+<script type="module" src="demo2.ts"></script>
 <link href="index.css" type="text/css" rel="stylesheet" />

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,3 +1,3 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw();
+loadAndDraw(false);


### PR DESCRIPTION
## Summary
- allow specifying dual or single y-axis for demo charts
- add dedicated entry points so demo1 uses a dual axis and demo2 uses a single axis
- drop unused demos index file

## Testing
- `npm run format`
- `git commit` (runs lint, typecheck, tests)


------
https://chatgpt.com/codex/tasks/task_e_689388b8a804832b9d8f0d65d4b9cc77