### PR TITLE
fix: prevent zoom recursion

### DIFF
--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -48,7 +48,8 @@ export class ChartInteraction {
   }
 
   public zoom = (event: D3ZoomEvent<Element, unknown>) => {
-    this.zoomState.zoom(event);
+    this.zoomState.zoom(event, false);
+    this.legendController.refresh();
   };
 
   public onHover = (x: number) => {

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -48,6 +48,25 @@ describe("ZoomState", () => {
     expect(zoomCb).toHaveBeenCalledWith(event);
   });
 
+  it("skips callback when flag is false", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const ny = { onZoomPan: vi.fn() };
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny },
+    };
+    const refresh = vi.fn();
+    const zoomCb = vi.fn();
+    const zs = new ZoomState(rect as any, state, refresh, zoomCb);
+
+    const event = { transform: { x: 1, k: 1 } } as any;
+    zs.zoom(event, false);
+    vi.runAllTimers();
+
+    expect(zoomCb).not.toHaveBeenCalled();
+  });
+
   it("refresh re-applies transform and triggers refresh callback", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -44,12 +44,14 @@ export class ZoomState {
     });
   }
 
-  public zoom = (event: D3ZoomEvent<Element, unknown>) => {
+  public zoom = (event: D3ZoomEvent<Element, unknown>, callCallback = true) => {
     this.currentPanZoomTransformState = event.transform;
     this.state.transforms.ny.onZoomPan(event.transform);
     this.state.transforms.sf?.onZoomPan(event.transform);
     this.scheduleRefresh();
-    this.zoomCallback(event);
+    if (callCallback) {
+      this.zoomCallback(event);
+    }
   };
 
   public refresh = () => {


### PR DESCRIPTION
## Summary
- avoid recursive callbacks when syncing zoom across charts
- refresh legend after externally-applied zoom
- test skipping zoom callback during programmatic sync

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689390e7fb9c832b9ca8686bed55d213