### PR TITLE
test: verify circle updates after hover

### DIFF
--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -124,6 +124,8 @@ function createChart(data: Array<[number]>) {
     onHover: interaction.onHover,
     svgEl,
     legend,
+    chartData,
+    interaction,
   };
 }
 
@@ -179,6 +181,29 @@ describe("chart interaction single-axis", () => {
     const transform = nodeTransforms.get(circle)!;
     expect(transform.tx).toBe(1);
     expect(transform.ty).toBe(30);
+  });
+
+  it("updates circle after appending data", () => {
+    const data: Array<[number]> = [[10], [30]];
+    const { onHover, svgEl, legend, chartData, interaction } =
+      createChart(data);
+    vi.runAllTimers();
+
+    chartData.append([50]);
+    interaction.drawNewData();
+    vi.runAllTimers();
+
+    onHover(1);
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("50");
+
+    const circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    const transform = nodeTransforms.get(circle)!;
+    expect(transform.tx).toBe(1);
+    expect(transform.ty).toBe(50);
   });
 
   it("handles NaN data", () => {

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -133,6 +133,8 @@ function createChart(
     onHover: interaction.onHover,
     svgEl,
     legend,
+    chartData,
+    interaction,
   };
 }
 
@@ -201,6 +203,38 @@ describe("chart interaction", () => {
     expect(greenTransform.ty).toBe(30);
     expect(blueTransform.tx).toBe(1);
     expect(blueTransform.ty).toBe(40);
+  });
+
+  it("updates circles after appending data", () => {
+    const data: Array<[number, number]> = [
+      [10, 20],
+      [30, 40],
+    ];
+    const { onHover, svgEl, legend, chartData, interaction } =
+      createChart(data);
+    vi.runAllTimers();
+
+    chartData.append([50, 60]);
+    interaction.drawNewData();
+    vi.runAllTimers();
+
+    onHover(1);
+    vi.runAllTimers();
+
+    expect(
+      legend.querySelector(".chart-legend__green_value")!.textContent,
+    ).toBe("50");
+    expect(legend.querySelector(".chart-legend__blue_value")!.textContent).toBe(
+      "60",
+    );
+
+    const circles = svgEl.querySelectorAll("circle");
+    const greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
+    const blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
+    expect(greenTransform.tx).toBe(1);
+    expect(greenTransform.ty).toBe(50);
+    expect(blueTransform.tx).toBe(1);
+    expect(blueTransform.ty).toBe(60);
   });
 
   it("uses custom time formatter when provided", () => {


### PR DESCRIPTION
## Summary
- add tests ensuring hover reflects appended data for dual-axis charts
- add similar hover update test for single-axis charts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68939dc4fecc832ba588645ce577c046