### PR TITLE
refactor: refine chart type definitions

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -26,7 +26,7 @@ function buildSegmentTreeTupleSf(
 export function drawCharts(data: [number, number][], dualYAxis = false) {
   const charts: TimeSeriesChart[] = [];
 
-  const onZoom = (event: D3ZoomEvent<Element, unknown>) =>
+  const onZoom = (event: D3ZoomEvent<SVGRectElement, unknown>) =>
     charts.forEach((c) => c.zoom(event));
   const onMouseMove: (this: Element, event: MouseEvent) => void = function (
     this: Element,

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -41,8 +41,8 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
     _index,
     _groups,
   ) {
-    const svg = select(this).select("svg");
-    const legend = select(this).select(".chart-legend");
+    const svg = select(this).select<SVGSVGElement>("svg");
+    const legend = select(this).select<HTMLElement>(".chart-legend");
     const chart = new TimeSeriesChart(
       svg,
       legend,

--- a/svg-time-series/src/chart/interaction.ts
+++ b/svg-time-series/src/chart/interaction.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection } from "d3-selection";
+import { Selection } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
@@ -8,16 +8,16 @@ import { LegendController } from "./legend.ts";
 import { ZoomState } from "./zoomState.ts";
 
 export class ChartInteraction {
-  private zoomArea: Selection<SVGRectElement, unknown, BaseType, unknown>;
+  private zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>;
   private zoomState: ZoomState;
   private legendController: LegendController;
 
   constructor(
-    svg: Selection<BaseType, unknown, HTMLElement, unknown>,
-    legend: Selection<BaseType, unknown, HTMLElement, unknown>,
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+    legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
     private state: RenderState,
     private data: ChartData,
-    zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void,
+    zoomHandler: (event: D3ZoomEvent<SVGRectElement, unknown>) => void,
     mouseMoveHandler: (event: MouseEvent) => void,
     formatTime: (timestamp: number) => string = (timestamp) =>
       new Date(timestamp).toLocaleString(),
@@ -47,7 +47,7 @@ export class ChartInteraction {
     );
   }
 
-  public zoom = (event: D3ZoomEvent<Element, unknown>) => {
+  public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.zoomState.zoom(event, false);
     this.legendController.refresh();
   };

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,13 +1,13 @@
-import { BaseType, Selection, select } from "d3-selection";
+import { Selection, select } from "d3-selection";
 import { drawProc } from "../utils/drawProc.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import type { ChartData } from "./data.ts";
 import type { RenderState } from "./render.ts";
 
 export class LegendController {
-  private legendTime: Selection<BaseType, unknown, HTMLElement, unknown>;
-  private legendGreen: Selection<BaseType, unknown, HTMLElement, unknown>;
-  private legendBlue: Selection<BaseType, unknown, HTMLElement, unknown>;
+  private legendTime: Selection<HTMLElement, unknown, HTMLElement, unknown>;
+  private legendGreen: Selection<HTMLElement, unknown, HTMLElement, unknown>;
+  private legendBlue: Selection<HTMLElement, unknown, HTMLElement, unknown>;
 
   private readonly dotRadius = 3;
   private highlightedGreenDot: SVGCircleElement;
@@ -21,7 +21,7 @@ export class LegendController {
   private scheduleRefresh: () => void;
 
   constructor(
-    legend: Selection<BaseType, unknown, HTMLElement, unknown>,
+    legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
     private state: RenderState,
     private data: ChartData,
     private formatTime: (timestamp: number) => string = (timestamp) =>
@@ -76,7 +76,7 @@ export class LegendController {
       isNaN(n) ? valueForNaN : n;
     const updateDot = (
       val: number,
-      legendSel: Selection<BaseType, unknown, HTMLElement, unknown>,
+      legendSel: Selection<HTMLElement, unknown, HTMLElement, unknown>,
       node: SVGGraphicsElement | null,
       dotScaleMatrix?: SVGMatrix,
     ) => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection } from "d3-selection";
+import { Selection } from "d3-selection";
 
 import { MyAxis, Orientation } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
@@ -16,7 +16,7 @@ import {
 } from "./render/utils.ts";
 
 function setupAxes(
-  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   scales: ScaleSet,
   width: number,
   height: number,
@@ -70,10 +70,10 @@ function setupAxes(
 interface AxisSet {
   x: MyAxis;
   y: MyAxis;
-  gX: Selection<SVGGElement, unknown, any, any>;
-  gY: Selection<SVGGElement, unknown, any, any>;
+  gX: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+  gY: Selection<SVGGElement, unknown, HTMLElement, unknown>;
   yRight?: MyAxis;
-  gYRight?: Selection<SVGGElement, unknown, any, any>;
+  gYRight?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
 }
 
 interface TransformSet {
@@ -97,7 +97,7 @@ export interface RenderState {
 }
 
 export function setupRender(
-  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   data: ChartData,
   dualYAxis: boolean,
 ): RenderState {

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection } from "d3-selection";
+import { Selection } from "d3-selection";
 import { line } from "d3-shape";
 import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../../math/affine.ts";
@@ -8,7 +8,7 @@ import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
 export function createDimensions(
-  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
 ) {
   const node: SVGSVGElement = svg.node() as SVGSVGElement;
   const div: HTMLElement = node.parentNode as HTMLElement;
@@ -74,7 +74,7 @@ export function updateScaleY(
 }
 
 export interface PathSet {
-  path: Selection<SVGPathElement, number, any, unknown>;
+  path: Selection<SVGPathElement, number, SVGSVGElement, unknown>;
   viewNy: SVGGElement;
   viewSf?: SVGGElement;
 }
@@ -85,7 +85,7 @@ export interface TransformPair {
 }
 
 export function initPaths(
-  svg: Selection<BaseType, unknown, HTMLElement, unknown>,
+  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   hasSf: boolean,
 ): PathSet {
   const views = svg

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -74,7 +74,7 @@ export function updateScaleY(
 }
 
 export interface PathSet {
-  path: Selection<SVGPathElement, number, SVGSVGElement, unknown>;
+  path: Selection<SVGPathElement, number, SVGGElement, unknown>;
   viewNy: SVGGElement;
   viewSf?: SVGGElement;
 }

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection } from "d3-selection";
+import { Selection } from "d3-selection";
 import {
   zoom as d3zoom,
   D3ZoomEvent,
@@ -14,11 +14,11 @@ export class ZoomState {
   private scheduleRefresh: () => void;
 
   constructor(
-    private zoomArea: Selection<SVGRectElement, unknown, BaseType, unknown>,
+    private zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
     private state: RenderState,
     private refreshChart: () => void,
     private zoomCallback: (
-      event: D3ZoomEvent<Element, unknown>,
+      event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
   ) {
     this.zoomBehavior = d3zoom<SVGRectElement, unknown>()
@@ -27,7 +27,7 @@ export class ZoomState {
         [0, 0],
         [state.dimensions.width, state.dimensions.height],
       ])
-      .on("zoom", (event: D3ZoomEvent<Element, unknown>) => {
+      .on("zoom", (event: D3ZoomEvent<SVGRectElement, unknown>) => {
         this.zoom(event);
       });
 
@@ -44,7 +44,10 @@ export class ZoomState {
     });
   }
 
-  public zoom = (event: D3ZoomEvent<Element, unknown>, callCallback = true) => {
+  public zoom = (
+    event: D3ZoomEvent<SVGRectElement, unknown>,
+    callCallback = true,
+  ) => {
     this.currentPanZoomTransformState = event.transform;
     this.state.transforms.ny.onZoomPan(event.transform);
     this.state.transforms.sf?.onZoomPan(event.transform);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection } from "d3-selection";
+import { Selection } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 
 import { ChartData, IMinMax } from "./chart/data.ts";
@@ -8,15 +8,15 @@ import { ChartInteraction } from "./chart/interaction.ts";
 export type { IMinMax } from "./chart/data.ts";
 
 export class TimeSeriesChart {
-  public zoom: (event: D3ZoomEvent<Element, unknown>) => void;
+  public zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
   public onHover: (x: number) => void;
   private drawNewData: () => void;
   private data: ChartData;
   private destroyInteraction: () => void;
 
   constructor(
-    svg: Selection<BaseType, unknown, HTMLElement, unknown>,
-    legend: Selection<BaseType, unknown, HTMLElement, unknown>,
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+    legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
     startTime: number,
     timeStep: number,
     data: Array<[number, number?]>,
@@ -29,7 +29,9 @@ export class TimeSeriesChart {
       elements: ReadonlyArray<[number, number?]>,
     ) => IMinMax,
     dualYAxis = false,
-    zoomHandler: (event: D3ZoomEvent<Element, unknown>) => void = () => {},
+    zoomHandler: (
+      event: D3ZoomEvent<SVGRectElement, unknown>,
+    ) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
     formatTime: (timestamp: number) => string = (timestamp) =>
       new Date(timestamp).toLocaleString(),

--- a/svg-time-series/src/utils/drawProc.ts
+++ b/svg-time-series/src/utils/drawProc.ts
@@ -1,11 +1,11 @@
 import { timeout as runTimeout } from "d3-timer";
 
-export function drawProc<T extends unknown[]>(
-  f: (...args: T) => void,
-): (...args: T) => void {
+export function drawProc<F extends (...args: unknown[]) => void>(
+  f: F,
+): (...args: Parameters<F>) => void {
   let requested = false;
 
-  return (...params: T) => {
+  return (...params: Parameters<F>) => {
     if (!requested) {
       requested = true;
       runTimeout(() => {


### PR DESCRIPTION
## Summary
- tighten drawProc signature to preserve wrapped function parameter types
- use SVG-specific zoom events and selections across the chart implementation
- clarify legend and render utilities with concrete HTMLElement and SVGSVGElement selections

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68939d397794832b99c654821dc7ab0a