### PR TITLE
fix: clean up zoom event listeners on destroy

### DIFF
--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import { select } from "d3-selection";
+
+vi.mock("d3-zoom", () => {
+  return {
+    zoom: () => {
+      const behavior: any = (selection: any) => {
+        selection.on("wheel.zoom", (event: Event) =>
+          behavior._handler?.(event as any),
+        );
+        selection.on("pointerdown.zoom", (event: Event) =>
+          behavior._handler?.(event as any),
+        );
+      };
+      behavior.scaleExtent = () => behavior;
+      behavior.translateExtent = () => behavior;
+      behavior.on = (_: string, handler: any) => {
+        behavior._handler = handler;
+        return behavior;
+      };
+      behavior.transform = vi.fn();
+      return behavior;
+    },
+  };
+});
+
+import { ZoomState } from "./zoomState.ts";
+
+describe("ZoomState.destroy", () => {
+  it("removes wheel and pointer handlers", () => {
+    const svg = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg",
+    ) as any;
+    svg.width = { baseVal: { value: 10 } };
+    svg.height = { baseVal: { value: 10 } };
+    const rect = select(svg).append("rect");
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny: { onZoomPan: vi.fn() } },
+    };
+    const refresh = vi.fn();
+    const zoomCb = vi.fn();
+    const zs = new ZoomState(rect as any, state, refresh, zoomCb);
+
+    rect.node()?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    expect(zoomCb).toHaveBeenCalled();
+
+    zoomCb.mockClear();
+    zs.destroy();
+    rect.node()?.dispatchEvent(new Event("wheel", { bubbles: true }));
+    rect.node()?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    expect(zoomCb).not.toHaveBeenCalled();
+  });
+});

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -62,6 +62,7 @@ export class ZoomState {
   };
 
   public destroy = () => {
+    this.zoomArea.on(".zoom", null);
     this.zoomBehavior.on("zoom", null);
   };
 }


### PR DESCRIPTION
## Summary
- ensure ZoomState destroys zoom listeners on its selection
- test that wheel and pointer events are ignored after destroy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893a8087b38832ba38dad4bf9d31c3e