### PR TITLE
refactor: use direct product space in viewport transform

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -1,31 +1,27 @@
 import { ZoomTransform } from "d3-zoom";
-import { AR1Basis, betweenTBasesAR1, bPlaceholder } from "./math/affine.ts";
-import { applyAR1ToMatrixX, applyAR1ToMatrixY } from "./utils/domMatrix.ts";
+import {
+  AR1Basis,
+  DirectProductBasis,
+  betweenTBasesDirectProduct,
+  dpbPlaceholder,
+} from "./math/affine.ts";
+import { applyDirectProductToMatrix } from "./utils/domMatrix.ts";
 
 export class ViewportTransform {
-  private viewPortPointsX: AR1Basis = bPlaceholder;
-  private viewPortPointsY: AR1Basis = bPlaceholder;
+  private viewPortPoints: DirectProductBasis = dpbPlaceholder;
 
-  private referenceViewWindowPointsX: AR1Basis = bPlaceholder;
-  private referenceViewWindowPointsY: AR1Basis = bPlaceholder;
+  private referenceViewWindowPoints: DirectProductBasis = dpbPlaceholder;
 
   private zoomTransform: DOMMatrix = new DOMMatrix();
   private referenceTransform: DOMMatrix = new DOMMatrix();
   private composedMatrix: DOMMatrix = new DOMMatrix();
 
   private updateReferenceTransform() {
-    const affX = betweenTBasesAR1(
-      this.referenceViewWindowPointsX,
-      this.viewPortPointsX,
+    const dp = betweenTBasesDirectProduct(
+      this.referenceViewWindowPoints,
+      this.viewPortPoints,
     );
-    const affY = betweenTBasesAR1(
-      this.referenceViewWindowPointsY,
-      this.viewPortPointsY,
-    );
-    this.referenceTransform = applyAR1ToMatrixY(
-      affY,
-      applyAR1ToMatrixX(affX, new DOMMatrix()),
-    );
+    this.referenceTransform = applyDirectProductToMatrix(dp, new DOMMatrix());
     this.updateComposedMatrix();
   }
 
@@ -37,8 +33,10 @@ export class ViewportTransform {
     bScreenXVisible: AR1Basis,
     bScreenYVisible: AR1Basis,
   ): void {
-    this.viewPortPointsX = bScreenXVisible;
-    this.viewPortPointsY = bScreenYVisible;
+    this.viewPortPoints = DirectProductBasis.fromProjections(
+      bScreenXVisible,
+      bScreenYVisible,
+    );
     this.updateReferenceTransform();
   }
 
@@ -46,8 +44,10 @@ export class ViewportTransform {
     newPointsX: AR1Basis,
     newPointsY: AR1Basis,
   ) {
-    this.referenceViewWindowPointsX = newPointsX;
-    this.referenceViewWindowPointsY = newPointsY;
+    this.referenceViewWindowPoints = DirectProductBasis.fromProjections(
+      newPointsX,
+      newPointsY,
+    );
     this.updateReferenceTransform();
   }
 

--- a/svg-time-series/src/affine.test.ts
+++ b/svg-time-series/src/affine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   AR1,
   AR1Basis,
+  DirectProduct,
   DirectProductBasis,
   betweenTBasesDirectProduct,
 } from "./math/affine.ts";
@@ -48,5 +49,29 @@ describe("DirectProduct", () => {
     const s2Id = dp.s2.composeWith(dp.s2.inverse());
     expect(s1Id.applyToPoint(5)).toBeCloseTo(5);
     expect(s2Id.applyToPoint(15)).toBeCloseTo(15);
+  });
+
+  it("composes and inverts direct product transforms", () => {
+    const dp1 = new DirectProduct(new AR1([2, 3]), new AR1([4, 5]));
+    const dp2 = new DirectProduct(new AR1([6, 7]), new AR1([8, 9]));
+    const composed = dp1.composeWith(dp2);
+    const [x, y] = composed.applyToPoint([1, 1]);
+    expect(x).toBeCloseTo(dp2.s1.applyToPoint(dp1.s1.applyToPoint(1)));
+    expect(y).toBeCloseTo(dp2.s2.applyToPoint(dp1.s2.applyToPoint(1)));
+
+    const identity = dp1.composeWith(dp1.inverse());
+    const [ix, iy] = identity.applyToPoint([2, 3]);
+    expect(ix).toBeCloseTo(2);
+    expect(iy).toBeCloseTo(3);
+  });
+
+  it("transforms direct product bases", () => {
+    const basis = new DirectProductBasis([0, 0], [1, 1]);
+    const dp = new DirectProduct(new AR1([2, 3]), new AR1([4, 5]));
+    const transformed = basis.transformWith(dp);
+    expect(transformed.toArr()).toEqual([
+      [dp.s1.applyToPoint(0), dp.s1.applyToPoint(1)],
+      [dp.s2.applyToPoint(0), dp.s2.applyToPoint(1)],
+    ]);
   });
 });

--- a/svg-time-series/src/math/affine.ts
+++ b/svg-time-series/src/math/affine.ts
@@ -64,6 +64,21 @@ export class DirectProduct {
     public s1: AR1,
     public s2: AR1,
   ) {}
+
+  composeWith(dp2: DirectProduct): DirectProduct {
+    return new DirectProduct(
+      this.s1.composeWith(dp2.s1),
+      this.s2.composeWith(dp2.s2),
+    );
+  }
+
+  inverse(): DirectProduct {
+    return new DirectProduct(this.s1.inverse(), this.s2.inverse());
+  }
+
+  applyToPoint(p: [number, number]): [number, number] {
+    return [this.s1.applyToPoint(p[0]), this.s2.applyToPoint(p[1])];
+  }
 }
 
 export class DirectProductBasis {
@@ -89,6 +104,13 @@ export class DirectProductBasis {
 
   toArr() {
     return [this.x().toArr(), this.y().toArr()];
+  }
+
+  transformWith(dp: DirectProduct): DirectProductBasis {
+    return new DirectProductBasis(
+      dp.applyToPoint(this.p1),
+      dp.applyToPoint(this.p2),
+    );
   }
 
   static fromProjections(b1: AR1Basis, b2: AR1Basis): DirectProductBasis {


### PR DESCRIPTION
## Summary
- use DirectProductBasis in `ViewportTransform` instead of separate x/y spaces
- extend direct product helpers with composition, inversion, point and basis transforms
- cover DirectProduct with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689483135070832bbecf0ff3cbbbd67c