### PR TITLE
refactor: accept DirectProductBasis in viewport transform

### DIFF
--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -14,6 +14,7 @@ import {
 import {
   AR1Basis,
   AR1,
+  DirectProductBasis,
   betweenTBasesAR1,
   bPlaceholder,
   bUnit,
@@ -217,8 +218,10 @@ export class TimeSeriesChart {
       // ����������� �� � � Y � ������� ������������
       // ������e��� �� ������ �������������
       pathTransform.onReferenceViewWindowResize(
-        this.bIndexFull,
-        bTemperatureVisible,
+        DirectProductBasis.fromProjections(
+          this.bIndexFull,
+          bTemperatureVisible,
+        ),
       );
 
       const bTimeVisible = bIndexVisible.transformWith(this.idxToTime);
@@ -263,8 +266,12 @@ export class TimeSeriesChart {
       xAxis.axisUp(gX);
       yAxis.axisUp(gY);
     });
-    pathTransform.onViewPortResize(bScreenXVisible, bScreenYVisible);
-    pathTransform.onReferenceViewWindowResize(this.bIndexFull, bPlaceholder);
+    pathTransform.onViewPortResize(
+      DirectProductBasis.fromProjections(bScreenXVisible, bScreenYVisible),
+    );
+    pathTransform.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(this.bIndexFull, bPlaceholder),
+    );
     svg
       .append("rect")
       .attr("class", "zoom")

--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import { AR1Basis } from "./math/affine.ts";
+import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 
 class Matrix {
   constructor(
@@ -69,8 +69,18 @@ describe("ViewportTransform", () => {
   it("composes zoom and reference transforms and inverts them", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
-    vt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    vt.onViewPortResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 100),
+        new AR1Basis(0, 100),
+      ),
+    );
+    vt.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 10),
+        new AR1Basis(0, 10),
+      ),
+    );
 
     // without zoom
     expect(vt.fromScreenToModelX(50)).toBeCloseTo(5);
@@ -86,8 +96,18 @@ describe("ViewportTransform", () => {
   it("maps screen bases back to model bases through inverse transforms", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
-    vt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    vt.onViewPortResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 100),
+        new AR1Basis(0, 100),
+      ),
+    );
+    vt.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 10),
+        new AR1Basis(0, 10),
+      ),
+    );
     vt.onZoomPan({ x: 10, k: 2 } as any);
 
     const basis = vt.fromScreenToModelBasisX(new AR1Basis(20, 40));
@@ -99,8 +119,18 @@ describe("ViewportTransform", () => {
   it("converts screen points to model points", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(new AR1Basis(0, 100), new AR1Basis(0, 100));
-    vt.onReferenceViewWindowResize(new AR1Basis(0, 10), new AR1Basis(0, 10));
+    vt.onViewPortResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 100),
+        new AR1Basis(0, 100),
+      ),
+    );
+    vt.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 10),
+        new AR1Basis(0, 10),
+      ),
+    );
     vt.onZoomPan({ x: 10, k: 2 } as any);
 
     const p = (vt as any).toModelPoint(70, 20) as { x: number; y: number };

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -29,25 +29,13 @@ export class ViewportTransform {
     this.composedMatrix = this.zoomTransform.multiply(this.referenceTransform);
   }
 
-  public onViewPortResize(
-    bScreenXVisible: AR1Basis,
-    bScreenYVisible: AR1Basis,
-  ): void {
-    this.viewPortPoints = DirectProductBasis.fromProjections(
-      bScreenXVisible,
-      bScreenYVisible,
-    );
+  public onViewPortResize(bScreenVisible: DirectProductBasis): void {
+    this.viewPortPoints = bScreenVisible;
     this.updateReferenceTransform();
   }
 
-  public onReferenceViewWindowResize(
-    newPointsX: AR1Basis,
-    newPointsY: AR1Basis,
-  ) {
-    this.referenceViewWindowPoints = DirectProductBasis.fromProjections(
-      newPointsX,
-      newPointsY,
-    );
+  public onReferenceViewWindowResize(newPoints: DirectProductBasis) {
+    this.referenceViewWindowPoints = newPoints;
     this.updateReferenceTransform();
   }
 

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -3,7 +3,7 @@ import { Selection } from "d3-selection";
 import { MyAxis, Orientation } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
-import { AR1Basis, bPlaceholder } from "../math/affine.ts";
+import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData } from "./data.ts";
 import {
   createDimensions,
@@ -131,7 +131,9 @@ export function setupRender(
       Math.min(nyMin, sfMin),
       Math.max(nyMax, sfMax),
     );
-    transformsInner.ny.onReferenceViewWindowResize(data.bIndexFull, combined);
+    transformsInner.ny.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(data.bIndexFull, combined),
+    );
     scales.yNy.domain(combined.toArr());
   } else {
     updateScaleY(
@@ -154,12 +156,17 @@ export function setupRender(
 
   const axes = setupAxes(svg, scales, width, height, hasSf, dualYAxis);
 
-  transformsInner.ny.onViewPortResize(bScreenXVisible, bScreenYVisible);
-  transformsInner.sf?.onViewPortResize(bScreenXVisible, bScreenYVisible);
-  transformsInner.ny.onReferenceViewWindowResize(data.bIndexFull, bPlaceholder);
+  const bScreenVisibleDp = DirectProductBasis.fromProjections(
+    bScreenXVisible,
+    bScreenYVisible,
+  );
+  transformsInner.ny.onViewPortResize(bScreenVisibleDp);
+  transformsInner.sf?.onViewPortResize(bScreenVisibleDp);
+  transformsInner.ny.onReferenceViewWindowResize(
+    DirectProductBasis.fromProjections(data.bIndexFull, bPlaceholder),
+  );
   transformsInner.sf?.onReferenceViewWindowResize(
-    data.bIndexFull,
-    bPlaceholder,
+    DirectProductBasis.fromProjections(data.bIndexFull, bPlaceholder),
   );
 
   const transforms: TransformSet = {
@@ -207,8 +214,12 @@ export function refreshChart(state: RenderState, data: ChartData) {
       Math.min(nyMin, sfMin),
       Math.max(nyMax, sfMax),
     );
-    state.transforms.ny.onReferenceViewWindowResize(data.bIndexFull, combined);
-    state.transforms.sf?.onReferenceViewWindowResize(data.bIndexFull, combined);
+    state.transforms.ny.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(data.bIndexFull, combined),
+    );
+    state.transforms.sf?.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(data.bIndexFull, combined),
+    );
     state.scales.yNy.domain(combined.toArr());
     if (state.paths.viewSf) {
       updateNode(state.paths.viewSf, state.transforms.ny.matrix);

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,7 +1,7 @@
 import { Selection } from "d3-selection";
 import { line } from "d3-shape";
 import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
-import { AR1Basis } from "../../math/affine.ts";
+import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import { SegmentTree } from "../../segmentTree.ts";
 import { ViewportTransform } from "../../ViewportTransform.ts";
 import type { ChartData } from "../data.ts";
@@ -67,8 +67,7 @@ export function updateScaleY(
 ) {
   const bTemperatureVisible = data.bTemperatureVisible(bIndexVisible, tree);
   pathTransform.onReferenceViewWindowResize(
-    data.bIndexFull,
-    bTemperatureVisible,
+    DirectProductBasis.fromProjections(data.bIndexFull, bTemperatureVisible),
   );
   yScale.domain(bTemperatureVisible.toArr());
 }


### PR DESCRIPTION
## Summary
- switch `ViewportTransform` to accept full `DirectProductBasis` objects instead of separate axis pairs
- update chart rendering utilities and demo to build direct-product bases for viewport and reference windows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68948c492298832b920c3af0e9c8ce65