### PR TITLE
refactor: encapsulate chart interaction

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -27,13 +27,13 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
   const charts: TimeSeriesChart[] = [];
 
   const onZoom = (event: D3ZoomEvent<SVGRectElement, unknown>) =>
-    charts.forEach((c) => c.zoom(event));
+    charts.forEach((c) => c.interaction.zoom(event));
   const onMouseMove: (this: Element, event: MouseEvent) => void = function (
     this: Element,
     event: MouseEvent,
   ) {
     const [x] = pointer(event, this);
-    charts.forEach((c) => c.onHover(x));
+    charts.forEach((c) => c.interaction.onHover(x));
   };
 
   const onSelectChart: ValueFn<HTMLElement, unknown, void> = function (

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -99,7 +99,7 @@ describe("TimeSeriesChart", () => {
     ]);
 
     chart.updateChartWithNewData([2, 2]);
-    chart.onHover(0);
+    chart.interaction.onHover(0);
 
     expect(onHoverUsedData).toEqual([
       [1, 1],

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -7,12 +7,14 @@ import { ChartInteraction } from "./chart/interaction.ts";
 
 export type { IMinMax } from "./chart/data.ts";
 
+export interface IPublicInteraction {
+  zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
+  onHover: (x: number) => void;
+}
+
 export class TimeSeriesChart {
-  public zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
-  public onHover: (x: number) => void;
-  private drawNewData: () => void;
   private data: ChartData;
-  private destroyInteraction: () => void;
+  private _interaction: ChartInteraction;
 
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -45,7 +47,7 @@ export class TimeSeriesChart {
     );
 
     const renderState = setupRender(svg, this.data, dualYAxis);
-    const interaction = new ChartInteraction(
+    this._interaction = new ChartInteraction(
       svg,
       legend,
       renderState,
@@ -55,21 +57,20 @@ export class TimeSeriesChart {
       formatTime,
     );
 
-    this.zoom = interaction.zoom;
-    this.onHover = interaction.onHover;
-    this.drawNewData = interaction.drawNewData;
-    this.destroyInteraction = interaction.destroy;
+    this._interaction.drawNewData();
+    this._interaction.onHover(renderState.dimensions.width - 1);
+  }
 
-    this.drawNewData();
-    this.onHover(renderState.dimensions.width - 1);
+  public get interaction(): IPublicInteraction {
+    return this._interaction;
   }
 
   public updateChartWithNewData(newData: [number, number?]) {
     this.data.append(newData);
-    this.drawNewData();
+    this._interaction.drawNewData();
   }
 
   public dispose() {
-    this.destroyInteraction();
+    this._interaction.destroy();
   }
 }


### PR DESCRIPTION
## Summary
- encapsulate chart interaction behind private field and IPublicInteraction getter
- update tests and demos to use the new interaction API

## Testing
- `npm run format`
- `git commit` (runs lint, typecheck, tests)


------
https://chatgpt.com/codex/tasks/task_e_6894962fb3f0832b8cf5ab23e5cbc5ee