### PR TITLE
refactor: compute combined basis in ChartData

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -205,6 +205,24 @@ describe("ChartData", () => {
     ]);
   });
 
+  it("computes combined temperature basis and direct product", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [0, 10],
+        [5, 2],
+        [-3, 7],
+      ],
+      buildNy,
+      buildSf,
+    );
+    const { combined, dp } = cd.combinedTemperatureDp(cd.bIndexFull);
+    expect(combined.toArr()).toEqual([-3, 10]);
+    expect(dp.x().toArr()).toEqual([0, 2]);
+    expect(dp.y().toArr()).toEqual([-3, 10]);
+  });
+
   describe("single-axis", () => {
     const buildNy = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
       min: arr[i][0],

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,4 +1,10 @@
-import { AR1, AR1Basis, betweenTBasesAR1, bUnit } from "../math/affine.ts";
+import {
+  AR1,
+  AR1Basis,
+  DirectProductBasis,
+  betweenTBasesAR1,
+  bUnit,
+} from "../math/affine.ts";
 import { IMinMax, SegmentTree } from "../segmentTree.ts";
 
 export type { IMinMax };
@@ -89,5 +95,24 @@ export class ChartData {
     }
     const { min, max } = tree.query(startIdx, endIdx);
     return new AR1Basis(min, max);
+  }
+
+  combinedTemperatureDp(bIndexVisible: AR1Basis): {
+    combined: AR1Basis;
+    dp: DirectProductBasis;
+  } {
+    if (!this.treeSf) {
+      throw new Error("Second series data is unavailable");
+    }
+    const bNy = this.bTemperatureVisible(bIndexVisible, this.treeNy);
+    const bSf = this.bTemperatureVisible(bIndexVisible, this.treeSf);
+    const [nyMin, nyMax] = bNy.toArr();
+    const [sfMin, sfMax] = bSf.toArr();
+    const combined = new AR1Basis(
+      Math.min(nyMin, sfMin),
+      Math.max(nyMax, sfMax),
+    );
+    const dp = DirectProductBasis.fromProjections(this.bIndexFull, combined);
+    return { combined, dp };
   }
 }

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -123,17 +123,8 @@ export function setupRender(
 
   updateScaleX(scales.x, data.bIndexFull, data);
   if (hasSf && !dualYAxis && data.treeSf) {
-    const bNy = data.bTemperatureVisible(data.bIndexFull, data.treeNy);
-    const bSf = data.bTemperatureVisible(data.bIndexFull, data.treeSf);
-    const [nyMin, nyMax] = bNy.toArr();
-    const [sfMin, sfMax] = bSf.toArr();
-    const combined = new AR1Basis(
-      Math.min(nyMin, sfMin),
-      Math.max(nyMax, sfMax),
-    );
-    transformsInner.ny.onReferenceViewWindowResize(
-      DirectProductBasis.fromProjections(data.bIndexFull, combined),
-    );
+    const { combined, dp } = data.combinedTemperatureDp(data.bIndexFull);
+    transformsInner.ny.onReferenceViewWindowResize(dp);
     scales.yNy.domain(combined.toArr());
   } else {
     updateScaleY(
@@ -206,20 +197,9 @@ export function refreshChart(state: RenderState, data: ChartData) {
     );
     updateNode(state.paths.viewSf!, state.transforms.sf.matrix);
   } else if (data.treeSf) {
-    const bNy = data.bTemperatureVisible(bIndexVisible, data.treeNy);
-    const bSf = data.bTemperatureVisible(bIndexVisible, data.treeSf);
-    const [nyMin, nyMax] = bNy.toArr();
-    const [sfMin, sfMax] = bSf.toArr();
-    const combined = new AR1Basis(
-      Math.min(nyMin, sfMin),
-      Math.max(nyMax, sfMax),
-    );
-    state.transforms.ny.onReferenceViewWindowResize(
-      DirectProductBasis.fromProjections(data.bIndexFull, combined),
-    );
-    state.transforms.sf?.onReferenceViewWindowResize(
-      DirectProductBasis.fromProjections(data.bIndexFull, combined),
-    );
+    const { combined, dp } = data.combinedTemperatureDp(bIndexVisible);
+    state.transforms.ny.onReferenceViewWindowResize(dp);
+    state.transforms.sf?.onReferenceViewWindowResize(dp);
     state.scales.yNy.domain(combined.toArr());
     if (state.paths.viewSf) {
       updateNode(state.paths.viewSf, state.transforms.ny.matrix);


### PR DESCRIPTION
## Summary
- centralize combined Y-range & direct product computation in `ChartData`
- use new `combinedTemperatureDp` in chart rendering logic
- restore comprehensive chart data tests and add coverage for combined basis

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894aedeba18832bba94992d40c47c4a