### PR TITLE
fix: use latest params in drawProc

### DIFF
--- a/svg-time-series/src/utils/drawProc.ts
+++ b/svg-time-series/src/utils/drawProc.ts
@@ -4,13 +4,15 @@ export function drawProc<F extends (...args: unknown[]) => void>(
   f: F,
 ): (...args: Parameters<F>) => void {
   let requested = false;
+  let latestParams: Parameters<F>;
 
   return (...params: Parameters<F>) => {
+    latestParams = params;
     if (!requested) {
       requested = true;
       runTimeout(() => {
         requested = false;
-        f(...params);
+        f(...latestParams);
       });
     }
   };


### PR DESCRIPTION
## Summary
- track latest params for drawProc so scheduled callback uses most recent invocation

## Testing
- `npm run format`
- `git commit -am "fix: use latest params in draw proc"`


------
https://chatgpt.com/codex/tasks/task_e_6894b3641384832b86d024429e59fc33