### PR TITLE
feat: add zoom reset api and sample

### DIFF
--- a/samples/demos/resetZoom.html
+++ b/samples/demos/resetZoom.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta
+  name="viewport"
+  content="width=device-width, initial-scale=1, maximum-scale=1"
+/>
+<button id="reset">Reset Zoom</button>
+<div class="charts">
+  <div class="chart">
+    <div class="chart-drawing">
+      <svg></svg>
+    </div>
+    <div class="chart-legend">
+      <div class="chart-legend__time"></div>
+      <div class="chart-legend__green_caption">NY:</div>
+      <div class="chart-legend__green_value"></div>
+      <div class="chart-legend__blue_caption">SF:</div>
+      <div class="chart-legend__blue_value"></div>
+    </div>
+  </div>
+</div>
+<script type="module" src="resetZoom.ts"></script>
+<link href="index.css" type="text/css" rel="stylesheet" />

--- a/samples/demos/resetZoom.ts
+++ b/samples/demos/resetZoom.ts
@@ -1,0 +1,63 @@
+import { csv } from "d3-request";
+import { pointer, select } from "d3-selection";
+import { D3ZoomEvent } from "d3-zoom";
+
+import { TimeSeriesChart, IMinMax } from "svg-time-series";
+
+function buildSegmentTreeTupleNy(
+  index: number,
+  elements: ReadonlyArray<[number, number]>,
+): IMinMax {
+  const nyMinValue = isNaN(elements[index][0]) ? Infinity : elements[index][0];
+  const nyMaxValue = isNaN(elements[index][0]) ? -Infinity : elements[index][0];
+  return { min: nyMinValue, max: nyMaxValue };
+}
+
+function buildSegmentTreeTupleSf(
+  index: number,
+  elements: ReadonlyArray<[number, number]>,
+): IMinMax {
+  const sfMinValue = isNaN(elements[index][1]) ? Infinity : elements[index][1];
+  const sfMaxValue = isNaN(elements[index][1]) ? -Infinity : elements[index][1];
+  return { min: sfMinValue, max: sfMaxValue };
+}
+
+csv("ny-vs-sf.csv")
+  .row((d: { NY: string; SF: string }) => [
+    parseFloat(d.NY.split(";")[0]),
+    parseFloat(d.SF.split(";")[0]),
+  ])
+  .get((error: null, data: [number, number][]) => {
+    if (error != null) {
+      alert("Data can't be downloaded or parsed");
+      return;
+    }
+
+    let chart: TimeSeriesChart;
+
+    const onZoom = (event: D3ZoomEvent<SVGRectElement, unknown>) =>
+      chart.interaction.zoom(event);
+    const onMouseMove = function (this: Element, event: MouseEvent) {
+      const [x] = pointer(event, this);
+      chart.interaction.onHover(x);
+    };
+
+    const svg = select<SVGSVGElement, unknown>("svg");
+    const legend = select<HTMLElement, unknown>(".chart-legend");
+    chart = new TimeSeriesChart(
+      svg,
+      legend,
+      Date.now(),
+      86400000,
+      data,
+      buildSegmentTreeTupleNy,
+      buildSegmentTreeTupleSf,
+      true,
+      onZoom,
+      onMouseMove,
+    );
+
+    document
+      .getElementById("reset")!
+      .addEventListener("click", () => chart.interaction.resetZoom());
+  });

--- a/samples/index.html
+++ b/samples/index.html
@@ -93,6 +93,7 @@
       </li>
       <li><a href="./demos/demo1.html">./demos/demo1.html</a></li>
       <li><a href="./demos/demo2.html">./demos/demo2.html</a></li>
+      <li><a href="./demos/resetZoom.html">./demos/resetZoom.html</a></li>
       <li><a href="./index.html">./index.html</a></li>
     </ul>
   </body>

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -8,8 +8,16 @@ vi.mock("d3-zoom", () => {
   const behavior: any = () => {};
   behavior.scaleExtent = () => behavior;
   behavior.translateExtent = () => behavior;
-  behavior.on = () => behavior;
-  behavior.transform = vi.fn();
+  behavior.on = (event: string, handler: any) => {
+    behavior._zoomHandler = handler;
+    return behavior;
+  };
+  behavior.transform = vi.fn((selection: any, transform: any) => {
+    // Simulate the zoom event being triggered
+    if (behavior._zoomHandler) {
+      behavior._zoomHandler({ transform });
+    }
+  });
   return { zoom: () => behavior, zoomIdentity: { k: 1, x: 0, y: 0 } };
 });
 
@@ -92,7 +100,7 @@ describe("ZoomState", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 
-  it("reset sets transform to identity without event", () => {
+  it("reset sets transform to identity and triggers zoom event", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const ny = { onZoomPan: vi.fn() };
@@ -105,6 +113,8 @@ describe("ZoomState", () => {
 
     const transformSpy = zs.zoomBehavior.transform as any;
     transformSpy.mockClear();
+    ny.onZoomPan.mockClear();
+    refresh.mockClear();
 
     zs.reset();
     vi.runAllTimers();
@@ -113,9 +123,12 @@ describe("ZoomState", () => {
       rect,
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
-    expect(transformSpy.mock.calls[0][2]).toBeUndefined();
+    expect(ny.onZoomPan).toHaveBeenCalledWith(
+      expect.objectContaining({ k: 1, x: 0, y: 0 }),
+    );
     expect((zs as any).currentPanZoomTransformState).toEqual(
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -12,7 +12,7 @@ vi.mock("d3-zoom", () => {
     behavior._zoomHandler = handler;
     return behavior;
   };
-  behavior.transform = vi.fn();
+  behavior.transform = vi.fn(() => behavior);
   behavior.triggerZoom = (transform: any) => {
     if (behavior._zoomHandler) {
       behavior._zoomHandler({ transform });

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -10,7 +10,7 @@ vi.mock("d3-zoom", () => {
   behavior.translateExtent = () => behavior;
   behavior.on = () => behavior;
   behavior.transform = vi.fn();
-  return { zoom: () => behavior };
+  return { zoom: () => behavior, zoomIdentity: { k: 1, x: 0, y: 0 } };
 });
 
 import { ZoomState } from "./zoomState.ts";
@@ -90,5 +90,32 @@ describe("ZoomState", () => {
 
     expect(transformSpy).toHaveBeenCalled();
     expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("reset sets transform to identity without event", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const ny = { onZoomPan: vi.fn() };
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny },
+    };
+    const refresh = vi.fn();
+    const zs = new ZoomState(rect as any, state, refresh);
+
+    const transformSpy = zs.zoomBehavior.transform as any;
+    transformSpy.mockClear();
+
+    zs.reset();
+    vi.runAllTimers();
+
+    expect(transformSpy).toHaveBeenCalledWith(
+      rect,
+      expect.objectContaining({ k: 1, x: 0, y: 0 }),
+    );
+    expect(transformSpy.mock.calls[0][2]).toBeUndefined();
+    expect((zs as any).currentPanZoomTransformState).toEqual(
+      expect.objectContaining({ k: 1, x: 0, y: 0 }),
+    );
   });
 });

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -12,12 +12,12 @@ vi.mock("d3-zoom", () => {
     behavior._zoomHandler = handler;
     return behavior;
   };
-  behavior.transform = vi.fn((selection: any, transform: any) => {
-    // Simulate the zoom event being triggered
+  behavior.transform = vi.fn();
+  behavior.triggerZoom = (transform: any) => {
     if (behavior._zoomHandler) {
       behavior._zoomHandler({ transform });
     }
-  });
+  };
   return { zoom: () => behavior, zoomIdentity: { k: 1, x: 0, y: 0 } };
 });
 
@@ -117,6 +117,8 @@ describe("ZoomState", () => {
     refresh.mockClear();
 
     zs.reset();
+    // Manually trigger the zoom event that would happen in real d3-zoom
+    (zs.zoomBehavior as any).triggerZoom({ k: 1, x: 0, y: 0 });
     vi.runAllTimers();
 
     expect(transformSpy).toHaveBeenCalledWith(

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -63,6 +63,7 @@ export class ZoomState {
   };
 
   public reset = () => {
+    this.currentPanZoomTransformState = zoomIdentity;
     this.state.transforms.ny.onZoomPan(zoomIdentity);
     this.state.transforms.sf?.onZoomPan(zoomIdentity);
     this.zoomBehavior.transform(this.zoomArea, zoomIdentity);

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -4,6 +4,7 @@ import {
   D3ZoomEvent,
   ZoomBehavior,
   ZoomTransform,
+  zoomIdentity,
 } from "d3-zoom";
 import { drawProc } from "../utils/drawProc.ts";
 import type { RenderState } from "./render.ts";
@@ -59,6 +60,11 @@ export class ZoomState {
 
   public refresh = () => {
     this.scheduleRefresh();
+  };
+
+  public reset = () => {
+    this.currentPanZoomTransformState = zoomIdentity;
+    this.zoomBehavior.transform(this.zoomArea, zoomIdentity);
   };
 
   public destroy = () => {

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -63,9 +63,6 @@ export class ZoomState {
   };
 
   public reset = () => {
-    this.currentPanZoomTransformState = zoomIdentity;
-    this.state.transforms.ny.onZoomPan(zoomIdentity);
-    this.state.transforms.sf?.onZoomPan(zoomIdentity);
     this.zoomBehavior.transform(this.zoomArea, zoomIdentity);
   };
 

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -63,7 +63,8 @@ export class ZoomState {
   };
 
   public reset = () => {
-    this.currentPanZoomTransformState = zoomIdentity;
+    this.state.transforms.ny.onZoomPan(zoomIdentity);
+    this.state.transforms.sf?.onZoomPan(zoomIdentity);
     this.zoomBehavior.transform(this.zoomArea, zoomIdentity);
   };
 

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -13,6 +13,7 @@ export type { IMinMax } from "./chart/data.ts";
 export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
   onHover: (x: number) => void;
+  resetZoom: () => void;
 }
 
 export class TimeSeriesChart {
@@ -83,7 +84,11 @@ export class TimeSeriesChart {
   }
 
   public get interaction(): IPublicInteraction {
-    return { zoom: this.zoom, onHover: this.onHover };
+    return {
+      zoom: this.zoom,
+      onHover: this.onHover,
+      resetZoom: this.resetZoom,
+    };
   }
 
   public updateChartWithNewData(newData: [number, number?]) {
@@ -101,6 +106,10 @@ export class TimeSeriesChart {
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.zoomState.zoom(event, false);
     this.legendController.refresh();
+  };
+
+  public resetZoom = () => {
+    this.zoomState.reset();
   };
 
   public onHover = (x: number) => {


### PR DESCRIPTION
## Summary
- add `reset` method to `ZoomState` to restore identity transform
- expose `resetZoom` through `TimeSeriesChart` interaction
- add sample demonstrating programmatic zoom reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894b38f43e4832b944450708b9be7b2