### PR TITLE
feat: add helpers for legend data access

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -46,6 +46,23 @@ describe("ChartData", () => {
     expect(cd.idxToTime.applyToPoint(1)).toBe(0);
   });
 
+  it("provides clamped point data and timestamp", () => {
+    const cd = new ChartData(
+      0,
+      1,
+      [
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ],
+      buildNy,
+      buildSf,
+    );
+    expect(cd.getPoint(1)).toEqual({ values: [30, 40], timestamp: 1 });
+    expect(cd.getPoint(10)).toEqual({ values: [50, 60], timestamp: 2 });
+    expect(cd.getPoint(-5)).toEqual({ values: [10, 20], timestamp: 0 });
+  });
+
   it("reflects latest window after multiple appends", () => {
     const cd = new ChartData(
       0,

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -59,6 +59,24 @@ export class ChartData {
     this.rebuildSegmentTrees();
   }
 
+  get length(): number {
+    return this.data.length;
+  }
+
+  getPoint(idx: number): {
+    values: [number, number?];
+    timestamp: number;
+  } {
+    const clamped = Math.min(
+      Math.max(Math.round(idx), 0),
+      this.data.length - 1,
+    );
+    return {
+      values: this.data[clamped],
+      timestamp: this.idxToTime.applyToPoint(clamped),
+    };
+  }
+
   private rebuildSegmentTrees(): void {
     this.treeNy = new SegmentTree(
       this.data,

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -49,10 +49,7 @@ export class LegendController {
   }
 
   public onHover = (idx: number) => {
-    this.highlightedDataIdx = Math.min(
-      Math.max(idx, 0),
-      this.data.data.length - 1,
-    );
+    this.highlightedDataIdx = Math.min(Math.max(idx, 0), this.data.length - 1);
     this.scheduleRefresh();
   };
 
@@ -61,17 +58,14 @@ export class LegendController {
   };
 
   private update() {
-    const [greenData, blueData] =
-      this.data.data[Math.round(this.highlightedDataIdx)];
-    const timestamp = this.data.idxToTime.applyToPoint(this.highlightedDataIdx);
+    const {
+      values: [greenData, blueData],
+      timestamp,
+    } = this.data.getPoint(this.highlightedDataIdx);
     this.legendTime.text(this.formatTime(timestamp));
 
-    const dotScaleMatrixNy = this.state.transforms.ny.dotScaleMatrix(
-      this.dotRadius,
-    );
-    const dotScaleMatrixSf = this.state.transforms.sf?.dotScaleMatrix(
-      this.dotRadius,
-    );
+    const { ny: dotScaleMatrixNy, sf: dotScaleMatrixSf } =
+      this.state.transforms.getDotMatrices(this.dotRadius);
     const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
       isNaN(n) ? valueForNaN : n;
     const updateDot = (
@@ -97,7 +91,7 @@ export class LegendController {
       this.highlightedGreenDot,
       dotScaleMatrixNy,
     );
-    if (this.state.transforms.sf) {
+    if (dotScaleMatrixSf) {
       updateDot(
         blueData as number,
         this.legendBlue,

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -80,6 +80,10 @@ interface TransformSet {
   ny: ViewportTransform;
   sf?: ViewportTransform;
   bScreenXVisible: AR1Basis;
+  getDotMatrices: (radius: number) => {
+    ny: SVGMatrix;
+    sf?: SVGMatrix;
+  };
 }
 
 interface Dimensions {
@@ -173,6 +177,10 @@ export function setupRender(
     ny: transformsInner.ny,
     sf: transformsInner.sf,
     bScreenXVisible,
+    getDotMatrices: (radius: number) => ({
+      ny: transformsInner.ny.dotScaleMatrix(radius),
+      sf: transformsInner.sf?.dotScaleMatrix(radius),
+    }),
   };
   const dimensions: Dimensions = { width, height };
 


### PR DESCRIPTION
## Summary
- add ChartData.getPoint to return a clamped data tuple and timestamp
- expose TransformSet.getDotMatrices for legend dot scaling
- refactor LegendController to use new helpers and add corresponding tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894b4adad70832b8c8062d1b92fdaae