### PR TITLE
feat: add datasource interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,32 +40,20 @@ parameter of `TimeSeriesChart`, which enables independent left and right Y
 scales.
 
 ```ts
-import { TimeSeriesChart, IMinMax } from "svg-time-series";
+import { TimeSeriesChart, IDataSource } from "svg-time-series";
 
-function buildSegmentTreeTupleNy(
-  index: number,
-  elements: ReadonlyArray<[number, number]>,
-): IMinMax {
-  const ny = elements[index][0];
-  return { min: ny, max: ny };
-}
-
-function buildSegmentTreeTupleSf(
-  index: number,
-  elements: ReadonlyArray<[number, number]>,
-): IMinMax {
-  const sf = elements[index][1];
-  return { min: sf, max: sf };
-}
+const source: IDataSource = {
+  startTime,
+  timeStep,
+  length: data.length,
+  getNy: (i) => data[i][0],
+  getSf: (i) => data[i][1],
+};
 
 const chart = new TimeSeriesChart(
   svg,
   legend,
-  startTime,
-  timeStep,
-  data,
-  buildSegmentTreeTupleNy,
-  buildSegmentTreeTupleSf,
+  source,
   true, // enable dual Y axes
   onZoom,
   onMouseMove,
@@ -80,14 +68,18 @@ with `toLocaleString`.
 For two series sharing a single Y-axis, pass `false` for `dualYAxis`:
 
 ```ts
+const singleSource: IDataSource = {
+  startTime,
+  timeStep,
+  length: data.length,
+  getNy: (i) => data[i][0],
+  getSf: (i) => data[i][1],
+};
+
 const chartSingle = new TimeSeriesChart(
   svg,
   legend,
-  startTime,
-  timeStep,
-  data,
-  buildSegmentTreeTupleNy,
-  buildSegmentTreeTupleSf,
+  singleSource,
   false, // series share one axis
   onZoom,
   onMouseMove,
@@ -95,8 +87,8 @@ const chartSingle = new TimeSeriesChart(
 );
 ```
 
-If you only have one series, supply data with a single value per point and omit
-the second builder; the chart will render a single path and axis.
+If you only have one series, supply a data source without `getSf`; the chart
+will render a single path and axis.
 
 ## Secrets of Speed
 

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -18,27 +18,27 @@ import { TimeSeriesChart } from "svg-time-series";
 
 ```ts
 import { select } from "d3-selection";
-import { TimeSeriesChart } from "svg-time-series";
+import { TimeSeriesChart, IDataSource } from "svg-time-series";
 
 const svg = select("#chart").append("svg").append("g").attr("class", "view");
 const legend = select("#legend");
 
-// example data: [value1, value2]
-const data: [number, number][] = [
-  [10, 12],
-  [11, 13],
-];
+// example data arrays
+const ny = [10, 11];
+const sf = [12, 13];
 
-// The data array must contain at least one entry.
+const source: IDataSource = {
+  startTime: Date.now(),
+  timeStep: 1000, // time step in ms
+  length: ny.length,
+  getNy: (i) => ny[i],
+  getSf: (i) => sf[i],
+};
 
 const chart = new TimeSeriesChart(
   svg,
   legend,
-  Date.now(),
-  1000, // time step in ms
-  data,
-  (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
-  (i, arr) => ({ min: arr[i][1], max: arr[i][1] }),
+  source,
   true, // enable dual Y axes
   () => {},
   () => {},

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart } from "../draw.ts";
+import { TimeSeriesChart, IDataSource } from "../draw.ts";
 
 class Matrix {
   constructor(
@@ -99,14 +99,16 @@ function createChart(data: Array<[number]>) {
     '<span class="chart-legend__time"></span>' +
     '<span class="chart-legend__green_value"></span>';
 
+  const source: IDataSource = {
+    startTime: 0,
+    timeStep: 1,
+    length: data.length,
+    getNy: (i) => data[i][0],
+  };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     select(legend) as any,
-    0,
-    1,
-    data as Array<[number, number?]>,
-    (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
-    undefined,
+    source,
     false,
     () => {},
     () => {},
@@ -180,7 +182,7 @@ describe("chart interaction single-axis", () => {
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData([50]);
+    chart.updateChartWithNewData(50);
     vi.runAllTimers();
 
     onHover(1);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart } from "../draw.ts";
+import { TimeSeriesChart, IDataSource } from "../draw.ts";
 
 class Matrix {
   constructor(
@@ -103,14 +103,17 @@ function createChart(
     '<span class="chart-legend__green_value"></span>' +
     '<span class="chart-legend__blue_value"></span>';
 
+  const source: IDataSource = {
+    startTime: 0,
+    timeStep: 1,
+    length: data.length,
+    getNy: (i) => data[i][0],
+    getSf: (i) => data[i][1],
+  };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     select(legend) as any,
-    0,
-    1,
-    data,
-    (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
-    (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
+    source,
     true,
     () => {},
     () => {},
@@ -201,7 +204,7 @@ describe("chart interaction", () => {
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData([50, 60]);
+    chart.updateChartWithNewData(50, 60);
     vi.runAllTimers();
 
     onHover(1);
@@ -331,17 +334,17 @@ describe("chart interaction", () => {
 
     const mouseMoveHandler = vi.fn();
 
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      getNy: (i) => [0, 1][i],
+      getSf: (i) => [0, 1][i],
+    };
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       select(legend) as any,
-      0,
-      1,
-      [
-        [0, 0],
-        [1, 1],
-      ],
-      (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
-      (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
+      source,
       true,
       () => {},
       mouseMoveHandler,

--- a/svg-time-series/src/chart/legend.single.test.ts
+++ b/svg-time-series/src/chart/legend.single.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { ChartData } from "./data.ts";
+import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import { LegendController } from "./legend.ts";
 
@@ -90,10 +90,13 @@ function createLegend(data: Array<[number]>) {
     '<span class="chart-legend__time"></span>' +
     '<span class="chart-legend__green_value"></span>';
 
-  const chartData = new ChartData(0, 1, data, (i, arr) => ({
-    min: arr[i][0],
-    max: arr[i][0],
-  }));
+  const source: IDataSource = {
+    startTime: 0,
+    timeStep: 1,
+    length: data.length,
+    getNy: (i) => data[i][0],
+  };
+  const chartData = new ChartData(source);
 
   const renderState = setupRender(select(svgEl) as any, chartData, false);
   const controller = new LegendController(

--- a/svg-time-series/src/chart/legend.test.ts
+++ b/svg-time-series/src/chart/legend.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { ChartData } from "./data.ts";
+import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import { LegendController } from "./legend.ts";
 
@@ -94,13 +94,14 @@ function createLegend(
     '<span class="chart-legend__green_value"></span>' +
     '<span class="chart-legend__blue_value"></span>';
 
-  const chartData = new ChartData(
-    0,
-    1,
-    data,
-    (i, arr) => ({ min: arr[i][0], max: arr[i][0] }),
-    (i, arr) => ({ min: arr[i][1]!, max: arr[i][1]! }),
-  );
+  const source: IDataSource = {
+    startTime: 0,
+    timeStep: 1,
+    length: data.length,
+    getNy: (i) => data[i][0],
+    getSf: (i) => data[i][1],
+  };
+  const chartData = new ChartData(source);
 
   const renderState = setupRender(select(svgEl) as any, chartData, true);
   const controller = new LegendController(

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -59,7 +59,8 @@ export class LegendController {
 
   private update() {
     const {
-      values: [greenData, blueData],
+      ny: greenData,
+      sf: blueData,
       timestamp,
     } = this.data.getPoint(this.highlightedDataIdx);
     this.legendTime.text(this.formatTime(timestamp));

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
-import { ChartData } from "./data.ts";
+import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 
 class Matrix {
@@ -65,15 +65,6 @@ beforeAll(() => {
   (globalThis as any).DOMPoint = Point;
 });
 
-const buildNy = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
-  min: arr[i][0],
-  max: arr[i][0],
-});
-const buildSf = (i: number, arr: ReadonlyArray<[number, number?]>) => ({
-  min: arr[i][1]!,
-  max: arr[i][1]!,
-});
-
 function createSvg() {
   const dom = new JSDOM(`<div id="c"><svg><g class="view"></g></svg></div>`, {
     pretendToBeVisual: true,
@@ -88,17 +79,14 @@ function createSvg() {
 describe("setupRender Y-axis modes", () => {
   it("combines series when dualYAxis is false", () => {
     const svg = createSvg();
-    const data = new ChartData(
-      0,
-      1,
-      [
-        [1, 10],
-        [2, 20],
-        [3, 30],
-      ],
-      buildNy,
-      buildSf,
-    );
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      getNy: (i) => [1, 2, 3][i],
+      getSf: (i) => [10, 20, 30][i],
+    };
+    const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     expect(state.scales.yNy.domain()).toEqual([1, 30]);
     expect(state.scales.ySf).toBeUndefined();
@@ -106,17 +94,14 @@ describe("setupRender Y-axis modes", () => {
 
   it("separates scales when dualYAxis is true", () => {
     const svg = createSvg();
-    const data = new ChartData(
-      0,
-      1,
-      [
-        [1, 10],
-        [2, 20],
-        [3, 30],
-      ],
-      buildNy,
-      buildSf,
-    );
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      getNy: (i) => [1, 2, 3][i],
+      getSf: (i) => [10, 20, 30][i],
+    };
+    const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     expect(state.scales.yNy.domain()).toEqual([1, 3]);
     expect(state.scales.ySf!.domain()).toEqual([10, 30]);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,14 +1,14 @@
 import { Selection } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 
-import { ChartData, IMinMax } from "./chart/data.ts";
+import { ChartData, IMinMax, IDataSource } from "./chart/data.ts";
 import { setupRender, refreshChart } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
 import { LegendController } from "./chart/legend.ts";
 import { ZoomState } from "./chart/zoomState.ts";
 
-export type { IMinMax } from "./chart/data.ts";
+export type { IMinMax, IDataSource } from "./chart/data.ts";
 
 export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
@@ -25,17 +25,7 @@ export class TimeSeriesChart {
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
     legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
-    startTime: number,
-    timeStep: number,
-    data: Array<[number, number?]>,
-    buildSegmentTreeTupleNy: (
-      index: number,
-      elements: ReadonlyArray<[number, number?]>,
-    ) => IMinMax,
-    buildSegmentTreeTupleSf?: (
-      index: number,
-      elements: ReadonlyArray<[number, number?]>,
-    ) => IMinMax,
+    data: IDataSource,
     dualYAxis = false,
     zoomHandler: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
@@ -44,13 +34,7 @@ export class TimeSeriesChart {
     formatTime: (timestamp: number) => string = (timestamp) =>
       new Date(timestamp).toLocaleString(),
   ) {
-    this.data = new ChartData(
-      startTime,
-      timeStep,
-      data,
-      buildSegmentTreeTupleNy,
-      buildSegmentTreeTupleSf,
-    );
+    this.data = new ChartData(data);
 
     this.state = setupRender(svg, this.data, dualYAxis);
 
@@ -86,8 +70,8 @@ export class TimeSeriesChart {
     return { zoom: this.zoom, onHover: this.onHover };
   }
 
-  public updateChartWithNewData(newData: [number, number?]) {
-    this.data.append(newData);
+  public updateChartWithNewData(ny: number, sf?: number) {
+    this.data.append(ny, sf);
     this.drawNewData();
   }
 


### PR DESCRIPTION
## Summary
- introduce IDataSource so consumers provide series without segment tree details
- refactor chart to build segment trees internally and expose simpler APIs
- document new data source pattern and update samples/tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bde8ca18832ba8c9fa6e767fd2ee