### PR TITLE
refactor: use d3 scale types

### DIFF
--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -5,15 +5,13 @@
   Left,
 }
 
-const slice = Array.prototype.slice;
-
 const id = <T>(x: T) => x;
 
 const formatIdentity = (d: number | Date) => `${d}`;
 
-function center<D>(scale: Scale<D>) {
+function center(scale: ScaleType) {
   const width = (scale.bandwidth?.() ?? 0) / 2;
-  return (d: D) => scale(d) + width;
+  return (d: number | Date) => scale(d as any) + width;
 }
 
 type PositionFn<D> = (d: D) => number;
@@ -29,10 +27,13 @@ function translateY<D>(scale0: PositionFn<D>, scale1: PositionFn<D>, d: D) {
 }
 
 import { Selection } from "d3-selection";
+import type { ScaleContinuousNumeric, ScaleLinear, ScaleTime } from "d3-scale";
 
-import { Scale } from "./scale";
-
-type ScaleType = Scale<number | Date>;
+type ScaleType = (
+  | ScaleContinuousNumeric<number, number>
+  | ScaleTime<number, number>
+  | ScaleLinear<number, number>
+) & { bandwidth?: () => number };
 
 export class MyAxis {
   private tickArguments: number[];

--- a/svg-time-series/src/scale.ts
+++ b/svg-time-series/src/scale.ts
@@ -1,8 +1,0 @@
-export interface Scale<Domain> {
-  (value: Domain): number;
-  ticks?: (count?: number) => ReadonlyArray<Domain>;
-  tickFormat?: (count?: number, specifier?: string) => (d: any) => string;
-  bandwidth?: () => number;
-  domain: () => ReadonlyArray<Domain>;
-  copy: () => Scale<Domain>;
-}


### PR DESCRIPTION
## Summary
- remove custom Scale interface and use d3-scale types
- simplify axis to accept ScaleTime/ScaleLinear/ScaleContinuousNumeric

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c84cc9f8832ba2e104bd3ff280bd