### PR TITLE
refactor: remove unused dotScaleMatrix

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -56,18 +56,6 @@ export class ViewportTransform {
     return this.toModelPoint(0, y).y;
   }
 
-  public dotScaleMatrix(dotRadius: number) {
-    const inv = this.composedMatrix.inverse();
-    const tp0 = new DOMPoint(0, 0).matrixTransform(inv);
-    const tp1 = new DOMPoint(dotRadius, dotRadius).matrixTransform(inv);
-    const dotRadiusXModel = tp0.x - tp1.x;
-    const dotRadiusYModel = tp0.y - tp1.y;
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    return svg
-      .createSVGMatrix()
-      .scaleNonUniform(dotRadiusXModel, dotRadiusYModel);
-  }
-
   public fromScreenToModelBasisX(b: AR1Basis) {
     const transformPoint = (x: number) => this.toModelPoint(x, 0).x;
     const [p1, p2] = b.toArr().map(transformPoint);

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -43,7 +43,6 @@ vi.mock("../ViewportTransform.ts", () => ({
     fromScreenToModelBasisX = vi.fn(
       () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
     );
-    dotScaleMatrix = vi.fn(() => new Matrix());
     onViewPortResize = vi.fn();
     onReferenceViewWindowResize = vi.fn();
   },

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -43,7 +43,6 @@ vi.mock("../ViewportTransform.ts", () => ({
     fromScreenToModelBasisX = vi.fn(
       () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
     );
-    dotScaleMatrix = vi.fn(() => new Matrix());
     onViewPortResize = vi.fn();
     onReferenceViewWindowResize = vi.fn();
   },

--- a/svg-time-series/src/chart/legend.single.test.ts
+++ b/svg-time-series/src/chart/legend.single.test.ts
@@ -45,7 +45,6 @@ vi.mock("../ViewportTransform.ts", () => ({
     fromScreenToModelBasisX = vi.fn(
       () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
     );
-    dotScaleMatrix = vi.fn(() => new Matrix());
     onViewPortResize = vi.fn();
     onReferenceViewWindowResize = vi.fn();
   },

--- a/svg-time-series/src/chart/legend.test.ts
+++ b/svg-time-series/src/chart/legend.test.ts
@@ -45,7 +45,6 @@ vi.mock("../ViewportTransform.ts", () => ({
     fromScreenToModelBasisX = vi.fn(
       () => new AR1Basis(0, Math.max(currentDataLength - 1, 0)),
     );
-    dotScaleMatrix = vi.fn(() => new Matrix());
     onViewPortResize = vi.fn();
     onReferenceViewWindowResize = vi.fn();
   },


### PR DESCRIPTION
## Summary
- remove dead `dotScaleMatrix` helper from `ViewportTransform`
- drop `dotScaleMatrix` mocks from chart tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c9ed9d5c832b8b0e481d2c6829bf