### PR TITLE
chore: check formatting in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-npm run lint && npm run typecheck && npm test
+npm run format:check && npm run lint && npm run typecheck && npm test


### PR DESCRIPTION
## Summary
- run format:check as part of Husky pre-commit hook to enforce Prettier formatting before linting and tests

## Testing
- `CI=1 git commit -am "chore: check formatting in pre-commit"`


------
https://chatgpt.com/codex/tasks/task_e_6894d2e63068832bb12c39384595c51c