### PR TITLE
feat: add segment tree benchmarks

### DIFF
--- a/segment-tree-rmq/bench/segmentTree.bench.ts
+++ b/segment-tree-rmq/bench/segmentTree.bench.ts
@@ -1,0 +1,31 @@
+import { bench, describe } from "vitest";
+import { SegmentTree } from "../src/index.ts";
+
+describe("SegmentTree performance", () => {
+  const size = 100_000;
+  const data = Array.from({ length: size }, () => Math.random());
+  const tree = new SegmentTree<number>(data, (a, b) => a + b, 0);
+
+  const updateIndices = Array.from({ length: 1000 }, () =>
+    Math.floor(Math.random() * size),
+  );
+  let ui = 0;
+
+  bench("update", () => {
+    tree.update(updateIndices[ui], Math.random());
+    ui = (ui + 1) % updateIndices.length;
+  });
+
+  const queryRanges = Array.from({ length: 1000 }, () => {
+    const l = Math.floor(Math.random() * size);
+    const r = l + Math.floor(Math.random() * (size - l));
+    return [l, r] as const;
+  });
+  let qi = 0;
+
+  bench("query", () => {
+    const [l, r] = queryRanges[qi];
+    tree.query(l, r);
+    qi = (qi + 1) % queryRanges.length;
+  });
+});

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",


### PR DESCRIPTION
## Summary
- add Vitest bench for `SegmentTree` update/query
- expose `bench:segment-tree` script to run benchmarks

## Testing
- `npm run bench:segment-tree --workspace=segment-tree-rmq`


------
https://chatgpt.com/codex/tasks/task_e_6894d19bbabc832ba27de9438f716e95