### PR TITLE
Use requestAnimationFrame for benchmark frame measurement

### DIFF
--- a/samples/benchmarks/axis-draw-transform/index.ts
+++ b/samples/benchmarks/axis-draw-transform/index.ts
@@ -1,6 +1,6 @@
 import { select, selectAll } from "d3-selection";
 
-import { measureAll } from "../bench.ts";
+import { measure, measureOnce } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 
 function makeChart() {
@@ -8,4 +8,11 @@ function makeChart() {
 }
 
 selectAll("svg").each(makeChart);
-measureAll();
+
+measure(3, (fps) => {
+  document.getElementById("fps").textContent = fps;
+});
+
+measureOnce(60, (fps) => {
+  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+});

--- a/samples/benchmarks/bench.ts
+++ b/samples/benchmarks/bench.ts
@@ -1,17 +1,7 @@
 import { csv } from "d3-request";
 import { timer as runTimer } from "d3-timer";
 
-import { measure, measureOnce } from "../measure.ts";
-
-export function measureAll(): void {
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
-  });
-
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
-  });
-}
+export { measure, measureOnce } from "../measure.ts";
 
 export function onCsv(f: (csv: number[][]) => void): void {
   csv("ny-vs-sf.csv")

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -1,5 +1,5 @@
 import { TimeSeriesChart, IDataSource } from "svg-time-series";
-import { measureAll, onCsv, animateBench } from "../bench.ts";
+import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
 import { select, Selection } from "d3-selection";
 
 onCsv((data: [number, number][]) => {
@@ -36,5 +36,11 @@ onCsv((data: [number, number][]) => {
     j++;
   });
 
-  measureAll();
+  measure(3, (fps) => {
+    document.getElementById("fps").textContent = fps;
+  });
+
+  measureOnce(60, (fps) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  });
 });

--- a/samples/benchmarks/demo2-without-grid/index.ts
+++ b/samples/benchmarks/demo2-without-grid/index.ts
@@ -1,4 +1,4 @@
-import * as measureFPS from "../../measure.ts";
+import { measure, measureOnce } from "../bench.ts";
 import * as common from "./common.ts";
 import { csv } from "d3-request";
 import { select, selectAll } from "d3-selection";
@@ -28,6 +28,10 @@ csv("ny-vs-sf.csv")
     }
   });
 
-measureFPS.measure(3, (fps: any) => {
+measure(3, (fps: string) => {
   document.getElementById("fps").textContent = fps;
+});
+
+measureOnce(60, (fps: string) => {
+  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
 });

--- a/samples/benchmarks/path-draw-transform-d3/index.ts
+++ b/samples/benchmarks/path-draw-transform-d3/index.ts
@@ -1,7 +1,7 @@
 ﻿import { select, selectAll } from "d3-selection";
 import { line } from "d3-shape";
 
-import { measureAll, onCsv } from "../bench.ts";
+import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 
 onCsv((data: number[][]) => {
@@ -21,5 +21,12 @@ onCsv((data: number[][]) => {
   selectAll("svg").each(function () {
     return new TimeSeriesChart(select(this), data.length);
   });
-  measureAll();
+
+  measure(3, (fps) => {
+    document.getElementById("fps").textContent = fps;
+  });
+
+  measureOnce(60, (fps) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  });
 });

--- a/samples/benchmarks/path-recreate-dom/index.ts
+++ b/samples/benchmarks/path-recreate-dom/index.ts
@@ -1,5 +1,5 @@
 ﻿import { select, selectAll } from "d3-selection";
-import { measureAll, onCsv } from "../bench.ts";
+import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 
 onCsv((data) => {
@@ -78,5 +78,11 @@ onCsv((data) => {
     return new TimeSeriesChart(select(this), dataLength, drawLine, i);
   });
 
-  measureAll();
+  measure(3, (fps) => {
+    document.getElementById("fps").textContent = fps;
+  });
+
+  measureOnce(60, (fps) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  });
 });

--- a/samples/benchmarks/path-segment-recreate-dom/index.ts
+++ b/samples/benchmarks/path-segment-recreate-dom/index.ts
@@ -1,5 +1,5 @@
-﻿import { Selection, select, selectAll } from "d3-selection";
-import { measureAll, onCsv } from "../bench.ts";
+import { Selection, select, selectAll } from "d3-selection";
+import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 
 onCsv((data) => {
@@ -119,5 +119,11 @@ onCsv((data) => {
     return new TimeSeriesChart(svg, dataLength, drawLine, i);
   });
 
-  measureAll();
+  measure(3, (fps) => {
+    document.getElementById("fps").textContent = fps;
+  });
+
+  measureOnce(60, (fps) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  });
 });

--- a/samples/benchmarks/segment-tree-queries/index.ts
+++ b/samples/benchmarks/segment-tree-queries/index.ts
@@ -1,7 +1,7 @@
 import { select, selectAll } from "d3-selection";
 import { line } from "d3-shape";
 
-import { measureAll, onCsv } from "../bench.ts";
+import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 
 onCsv((data: number[][]) => {
@@ -22,5 +22,12 @@ onCsv((data: number[][]) => {
   selectAll("svg").each(function () {
     return new TimeSeriesChart(select(this), data);
   });
-  measureAll();
+
+  measure(3, (fps) => {
+    document.getElementById("fps").textContent = fps;
+  });
+
+  measureOnce(60, (fps) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  });
 });

--- a/samples/benchmarks/svg-path-recreation-d3/index.ts
+++ b/samples/benchmarks/svg-path-recreation-d3/index.ts
@@ -1,6 +1,6 @@
 ﻿import { select, selectAll } from "d3-selection";
 import { line } from "d3-shape";
-import { measureAll, onCsv } from "../bench.ts";
+import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 
 onCsv((data) => {
@@ -26,5 +26,11 @@ onCsv((data) => {
     return new TimeSeriesChart(select(this), dataLength, drawLine);
   });
 
-  measureAll();
+  measure(3, (fps) => {
+    document.getElementById("fps").textContent = fps;
+  });
+
+  measureOnce(60, (fps) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  });
 });

--- a/samples/measure.ts
+++ b/samples/measure.ts
@@ -1,23 +1,41 @@
-﻿import { interval, timer, timeout } from "d3-timer";
+export interface FrameCounter {
+  read(): number;
+  reset(): void;
+  stop(): void;
+}
+
+export function startFrameCounter(): FrameCounter {
+  let count = 0;
+  let handle = 0;
+
+  const tick = () => {
+    count++;
+    handle = requestAnimationFrame(tick);
+  };
+
+  handle = requestAnimationFrame(tick);
+
+  return {
+    read: () => count,
+    reset: () => {
+      count = 0;
+    },
+    stop: () => cancelAnimationFrame(handle),
+  };
+}
 
 export function measure(sec: number, drawFPS: (fps: string) => void): void {
-  let ctr = 0;
-
-  timer(() => ctr++);
-
-  interval(() => {
-    drawFPS((ctr / sec).toPrecision(3));
-    ctr = 0;
+  const counter = startFrameCounter();
+  setInterval(() => {
+    drawFPS((counter.read() / sec).toPrecision(3));
+    counter.reset();
   }, 1000 * sec);
 }
 
 export function measureOnce(sec: number, drawFPS: (fps: string) => void): void {
-  let ctr = 0;
-
-  timer(() => ctr++);
-
-  timeout(() => {
-    drawFPS((ctr / sec).toPrecision(3));
-    ctr = 0;
+  const counter = startFrameCounter();
+  setTimeout(() => {
+    drawFPS((counter.read() / sec).toPrecision(3));
+    counter.stop();
   }, 1000 * sec);
 }

--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -1,6 +1,6 @@
 import { select } from "d3-selection";
 import { range } from "d3-array";
-import { measureAll } from "../../benchmarks/bench.ts";
+import { measure, measureOnce } from "../../benchmarks/bench.ts";
 import { zoom, ZoomTransform } from "d3-zoom";
 import { betweenBasesAR1 } from "../../../svg-time-series/src/math/affine.ts";
 import {
@@ -129,7 +129,13 @@ function drawProc(f: (time: number) => void) {
   };
 }
 
-measureAll();
+measure(3, (fps) => {
+  document.getElementById("fps").textContent = fps;
+});
+
+measureOnce(60, (fps) => {
+  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+});
 
 function test(svgNode: SVGSVGElement, viewNode: SVGGElement, width: number) {
   const id = svgNode.createSVGMatrix();


### PR DESCRIPTION
## Summary
- track rendered frames with a requestAnimationFrame-based counter
- expose frame counting helpers and re-export them from benchmark utilities
- update samples and benchmarks to use the new measurement functions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d188e428832bb61fa2cea9d6b027