### PR TITLE
feat: allow multiple series in data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ const source: IDataSource = {
   startTime,
   timeStep,
   length: data.length,
-  getNy: (i) => data[i][0],
-  getSf: (i) => data[i][1],
+  getNy: (i) => [data[i][0]],
+  getSf: (i) => [data[i][1]],
 };
 
 const chart = new TimeSeriesChart(
@@ -64,6 +64,10 @@ const chart = new TimeSeriesChart(
 );
 ```
 
+The `getNy` and `getSf` callbacks return arrays of numbers so a data source
+can supply multiple lines for each axis. The current chart implementation uses
+only the first value from each array.
+
 The third argument creates a legend controller, letting you customize how
 legend entries are rendered, including timestamp formatting.
 
@@ -74,8 +78,8 @@ const singleSource: IDataSource = {
   startTime,
   timeStep,
   length: data.length,
-  getNy: (i) => data[i][0],
-  getSf: (i) => data[i][1],
+  getNy: (i) => [data[i][0]],
+  getSf: (i) => [data[i][1]],
 };
 
 const chartSingle = new TimeSeriesChart(

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -22,8 +22,8 @@ onCsv((data: [number, number][]) => {
     startTime: Date.now(),
     timeStep: 86400000,
     length: data.length,
-    getNy: (i) => data[i][0],
-    getSf: (i) => data[i][1],
+    getNy: (i) => [data[i][0]],
+    getSf: (i) => [data[i][1]],
   };
   const chart = new TimeSeriesChart(
     svg,

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -30,8 +30,8 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
       startTime: Date.now(),
       timeStep: 86400000,
       length: data.length,
-      getNy: (i) => data[i][0],
-      getSf: (i) => data[i][1],
+      getNy: (i) => [data[i][0]],
+      getSf: (i) => [data[i][1]],
     };
     const chart = new TimeSeriesChart(
       svg,

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -32,8 +32,8 @@ const source: IDataSource = {
   startTime: Date.now(),
   timeStep: 1000, // time step in ms
   length: ny.length,
-  getNy: (i) => ny[i],
-  getSf: (i) => sf[i],
+  getNy: (i) => [ny[i]],
+  getSf: (i) => [sf[i]],
 };
 
 const chart = new TimeSeriesChart(
@@ -48,6 +48,9 @@ const chart = new TimeSeriesChart(
   () => {},
 );
 ```
+
+`getNy` and `getSf` return arrays, allowing a data source to provide multiple
+series per axis. At present, only the first value in each array is rendered.
 
 The third argument lets you supply a custom legend controller. See
 `samples/LegendController.ts` for a reference implementation.

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -7,8 +7,8 @@ describe("ChartData", () => {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    getNy: (i) => data[i][0],
-    getSf: (i) => data[i][1]!,
+    getNy: (i) => [data[i][0]],
+    getSf: (i) => [data[i][1]!],
   });
 
   it("throws if constructed with empty data", () => {
@@ -16,7 +16,7 @@ describe("ChartData", () => {
       startTime: 0,
       timeStep: 1,
       length: 0,
-      getNy: () => 0,
+      getNy: () => [0],
     };
     expect(() => new ChartData(source)).toThrow(/non-empty data array/);
   });
@@ -208,7 +208,7 @@ describe("ChartData", () => {
         startTime: 0,
         timeStep: 1,
         length: 2,
-        getNy: (i) => [0, 1][i],
+        getNy: (i) => [[0, 1][i]],
       };
       const cd = new ChartData(source);
       expect(cd.treeSf).toBeUndefined();

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -28,8 +28,8 @@ export interface IDataSource {
   readonly startTime: number;
   readonly timeStep: number;
   readonly length: number;
-  getNy(index: number): number;
-  getSf?(index: number): number;
+  getNy(index: number): number[];
+  getSf?(index: number): number[];
 }
 
 export class ChartData {
@@ -53,8 +53,8 @@ export class ChartData {
     this.hasSf = typeof source.getSf === "function";
     this.data = new Array(source.length);
     for (let i = 0; i < source.length; i++) {
-      const ny = source.getNy(i);
-      const sf = this.hasSf ? source.getSf!(i) : undefined;
+      const ny = source.getNy(i)[0];
+      const sf = this.hasSf ? source.getSf!(i)[0] : undefined;
       this.data[i] = [ny, sf];
     }
     this.idxToTime = betweenTBasesAR1(

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -103,7 +103,7 @@ function createChart(data: Array<[number]>) {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    getNy: (i) => data[i][0],
+    getNy: (i) => [data[i][0]],
   };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -107,8 +107,8 @@ function createChart(
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    getNy: (i) => data[i][0],
-    getSf: (i) => data[i][1],
+    getNy: (i) => [data[i][0]],
+    getSf: (i) => [data[i][1]],
   };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
@@ -338,8 +338,8 @@ describe("chart interaction", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      getNy: (i) => [0, 1][i],
-      getSf: (i) => [0, 1][i],
+      getNy: (i) => [[0, 1][i]],
+      getSf: (i) => [[0, 1][i]],
     };
     const chart = new TimeSeriesChart(
       select(svgEl) as any,

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -83,8 +83,8 @@ describe("setupRender Y-axis modes", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      getNy: (i) => [1, 2, 3][i],
-      getSf: (i) => [10, 20, 30][i],
+      getNy: (i) => [[1, 2, 3][i]],
+      getSf: (i) => [[10, 20, 30][i]],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
@@ -98,8 +98,8 @@ describe("setupRender Y-axis modes", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      getNy: (i) => [1, 2, 3][i],
-      getSf: (i) => [10, 20, 30][i],
+      getNy: (i) => [[1, 2, 3][i]],
+      getSf: (i) => [[10, 20, 30][i]],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);


### PR DESCRIPTION
## Summary
- allow `IDataSource` to return multiple Y1 and Y2 series
- document array-based data source values and note current single-series limitation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894d73e7e9c832b894cea59fb13e327