### PR TITLE
refactor: iterate series uniformly

### DIFF
--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -105,14 +105,14 @@ export function renderPaths(
   state: RenderState,
   dataArr: Array<[number, number?]>,
 ) {
-  const drawLine = (cityIdx: number) =>
-    line<[number, number?]>()
+  const paths = state.paths.path.nodes() as SVGPathElement[];
+  let cityIdx = 0;
+  for (const path of paths) {
+    const drawLine = line<[number, number?]>()
       .defined((d) => !(isNaN(d[cityIdx]!) || d[cityIdx] == null))
       .x((_, i) => i)
       .y((d) => d[cityIdx]!);
-
-  state.paths.path.attr(
-    "d",
-    (cityIndex: number) => drawLine(cityIndex)(dataArr) ?? "",
-  );
+    path.setAttribute("d", drawLine(dataArr) ?? "");
+    cityIdx++;
+  }
 }


### PR DESCRIPTION
## Summary
- iterate Y-series configuration via unified arrays
- refresh all chart series and axes in for-of loops
- render multiple paths by looping through path nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894dbaa59f8832b90d2419573efbe4f