### PR TITLE
Add cancelable drawProc and cancel ZoomState refresh on destroy

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -20,6 +20,7 @@ export class LegendController implements ILegendController {
 
   private highlightedDataIdx = 0;
   private scheduleRefresh: () => void;
+  private cancelRefresh: () => void;
 
   constructor(
     legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
@@ -43,9 +44,11 @@ export class LegendController implements ILegendController {
     this.highlightedGreenDot = makeDot();
     this.highlightedBlueDot = state.paths.viewSf ? makeDot() : null;
 
-    this.scheduleRefresh = drawProc(() => {
+    const { wrapped, cancel } = drawProc(() => {
       this.update();
     });
+    this.scheduleRefresh = wrapped;
+    this.cancelRefresh = cancel;
   }
 
   public onHover = (idx: number) => {
@@ -99,6 +102,7 @@ export class LegendController implements ILegendController {
   }
 
   public destroy = () => {
+    this.cancelRefresh();
     this.highlightedGreenDot.remove();
     this.highlightedBlueDot?.remove();
   };

--- a/svg-time-series/src/chart/drawProc.test.ts
+++ b/svg-time-series/src/chart/drawProc.test.ts
@@ -13,7 +13,7 @@ describe("drawProc", () => {
   it("executes underlying function only once", () => {
     vi.useFakeTimers();
     const fn = vi.fn();
-    const wrapped = drawProc(fn);
+    const { wrapped } = drawProc(fn);
 
     wrapped();
     wrapped();
@@ -29,7 +29,7 @@ describe("drawProc", () => {
   it("uses latest parameters when called multiple times", () => {
     vi.useFakeTimers();
     const fn = vi.fn();
-    const wrapped = drawProc(fn);
+    const { wrapped } = drawProc(fn);
 
     wrapped("first");
     wrapped("second");
@@ -41,5 +41,18 @@ describe("drawProc", () => {
 
     expect(fn).toHaveBeenCalledTimes(1);
     expect(fn).toHaveBeenCalledWith("third");
+  });
+
+  it("cancels scheduled execution", () => {
+    vi.useFakeTimers();
+    const fn = vi.fn();
+    const { wrapped, cancel } = drawProc(fn);
+
+    wrapped();
+    cancel();
+
+    vi.runAllTimers();
+
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { select } from "d3-selection";
 
 vi.mock("d3-zoom", () => {
@@ -29,8 +29,14 @@ vi.mock("d3-zoom", () => {
 
 import { ZoomState } from "./zoomState.ts";
 
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+});
+
 describe("ZoomState.destroy", () => {
   it("removes wheel and pointer handlers", () => {
+    vi.useFakeTimers();
     const svg = document.createElementNS(
       "http://www.w3.org/2000/svg",
       "svg",
@@ -54,5 +60,29 @@ describe("ZoomState.destroy", () => {
     rect.node()?.dispatchEvent(new Event("wheel", { bubbles: true }));
     rect.node()?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
     expect(zoomCb).not.toHaveBeenCalled();
+  });
+
+  it("cancels pending refresh", () => {
+    vi.useFakeTimers();
+    const svg = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "svg",
+    ) as any;
+    svg.width = { baseVal: { value: 10 } };
+    svg.height = { baseVal: { value: 10 } };
+    const rect = select(svg).append("rect");
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny: { onZoomPan: vi.fn() } },
+    };
+    const refresh = vi.fn();
+    const zs = new ZoomState(rect as any, state, refresh);
+
+    zs.refresh();
+    zs.destroy();
+
+    vi.runAllTimers();
+
+    expect(refresh).not.toHaveBeenCalled();
   });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -13,6 +13,7 @@ export class ZoomState {
   public zoomBehavior: ZoomBehavior<SVGRectElement, unknown>;
   private currentPanZoomTransformState: ZoomTransform | null = null;
   private scheduleRefresh: () => void;
+  private cancelRefresh: () => void;
   private internalEvent = false;
 
   constructor(
@@ -35,7 +36,7 @@ export class ZoomState {
 
     this.zoomArea.call(this.zoomBehavior);
 
-    this.scheduleRefresh = drawProc(() => {
+    const { wrapped, cancel } = drawProc(() => {
       if (this.currentPanZoomTransformState != null) {
         this.internalEvent = true;
         this.zoomBehavior.transform(
@@ -46,6 +47,8 @@ export class ZoomState {
       }
       this.refreshChart();
     });
+    this.scheduleRefresh = wrapped;
+    this.cancelRefresh = cancel;
   }
 
   public zoom = (
@@ -74,6 +77,7 @@ export class ZoomState {
   };
 
   public destroy = () => {
+    this.cancelRefresh();
     this.zoomArea.on(".zoom", null);
     this.zoomBehavior.on("zoom", null);
   };

--- a/svg-time-series/src/utils/drawProc.ts
+++ b/svg-time-series/src/utils/drawProc.ts
@@ -2,18 +2,33 @@ import { timeout as runTimeout } from "d3-timer";
 
 export function drawProc<F extends (...args: unknown[]) => void>(
   f: F,
-): (...args: Parameters<F>) => void {
+): {
+  wrapped: (...args: Parameters<F>) => void;
+  cancel: () => void;
+} {
   let requested = false;
   let latestParams: Parameters<F>;
+  let timer: ReturnType<typeof runTimeout> | null = null;
 
-  return (...params: Parameters<F>) => {
+  const wrapped = (...params: Parameters<F>) => {
     latestParams = params;
     if (!requested) {
       requested = true;
-      runTimeout(() => {
+      timer = runTimeout(() => {
         requested = false;
+        timer = null;
         f(...latestParams);
       });
     }
   };
+
+  const cancel = () => {
+    if (timer) {
+      timer.stop();
+      timer = null;
+    }
+    requested = false;
+  };
+
+  return { wrapped, cancel };
 }


### PR DESCRIPTION
## Summary
- make `drawProc` return a wrapper with a `cancel` method to stop pending timeouts
- store and invoke `cancel` in `ZoomState.destroy` so queued refreshes are cleared
- test that no refresh occurs after a `ZoomState` is destroyed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894de4b53ec832b82d2b3c0ed7fe8ce