### PR TITLE
chore: add bench scripts to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "npm run lint --workspaces --if-present",
     "typecheck": "npm run typecheck --workspaces --if-present",
     "test": "vitest run",
+    "bench": "npm run bench --workspaces --if-present",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
     "commitlint": "commitlint --from=HEAD~1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -5,7 +5,8 @@
     "dev": "vite",
     "build": "vite build",
     "typecheck": "tsc --noEmit",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "bench": "echo \"No benchmarks defined\""
   },
   "type": "module",
   "author": "",

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -13,7 +13,8 @@
     "build": "tsc",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts"
+    "bench": "npm run bench:segment-tree",
+    "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts --run"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -39,6 +39,7 @@
     "build": "tsc && vite build",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "bench": "echo \"No benchmarks defined\""
   }
 }


### PR DESCRIPTION
## Summary
- add top-level `bench` script and workspace equivalents
- provide stub benchmark scripts for packages lacking benchmarks
- run actual segment tree benchmark non-interactively

## Testing
- `npm run bench`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e01c8df8832bab52ff0147754953