### PR TITLE
feat: add benchmarks for SVG rendering and transforms

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { bench, describe } from "vitest";
+import { select } from "d3-selection";
+import { renderPaths } from "../src/chart/render/utils.ts";
+import type { RenderState } from "../src/chart/render.ts";
+
+describe("renderPaths performance", () => {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  const pathSelection = select(svg)
+    .selectAll("path")
+    .data([0, 1])
+    .enter()
+    .append("path");
+
+  const state = { paths: { path: pathSelection } } as unknown as RenderState;
+
+  const sizes = [100, 1_000, 10_000];
+  const datasets = sizes.map((n) =>
+    Array.from({ length: n }, (_, i) => [i, i] as [number, number]),
+  );
+
+  sizes.forEach((size, idx) => {
+    const data = datasets[idx];
+    bench(`size ${size}`, () => {
+      renderPaths(state, data);
+    });
+  });
+});

--- a/svg-time-series/bench/viewportTransform.bench.ts
+++ b/svg-time-series/bench/viewportTransform.bench.ts
@@ -1,0 +1,94 @@
+import { bench, describe } from "vitest";
+import { zoomIdentity } from "d3-zoom";
+import { ViewportTransform } from "../src/ViewportTransform.ts";
+import { AR1Basis, DirectProductBasis } from "../src/math/affine.ts";
+
+class Matrix {
+  constructor(
+    public a = 1,
+    public b = 0,
+    public c = 0,
+    public d = 1,
+    public e = 0,
+    public f = 0,
+  ) {}
+
+  multiply(m: Matrix) {
+    return new Matrix(
+      this.a * m.a + this.c * m.b,
+      this.b * m.a + this.d * m.b,
+      this.a * m.c + this.c * m.d,
+      this.b * m.c + this.d * m.d,
+      this.a * m.e + this.c * m.f + this.e,
+      this.b * m.e + this.d * m.f + this.f,
+    );
+  }
+
+  translate(tx: number, ty: number) {
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
+  }
+
+  scale(sx: number, sy: number) {
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
+  }
+
+  inverse() {
+    const det = this.a * this.d - this.b * this.c;
+    return new Matrix(
+      this.d / det,
+      -this.b / det,
+      -this.c / det,
+      this.a / det,
+      (this.c * this.f - this.d * this.e) / det,
+      (this.b * this.e - this.a * this.f) / det,
+    );
+  }
+}
+
+class Point {
+  constructor(
+    public x = 0,
+    public y = 0,
+  ) {}
+
+  matrixTransform(m: Matrix) {
+    return new Point(
+      this.x * m.a + this.y * m.c + m.e,
+      this.x * m.b + this.y * m.d + m.f,
+    );
+  }
+}
+
+// polyfill DOMMatrix and DOMPoint for Node environment
+(globalThis as any).DOMMatrix = Matrix;
+(globalThis as any).DOMPoint = Point;
+
+describe("ViewportTransform performance", () => {
+  const vt = new ViewportTransform();
+  vt.onViewPortResize(
+    DirectProductBasis.fromProjections(
+      new AR1Basis(0, 100),
+      new AR1Basis(0, 100),
+    ),
+  );
+  vt.onReferenceViewWindowResize(
+    DirectProductBasis.fromProjections(
+      new AR1Basis(0, 10),
+      new AR1Basis(0, 10),
+    ),
+  );
+
+  const t = zoomIdentity.translate(10, 0).scale(2);
+
+  bench("onZoomPan", () => {
+    vt.onZoomPan(t);
+  });
+
+  bench("fromScreenToModelX", () => {
+    vt.fromScreenToModelX(50);
+  });
+
+  bench("fromScreenToModelBasisX", () => {
+    vt.fromScreenToModelBasisX(new AR1Basis(20, 40));
+  });
+});

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -39,6 +39,7 @@
     "build": "tsc && vite build",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "bench:svg": "vitest bench bench/*.bench.ts"
   }
 }


### PR DESCRIPTION
## Summary
- benchmark renderPaths across varying data sizes
- measure ViewportTransform methods like onZoomPan and fromScreenToModelX
- add bench:svg script to run Vitest benchmarks

## Testing
- `npm run format`
- `npm run bench:svg --workspace=svg-time-series`


------
https://chatgpt.com/codex/tasks/task_e_6894e0187bc4832b92c64c2536485255