### PR TITLE
feat(samples): add performance-based fps utility

### DIFF
--- a/samples/benchmarks/axis-draw-transform/index.ts
+++ b/samples/benchmarks/axis-draw-transform/index.ts
@@ -9,10 +9,10 @@ function makeChart() {
 
 selectAll("svg").each(makeChart);
 
-measure(3, (fps) => {
-  document.getElementById("fps").textContent = fps;
+measure(3, ({ fps }) => {
+  document.getElementById("fps").textContent = fps.toFixed(2);
 });
 
-measureOnce(60, (fps) => {
-  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+measureOnce(60, ({ fps }) => {
+  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
 });

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -41,11 +41,11 @@ onCsv((data: [number, number][]) => {
     j++;
   });
 
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  measureOnce(60, ({ fps }) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
   });
 });

--- a/samples/benchmarks/demo2-without-grid/index.ts
+++ b/samples/benchmarks/demo2-without-grid/index.ts
@@ -28,10 +28,10 @@ csv("../../demos/ny-vs-sf.csv")
     }
   });
 
-measure(3, (fps: string) => {
-  document.getElementById("fps").textContent = fps;
+measure(3, ({ fps }) => {
+  document.getElementById("fps").textContent = fps.toFixed(2);
 });
 
-measureOnce(60, (fps: string) => {
-  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+measureOnce(60, ({ fps }) => {
+  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
 });

--- a/samples/benchmarks/path-draw-transform-d3/index.ts
+++ b/samples/benchmarks/path-draw-transform-d3/index.ts
@@ -22,11 +22,11 @@ onCsv((data: number[][]) => {
     return new TimeSeriesChart(select(this), data.length);
   });
 
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  measureOnce(60, ({ fps }) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
   });
 });

--- a/samples/benchmarks/path-recreate-dom/index.ts
+++ b/samples/benchmarks/path-recreate-dom/index.ts
@@ -78,11 +78,11 @@ onCsv((data) => {
     return new TimeSeriesChart(select(this), dataLength, drawLine, i);
   });
 
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  measureOnce(60, ({ fps }) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
   });
 });

--- a/samples/benchmarks/path-segment-recreate-dom/index.ts
+++ b/samples/benchmarks/path-segment-recreate-dom/index.ts
@@ -119,11 +119,11 @@ onCsv((data) => {
     return new TimeSeriesChart(svg, dataLength, drawLine, i);
   });
 
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  measureOnce(60, ({ fps }) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
   });
 });

--- a/samples/benchmarks/segment-tree-queries/index.ts
+++ b/samples/benchmarks/segment-tree-queries/index.ts
@@ -23,11 +23,11 @@ onCsv((data: number[][]) => {
     return new TimeSeriesChart(select(this), data);
   });
 
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  measureOnce(60, ({ fps }) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
   });
 });

--- a/samples/benchmarks/svg-path-recreation-d3/index.ts
+++ b/samples/benchmarks/svg-path-recreation-d3/index.ts
@@ -26,11 +26,11 @@ onCsv((data) => {
     return new TimeSeriesChart(select(this), dataLength, drawLine);
   });
 
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 
-  measureOnce(60, (fps) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+  measureOnce(60, ({ fps }) => {
+    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
   });
 });

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -52,8 +52,8 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
     charts.forEach((c) => c.updateChartWithNewData(newData[0], newData[1]));
     j++;
   }, 5000);
-  measure(3, (fps) => {
-    document.getElementById("fps").textContent = fps;
+  measure(3, ({ fps }) => {
+    document.getElementById("fps").textContent = fps.toFixed(2);
   });
 }
 

--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -129,12 +129,12 @@ function drawProc(f: (time: number) => void) {
   };
 }
 
-measure(3, (fps) => {
-  document.getElementById("fps").textContent = fps;
+measure(3, ({ fps }) => {
+  document.getElementById("fps").textContent = fps.toFixed(2);
 });
 
-measureOnce(60, (fps) => {
-  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps}`);
+measureOnce(60, ({ fps }) => {
+  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
 });
 
 function test(svgNode: SVGSVGElement, viewNode: SVGGElement, width: number) {


### PR DESCRIPTION
## Summary
- switch sample frame measurements to PerformanceObserver for `performance.now`-based timing
- return average FPS and frame time from measurement utility
- update benchmark samples to consume the new metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894e00a2bd0832bbd58239ec1b848da