### PR TITLE
refactor: map line generators by series

### DIFF
--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -11,7 +11,7 @@ describe("renderPaths", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const pathSelection = select(svg)
       .selectAll("path")
-      .data([0])
+      .data([0, 1])
       .enter()
       .append("path");
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -18,7 +18,10 @@ const lineSf = line<[number, number?]>()
   .x((_, i) => i)
   .y((d) => d[1]!);
 
-const lineGenerators = [lineNy, lineSf];
+const lineGenerators = {
+  ny: lineNy,
+  sf: lineSf,
+} as const;
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -118,10 +121,18 @@ export function renderPaths(
   dataArr: Array<[number, number?]>,
 ) {
   const paths = state.paths.path.nodes() as SVGPathElement[];
-  let cityIdx = 0;
-  for (const path of paths) {
-    const drawLine = lineGenerators[cityIdx];
-    path.setAttribute("d", drawLine(dataArr) ?? "");
-    cityIdx++;
+  const pathMap: Record<
+    keyof typeof lineGenerators,
+    SVGPathElement | undefined
+  > = {
+    ny: paths[0],
+    sf: paths[1],
+  };
+
+  for (const [seriesKey, generator] of Object.entries(lineGenerators)) {
+    const path = pathMap[seriesKey as keyof typeof lineGenerators];
+    if (path) {
+      path.setAttribute("d", generator(dataArr) ?? "");
+    }
   }
 }


### PR DESCRIPTION
## Summary
- map chart line generators by series key instead of array index
- draw each series path by iterating over generator entries
- adjust renderPaths test to create paths for each series

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e8a92bd0832bb10fa01d9c756453