### PR TITLE
refactor: adjust zoom callback handling

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -85,8 +85,7 @@ export class TimeSeriesChart {
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
-    this.zoomState.zoom(event, false);
-    this.legendController.refresh();
+    this.zoomState.zoom(event);
   };
 
   public resetZoom = () => {


### PR DESCRIPTION
## Summary
- remove internal zoom flags and always invoke zoom callback
- schedule refreshes based on source events and programmatic zooms
- simplify chart zoom API and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894e8964cac832b9c164aab05b4f6b1