### PR TITLE
feat: generalize data source series access

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ const source: IDataSource = {
   startTime,
   timeStep,
   length: data.length,
-  getNy: (i) => [data[i][0]],
-  getSf: (i) => [data[i][1]],
+  seriesCount: 2,
+  getSeries: (i, seriesIdx) => data[i][seriesIdx],
 };
 
 const chart = new TimeSeriesChart(
@@ -75,9 +75,8 @@ const chart = new TimeSeriesChart(
 );
 ```
 
-The `getNy` and `getSf` callbacks return arrays of numbers so a data source
-can supply multiple lines for each axis. The current chart implementation uses
-only the first value from each array.
+`getSeries` returns the value for the specified series index, while
+`seriesCount` declares how many series are available from the data source.
 
 The third argument creates a legend controller, letting you customize how
 legend entries are rendered, including timestamp formatting.
@@ -89,8 +88,8 @@ const singleSource: IDataSource = {
   startTime,
   timeStep,
   length: data.length,
-  getNy: (i) => [data[i][0]],
-  getSf: (i) => [data[i][1]],
+  seriesCount: 2,
+  getSeries: (i, seriesIdx) => data[i][seriesIdx],
 };
 
 const chartSingle = new TimeSeriesChart(
@@ -106,7 +105,7 @@ const chartSingle = new TimeSeriesChart(
 );
 ```
 
-If you only have one series, supply a data source without `getSf`; the chart
+If you only have one series, set `seriesCount` to 1; the chart
 will render a single path and axis.
 
 ## Secrets of Speed

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -22,8 +22,8 @@ onCsv((data: [number, number][]) => {
     startTime: Date.now(),
     timeStep: 86400000,
     length: data.length,
-    getNy: (i) => [data[i][0]],
-    getSf: (i) => [data[i][1]],
+    seriesCount: 2,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const chart = new TimeSeriesChart(
     svg,

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -30,8 +30,8 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
       startTime: Date.now(),
       timeStep: 86400000,
       length: data.length,
-      getNy: (i) => [data[i][0]],
-      getSf: (i) => [data[i][1]],
+      seriesCount: 2,
+      getSeries: (i, seriesIdx) => data[i][seriesIdx],
     };
     const chart = new TimeSeriesChart(
       svg,

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -32,8 +32,8 @@ const source: IDataSource = {
   startTime: Date.now(),
   timeStep: 1000, // time step in ms
   length: ny.length,
-  getNy: (i) => [ny[i]],
-  getSf: (i) => [sf[i]],
+  seriesCount: 2,
+  getSeries: (i, seriesIdx) => (seriesIdx === 0 ? ny[i] : sf[i]),
 };
 
 const chart = new TimeSeriesChart(
@@ -49,8 +49,9 @@ const chart = new TimeSeriesChart(
 );
 ```
 
-`getNy` and `getSf` return arrays, allowing a data source to provide multiple
-series per axis. At present, only the first value in each array is rendered.
+`getSeries` returns a value for the requested series index, while `seriesCount`
+declares how many series are available. At present, only the first two series
+are rendered.
 
 The third argument lets you supply a custom legend controller. See
 `samples/LegendController.ts` for a reference implementation.

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -7,8 +7,8 @@ describe("ChartData", () => {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    getNy: (i) => [data[i][0]],
-    getSf: (i) => [data[i][1]!],
+    seriesCount: data.some((d) => d[1] !== undefined) ? 2 : 1,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx]!,
   });
 
   it("throws if constructed with empty data", () => {
@@ -16,7 +16,8 @@ describe("ChartData", () => {
       startTime: 0,
       timeStep: 1,
       length: 0,
-      getNy: () => [0],
+      seriesCount: 1,
+      getSeries: () => 0,
     };
     expect(() => new ChartData(source)).toThrow(/non-empty data array/);
   });
@@ -208,7 +209,8 @@ describe("ChartData", () => {
         startTime: 0,
         timeStep: 1,
         length: 2,
-        getNy: (i) => [[0, 1][i]],
+        seriesCount: 1,
+        getSeries: (i) => [0, 1][i],
       };
       const cd = new ChartData(source);
       expect(cd.treeSf).toBeUndefined();

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -28,8 +28,8 @@ export interface IDataSource {
   readonly startTime: number;
   readonly timeStep: number;
   readonly length: number;
-  getNy(index: number): number[];
-  getSf?(index: number): number[];
+  readonly seriesCount: number;
+  getSeries(index: number, seriesIdx: number): number;
 }
 
 export class ChartData {
@@ -50,11 +50,11 @@ export class ChartData {
     if (source.length === 0) {
       throw new Error("ChartData requires a non-empty data array");
     }
-    this.hasSf = typeof source.getSf === "function";
+    this.hasSf = source.seriesCount > 1;
     this.data = new Array(source.length);
     for (let i = 0; i < source.length; i++) {
-      const ny = source.getNy(i)[0];
-      const sf = this.hasSf ? source.getSf!(i)[0] : undefined;
+      const ny = source.getSeries(i, 0);
+      const sf = this.hasSf ? source.getSeries(i, 1) : undefined;
       this.data[i] = [ny, sf];
     }
     this.idxToTime = betweenTBasesAR1(
@@ -71,7 +71,7 @@ export class ChartData {
   append(ny: number, sf?: number): void {
     if (!this.hasSf && sf !== undefined) {
       console.warn(
-        "ChartData: sf parameter provided but chart was initialized without getSf function. sf value will be ignored.",
+        "ChartData: sf parameter provided but data source has only one series. sf value will be ignored.",
       );
     }
     this.data.push([ny, this.hasSf ? sf : undefined]);

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -103,7 +103,8 @@ function createChart(data: Array<[number]>) {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    getNy: (i) => [data[i][0]],
+    seriesCount: 1,
+    getSeries: (i) => data[i][0],
   };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -107,8 +107,8 @@ function createChart(
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    getNy: (i) => [data[i][0]],
-    getSf: (i) => [data[i][1]],
+    seriesCount: 2,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
@@ -338,8 +338,8 @@ describe("chart interaction", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      getNy: (i) => [[0, 1][i]],
-      getSf: (i) => [[0, 1][i]],
+      seriesCount: 2,
+      getSeries: (i) => [0, 1][i],
     };
     const chart = new TimeSeriesChart(
       select(svgEl) as any,

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -86,8 +86,9 @@ describe("buildSeries", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      getNy: (i) => [[1, 2, 3][i]],
-      getSf: (i) => [[10, 20, 30][i]],
+      seriesCount: 2,
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
@@ -116,8 +117,9 @@ describe("buildSeries", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      getNy: (i) => [[1, 2, 3][i]],
-      getSf: (i) => [[10, 20, 30][i]],
+      seriesCount: 2,
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -83,8 +83,9 @@ describe("setupRender Y-axis modes", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      getNy: (i) => [[1, 2, 3][i]],
-      getSf: (i) => [[10, 20, 30][i]],
+      seriesCount: 2,
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
@@ -98,8 +99,9 @@ describe("setupRender Y-axis modes", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      getNy: (i) => [[1, 2, 3][i]],
-      getSf: (i) => [[10, 20, 30][i]],
+      seriesCount: 2,
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);


### PR DESCRIPTION
## Summary
- replace `getNy`/`getSf` with `getSeries` and `seriesCount`
- update tests, documentation and samples for new data source API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894eeb92990832b8db184858ef082be