### PR TITLE
fix: shift timestamps forward on append

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -40,9 +40,9 @@ describe("ChartData", () => {
       [1, 1],
       [2, 2],
     ]);
-    // appending shifts the index-to-time mapping one step backward
-    expect(cd.idxToTime.applyToPoint(0)).toBe(-1);
-    expect(cd.idxToTime.applyToPoint(1)).toBe(0);
+    // appending shifts the index-to-time mapping one step forward
+    expect(cd.idxToTime.applyToPoint(0)).toBe(1);
+    expect(cd.idxToTime.applyToPoint(1)).toBe(2);
   });
 
   it("provides clamped point data and timestamp", () => {
@@ -74,8 +74,8 @@ describe("ChartData", () => {
       [3, 3],
       [4, 4],
     ]);
-    expect(cd.idxToTime.applyToPoint(0)).toBe(-3);
-    expect(cd.idxToTime.applyToPoint(1)).toBe(-2);
+    expect(cd.idxToTime.applyToPoint(0)).toBe(3);
+    expect(cd.idxToTime.applyToPoint(1)).toBe(4);
     expect(cd.treeNy.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(cd.treeSf!.query(0, 1)).toEqual({ min: 3, max: 4 });
   });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -61,7 +61,7 @@ export class ChartData {
       bUnit,
       new AR1Basis(source.startTime, source.startTime + source.timeStep),
     );
-    this.idxShift = betweenTBasesAR1(new AR1Basis(1, 2), bUnit);
+    this.idxShift = betweenTBasesAR1(new AR1Basis(-1, 0), bUnit);
     // bIndexFull represents the full range of data indices and remains constant
     // since append() maintains a sliding window of fixed length
     this.bIndexFull = new AR1Basis(0, this.data.length - 1);
@@ -76,7 +76,7 @@ export class ChartData {
     }
     this.data.push([ny, this.hasSf ? sf : undefined]);
     this.data.shift();
-    this.idxToTime = this.idxToTime.composeWith(this.idxShift);
+    this.idxToTime = this.idxShift.composeWith(this.idxToTime);
     this.rebuildSegmentTrees();
   }
 


### PR DESCRIPTION
## Summary
- shift index-to-time transform to advance by one on append
- update tests for forward timestamp movement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894fb4e6e9c832b94ada1356990f0c8