### PR TITLE
perf: seed PRNG for segment tree benchmark

### DIFF
--- a/segment-tree-rmq/bench/segmentTree.bench.ts
+++ b/segment-tree-rmq/bench/segmentTree.bench.ts
@@ -1,24 +1,34 @@
 import { bench, describe } from "vitest";
 import { SegmentTree } from "../src/index.ts";
 
+// Deterministic seed for reproducible benchmarks
+const SEED = 123456789;
+let seed = SEED;
+const random = (): number => {
+  seed ^= seed << 13;
+  seed ^= seed >>> 17;
+  seed ^= seed << 5;
+  return (seed >>> 0) / 0xffffffff;
+};
+
 describe("SegmentTree performance", () => {
   const size = 100_000;
-  const data = Array.from({ length: size }, () => Math.random());
+  const data = Array.from({ length: size }, () => random());
   const tree = new SegmentTree<number>(data, (a, b) => a + b, 0);
 
   const updateIndices = Array.from({ length: 1000 }, () =>
-    Math.floor(Math.random() * size),
+    Math.floor(random() * size),
   );
   let ui = 0;
 
   bench("update", () => {
-    tree.update(updateIndices[ui], Math.random());
+    tree.update(updateIndices[ui], random());
     ui = (ui + 1) % updateIndices.length;
   });
 
   const queryRanges = Array.from({ length: 1000 }, () => {
-    const l = Math.floor(Math.random() * size);
-    const r = l + Math.floor(Math.random() * (size - l));
+    const l = Math.floor(random() * size);
+    const r = l + Math.floor(random() * (size - l));
     return [l, r] as const;
   });
   let qi = 0;


### PR DESCRIPTION
## Summary
- make segment tree benchmark reproducible with a deterministic xorshift PRNG

## Testing
- `npm run format`
- `git commit -am "perf: seed prng for segment tree benchmark"` (runs lint, typecheck, test)

------
https://chatgpt.com/codex/tasks/task_e_689500134328832ba71c11393ef2525c