### PR TITLE
fix: log benchmark results instead of alert

### DIFF
--- a/samples/benchmarks/axis-draw-transform/index.ts
+++ b/samples/benchmarks/axis-draw-transform/index.ts
@@ -14,5 +14,7 @@ measure(3, ({ fps }) => {
 });
 
 measureOnce(60, ({ fps }) => {
-  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+  console.log(
+    `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+  );
 });

--- a/samples/benchmarks/bench.ts
+++ b/samples/benchmarks/bench.ts
@@ -11,7 +11,7 @@ export function onCsv(f: (csv: number[][]) => void): void {
     ])
     .get((error: null, data: number[][]) => {
       if (error != null) {
-        alert("Data can't be downloaded or parsed");
+        console.error("Data can't be downloaded or parsed");
         return;
       }
       f(data);

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -46,6 +46,8 @@ onCsv((data: [number, number][]) => {
   });
 
   measureOnce(60, ({ fps }) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+    console.log(
+      `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+    );
   });
 });

--- a/samples/benchmarks/demo2-without-grid/index.ts
+++ b/samples/benchmarks/demo2-without-grid/index.ts
@@ -11,7 +11,7 @@ csv("../../demos/ny-vs-sf.csv")
     SF: parseFloat(d.SF.split(";")[0]),
   }))
   .get((error: any, data: any[]) => {
-    if (error != null) alert("Data can't be downloaded or parsed");
+    if (error != null) console.error("Data can't be downloaded or parsed");
     else {
       common.drawCharts(data);
 
@@ -33,5 +33,7 @@ measure(3, ({ fps }) => {
 });
 
 measureOnce(60, ({ fps }) => {
-  alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+  console.log(
+    `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+  );
 });

--- a/samples/benchmarks/path-draw-transform-d3/index.ts
+++ b/samples/benchmarks/path-draw-transform-d3/index.ts
@@ -27,6 +27,8 @@ onCsv((data: number[][]) => {
   });
 
   measureOnce(60, ({ fps }) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+    console.log(
+      `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+    );
   });
 });

--- a/samples/benchmarks/path-recreate-dom/index.ts
+++ b/samples/benchmarks/path-recreate-dom/index.ts
@@ -83,6 +83,8 @@ onCsv((data) => {
   });
 
   measureOnce(60, ({ fps }) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+    console.log(
+      `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+    );
   });
 });

--- a/samples/benchmarks/path-segment-recreate-dom/index.ts
+++ b/samples/benchmarks/path-segment-recreate-dom/index.ts
@@ -124,6 +124,8 @@ onCsv((data) => {
   });
 
   measureOnce(60, ({ fps }) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+    console.log(
+      `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+    );
   });
 });

--- a/samples/benchmarks/segment-tree-queries/index.ts
+++ b/samples/benchmarks/segment-tree-queries/index.ts
@@ -28,6 +28,8 @@ onCsv((data: number[][]) => {
   });
 
   measureOnce(60, ({ fps }) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+    console.log(
+      `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+    );
   });
 });

--- a/samples/benchmarks/svg-path-recreation-d3/index.ts
+++ b/samples/benchmarks/svg-path-recreation-d3/index.ts
@@ -31,6 +31,8 @@ onCsv((data) => {
   });
 
   measureOnce(60, ({ fps }) => {
-    alert(`${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`);
+    console.log(
+      `${window.innerWidth}x${window.innerHeight} FPS = ${fps.toFixed(2)}`,
+    );
   });
 });

--- a/samples/benchmarks/viewing-pipeline-transformations/index.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/index.ts
@@ -14,7 +14,7 @@ csv("../../demos/ny-vs-sf.csv")
   ])
   .get((error: any, data: any[]) => {
     if (error != null) {
-      alert("Data can't be downloaded or parsed");
+      console.error("Data can't be downloaded or parsed");
       return;
     }
 


### PR DESCRIPTION
## Summary
- replace blocking alerts with console logging in benchmark measureOnce callbacks
- report CSV load failures via `console.error` instead of alerts
- apply non-blocking FPS reporting across all benchmark samples

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950037f01c832b8be031f4e7ed34d4