### PR TITLE
Use deterministic time-series data for renderPaths benchmark

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -5,6 +5,7 @@ import { bench, describe } from "vitest";
 import { select } from "d3-selection";
 import { renderPaths } from "../src/chart/render/utils.ts";
 import type { RenderState } from "../src/chart/render.ts";
+import { sizes, datasets } from "./timeSeriesData.ts";
 
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -15,11 +16,6 @@ describe("renderPaths performance", () => {
     .append("path");
 
   const state = { paths: { path: pathSelection } } as unknown as RenderState;
-
-  const sizes = [100, 1_000, 10_000];
-  const datasets = sizes.map((n) =>
-    Array.from({ length: n }, (_, i) => [i, i] as [number, number]),
-  );
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];

--- a/svg-time-series/bench/timeSeriesData.ts
+++ b/svg-time-series/bench/timeSeriesData.ts
@@ -1,0 +1,26 @@
+export const sizes = [100, 1_000, 10_000];
+
+function mulberry32(a: number): () => number {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function generate(length: number, seed: number): [number, number][] {
+  const rand = mulberry32(seed);
+  const phase1 = rand() * Math.PI * 2;
+  const phase2 = rand() * Math.PI * 2;
+  const freq1 = rand() * 0.02 + 0.005;
+  const freq2 = rand() * 0.05 + 0.01;
+  const amp1 = rand() * 10 + 5;
+  const amp2 = rand() * 5 + 2;
+  return Array.from({ length }, (_, i) => [
+    i,
+    Math.sin(i * freq1 + phase1) * amp1 + Math.sin(i * freq2 + phase2) * amp2,
+  ]);
+}
+
+export const datasets = sizes.map((size, idx) => generate(size, idx + 1));


### PR DESCRIPTION
## Summary
- Generate deterministic, sinusoidal time-series datasets for benchmark sizes
- Benchmark renderPaths using precomputed datasets instead of inline sequential data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950022f408832b8629729e70e6f3fc