### PR TITLE
test: add min and max segment tree cases

### DIFF
--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -136,4 +136,36 @@ describe("Segment Tree Tests", () => {
     expect(() => tree.query(-1, 2)).toThrow("Range is not valid");
     expect(() => tree.query(0, 5)).toThrow("Range is not valid");
   });
+
+  it("should support min queries and updates", () => {
+    const data = [5, 3, 8, 6, 2, 7];
+    const minOperator = (a: number, b: number) => Math.min(a, b);
+    const identity = Infinity;
+    const tree = new SegmentTree(data, minOperator, identity);
+
+    expect(tree.query(0, 5)).toBe(2);
+    expect(tree.query(1, 3)).toBe(3);
+
+    tree.update(4, 10);
+    expect(tree.query(0, 5)).toBe(3);
+
+    tree.update(0, 1);
+    expect(tree.query(0, 5)).toBe(1);
+  });
+
+  it("should support max queries and updates", () => {
+    const data = [5, 3, 8, 6, 2, 7];
+    const maxOperator = (a: number, b: number) => Math.max(a, b);
+    const identity = -Infinity;
+    const tree = new SegmentTree(data, maxOperator, identity);
+
+    expect(tree.query(0, 5)).toBe(8);
+    expect(tree.query(1, 3)).toBe(8);
+
+    tree.update(2, 0);
+    expect(tree.query(0, 5)).toBe(7);
+
+    tree.update(1, 9);
+    expect(tree.query(0, 5)).toBe(9);
+  });
 });


### PR DESCRIPTION
## Summary
- add SegmentTree tests for min reducer
- add SegmentTree tests for max reducer

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689503842b50832bb2299a8d96f62f6f