### PR TITLE
feat: guard missing second series

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { ChartData, IDataSource } from "./data.ts";
 import { AR1Basis } from "../math/affine.ts";
 
@@ -78,6 +78,24 @@ describe("ChartData", () => {
     expect(cd.idxToTime.applyToPoint(1)).toBe(4);
     expect(cd.treeNy.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(cd.treeSf!.query(0, 1)).toEqual({ min: 3, max: 4 });
+  });
+
+  it("warns and uses NaN when sf is missing", () => {
+    const source = makeSource([
+      [0, 0],
+      [1, 1],
+    ]);
+    const cd = new ChartData(source);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    cd.append(2);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(cd.data).toEqual([
+      [1, 1],
+      [2, NaN],
+    ]);
+    warnSpy.mockRestore();
   });
 
   it("computes visible temperature bounds", () => {

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -73,6 +73,11 @@ export class ChartData {
       console.warn(
         "ChartData: sf parameter provided but data source has only one series. sf value will be ignored.",
       );
+    } else if (this.hasSf && sf === undefined) {
+      console.warn(
+        "ChartData: sf parameter missing but data source has two series. Using NaN as fallback.",
+      );
+      sf = NaN;
     }
     this.data.push([ny, this.hasSf ? sf : undefined]);
     this.data.shift();


### PR DESCRIPTION
## Summary
- warn and use NaN if second series value missing in ChartData.append
- test append guard when second series value is absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689504e5f9b0832b9698da34a5bff898