### PR TITLE
feat: enforce two-series limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ work is possible. Keep watching!
 
 ## Y-axis modes
 
-Charts can display one or two data series. By default, all series share a single
+Charts can display one or two data series. The library supports at most two
+series; additional series are ignored. By default, all series share a single
 Y-axis whose scale is computed from the combined minimum and maximum of every
 series. To draw series with different units, pass `true` for the `dualYAxis`
 parameter of `TimeSeriesChart`, which enables independent left and right Y

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -1,6 +1,6 @@
 # svg-time-series
 
-A small library for rendering high-performance SVG time series charts with D3. It exports a single class, `TimeSeriesChart`, which handles drawing, zooming and hover interactions.
+A small library for rendering high-performance SVG time series charts with D3. It exports a single class, `TimeSeriesChart`, which handles drawing, zooming and hover interactions. The library supports at most two data series.
 
 ## Installation
 
@@ -50,8 +50,8 @@ const chart = new TimeSeriesChart(
 ```
 
 `getSeries` returns a value for the requested series index, while `seriesCount`
-declares how many series are available. At present, only the first two series
-are rendered.
+declares how many series are available. The library supports at most two series;
+additional series are ignored.
 
 The third argument lets you supply a custom legend controller. See
 `samples/LegendController.ts` for a reference implementation.

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -22,6 +22,17 @@ describe("ChartData", () => {
     expect(() => new ChartData(source)).toThrow(/non-empty data array/);
   });
 
+  it("throws if seriesCount is not 1 or 2", () => {
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 1,
+      seriesCount: 3,
+      getSeries: () => 0,
+    };
+    expect(() => new ChartData(source)).toThrow(/1 or 2 series/);
+  });
+
   it("updates data and time mapping on append", () => {
     const source = makeSource([
       [0, 0],

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -50,6 +50,11 @@ export class ChartData {
     if (source.length === 0) {
       throw new Error("ChartData requires a non-empty data array");
     }
+    if (source.seriesCount !== 1 && source.seriesCount !== 2) {
+      throw new Error(
+        `ChartData supports 1 or 2 series, but received ${source.seriesCount}`,
+      );
+    }
     this.hasSf = source.seriesCount > 1;
     this.data = new Array(source.length);
     for (let i = 0; i < source.length; i++) {


### PR DESCRIPTION
## Summary
- validate data source only provides one or two series
- document that the library renders at most two data series
- cover invalid seriesCount with unit test

## Testing
- `git commit -am "feat: enforce two-series limit"`

------
https://chatgpt.com/codex/tasks/task_e_689504d9f9c8832ba06261d5f8ae56e8