### PR TITLE
test: cover single path rendering without sf

### DIFF
--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from "vitest";
-import { select } from "d3-selection";
-import { renderPaths } from "./render/utils.ts";
+import { describe, it, expect, vi } from "vitest";
+import { select, type Selection } from "d3-selection";
+import { initPaths, renderPaths } from "./render/utils.ts";
 import type { RenderState } from "./render.ts";
 
 describe("renderPaths", () => {
@@ -27,5 +27,37 @@ describe("renderPaths", () => {
     const d = pathSelection.attr("d");
     expect(d).not.toContain("1,");
     expect(d.match(/M/g)?.length).toBe(2);
+  });
+
+  it("only updates primary path when hasSf is false", () => {
+    const svgSelection = select(document.createElement("div")).append(
+      "svg",
+    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+    const svg = svgSelection.node()!;
+    const { path } = initPaths(svgSelection, false);
+    const state = { paths: { path } } as unknown as RenderState;
+    const pathNode = path.node()!;
+    const spy = vi.spyOn(pathNode, "setAttribute");
+
+    renderPaths(state, [[0], [1]]);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(path.attr("d")).not.toBe("");
+    expect(svg.querySelectorAll("path").length).toBe(1);
+
+    spy.mockRestore();
+  });
+});
+
+describe("initPaths", () => {
+  it("creates only primary path when hasSf is false", () => {
+    const svgSelection = select(document.createElement("div")).append(
+      "svg",
+    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+    const { path, viewNy, viewSf } = initPaths(svgSelection, false);
+
+    expect(path.size()).toBe(1);
+    expect(viewNy.tagName).toBe("g");
+    expect(viewSf).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- test initPaths without secondary field to ensure only a single path and view are created
- test renderPaths without secondary field to verify only the primary path updates

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689503d1e84c832bad38f69147e8d264