### PR TITLE
refactor: generalize series identifiers

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -33,7 +33,9 @@ export class LegendController implements ILegendController {
     this.legendGreen = legend.select(".chart-legend__green_value");
     this.legendBlue = legend.select(".chart-legend__blue_value");
 
-    const svg = state.paths.viewNy.ownerSVGElement!;
+    const viewNy = state.paths.viewSeriesA;
+    const viewSf = state.paths.viewSeriesB;
+    const svg = viewNy.ownerSVGElement!;
     const makeDot = () =>
       select(svg)
         .append("circle")
@@ -42,7 +44,7 @@ export class LegendController implements ILegendController {
         .attr("r", this.dotRadius)
         .node() as SVGCircleElement;
     this.highlightedGreenDot = makeDot();
-    this.highlightedBlueDot = state.paths.viewSf ? makeDot() : null;
+    this.highlightedBlueDot = viewSf ? makeDot() : null;
 
     const { wrapped, cancel } = drawProc(() => {
       this.update();
@@ -62,8 +64,8 @@ export class LegendController implements ILegendController {
 
   private update() {
     const {
-      ny: greenData,
-      sf: blueData,
+      seriesA: ny,
+      seriesB: sf,
       timestamp,
     } = this.data.getPoint(this.highlightedDataIdx);
     this.legendTime.text(this.formatTime(timestamp));
@@ -71,6 +73,8 @@ export class LegendController implements ILegendController {
     const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
       isNaN(n) ? valueForNaN : n;
     const screenX = this.state.scales.x(timestamp);
+    const yNy = this.state.scales.ySeriesA;
+    const ySf = this.state.scales.ySeriesB ?? yNy;
     const updateDot = (
       val: number,
       legendSel: Selection<HTMLElement, unknown, HTMLElement, unknown>,
@@ -85,19 +89,9 @@ export class LegendController implements ILegendController {
       }
     };
 
-    updateDot(
-      greenData,
-      this.legendGreen,
-      this.highlightedGreenDot,
-      this.state.scales.yNy,
-    );
+    updateDot(ny, this.legendGreen, this.highlightedGreenDot, yNy);
     if (this.highlightedBlueDot) {
-      updateDot(
-        blueData as number,
-        this.legendBlue,
-        this.highlightedBlueDot,
-        this.state.scales.ySf ?? this.state.scales.yNy,
-      );
+      updateDot(sf as number, this.legendBlue, this.highlightedBlueDot, ySf);
     }
   }
 

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -146,7 +146,7 @@ describe("chart interaction single-axis", () => {
 
     const xAxis = axisInstances[0];
     const yAxis = axisInstances[1];
-    const mtNy = transformInstances[0];
+    const mtSeriesA = transformInstances[0];
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
@@ -154,7 +154,7 @@ describe("chart interaction single-axis", () => {
     zoom({ transform: { x: 10, k: 2 } } as any);
     vi.runAllTimers();
 
-    expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(mtSeriesA.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(transformInstances.length).toBe(1);
     expect(updateNodeCalls).toBeGreaterThan(callCount);
     expect(xAxis.axisUpCalls).toBeGreaterThan(xCalls);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -153,8 +153,8 @@ describe("chart interaction", () => {
 
     const xAxis = axisInstances[0];
     const yAxis = axisInstances[1];
-    const mtNy = transformInstances[0];
-    const mtSf = transformInstances[1];
+    const mtSeriesA = transformInstances[0];
+    const mtSeriesB = transformInstances[1];
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
@@ -162,8 +162,8 @@ describe("chart interaction", () => {
     zoom({ transform: { x: 10, k: 2 } } as any);
     vi.runAllTimers();
 
-    expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
-    expect(mtSf.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(mtSeriesA.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(mtSeriesB.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(updateNodeCalls).toBeGreaterThan(callCount);
     expect(xAxis.axisUpCalls).toBeGreaterThan(xCalls);
     expect(yAxis.axisUpCalls).toBeGreaterThan(yCalls);

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -102,10 +102,10 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(1);
     expect(series[0]).toMatchObject({
-      tree: data.treeNy,
-      transform: state.transforms.ny,
-      scale: state.scales.yNy,
-      view: state.paths.viewNy,
+      tree: data.primaryTree,
+      transform: state.transforms.seriesA,
+      scale: state.scales.ySeriesA,
+      view: state.paths.viewSeriesA,
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
@@ -133,18 +133,18 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeNy,
-      transform: state.transforms.ny,
-      scale: state.scales.yNy,
-      view: state.paths.viewNy,
+      tree: data.primaryTree,
+      transform: state.transforms.seriesA,
+      scale: state.scales.ySeriesA,
+      view: state.paths.viewSeriesA,
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeSf,
-      transform: state.transforms.sf,
-      scale: state.scales.ySf,
-      view: state.paths.viewSf,
+      tree: data.secondaryTree,
+      transform: state.transforms.seriesB,
+      scale: state.scales.ySeriesB,
+      view: state.paths.viewSeriesB,
       axis: state.axes.yRight,
       gAxis: state.axes.gYRight,
     });

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -89,8 +89,8 @@ describe("setupRender Y-axis modes", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    expect(state.scales.yNy.domain()).toEqual([1, 30]);
-    expect(state.scales.ySf).toBeUndefined();
+    expect(state.scales.ySeriesA.domain()).toEqual([1, 30]);
+    expect(state.scales.ySeriesB).toBeUndefined();
   });
 
   it("separates scales when dualYAxis is true", () => {
@@ -105,7 +105,7 @@ describe("setupRender Y-axis modes", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    expect(state.scales.yNy.domain()).toEqual([1, 3]);
-    expect(state.scales.ySf!.domain()).toEqual([10, 30]);
+    expect(state.scales.ySeriesA.domain()).toEqual([1, 3]);
+    expect(state.scales.ySeriesB!.domain()).toEqual([10, 30]);
   });
 });

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -46,7 +46,7 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state: any = {
       dimensions: { width: 10, height: 10 },
-      transforms: { ny: { onZoomPan: vi.fn() } },
+      transforms: { seriesA: { onZoomPan: vi.fn() } },
     };
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -73,7 +73,7 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state: any = {
       dimensions: { width: 10, height: 10 },
-      transforms: { ny: { onZoomPan: vi.fn() } },
+      transforms: { seriesA: { onZoomPan: vi.fn() } },
     };
     const refresh = vi.fn();
     const zs = new ZoomState(rect as any, state, refresh);

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -39,11 +39,11 @@ describe("ZoomState", () => {
   it("updates transforms and triggers refresh on zoom", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const ny = { onZoomPan: vi.fn() };
-    const sf = { onZoomPan: vi.fn() };
+    const seriesA = { onZoomPan: vi.fn() };
+    const seriesB = { onZoomPan: vi.fn() };
     const state: any = {
       dimensions: { width: 10, height: 10 },
-      transforms: { ny, sf },
+      transforms: { seriesA, seriesB },
     };
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -53,8 +53,8 @@ describe("ZoomState", () => {
     zs.zoom(event);
     vi.runAllTimers();
 
-    expect(ny.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
-    expect(sf.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(seriesA.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(seriesB.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
@@ -66,10 +66,10 @@ describe("ZoomState", () => {
   it("does not reschedule for programmatic transform", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const ny = { onZoomPan: vi.fn() };
+    const seriesA = { onZoomPan: vi.fn() };
     const state: any = {
       dimensions: { width: 10, height: 10 },
-      transforms: { ny },
+      transforms: { seriesA },
     };
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -90,10 +90,10 @@ describe("ZoomState", () => {
   it("refresh re-applies transform and triggers refresh callback", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const ny = { onZoomPan: vi.fn() };
+    const seriesA = { onZoomPan: vi.fn() };
     const state: any = {
       dimensions: { width: 10, height: 10 },
-      transforms: { ny },
+      transforms: { seriesA },
     };
     const refresh = vi.fn();
     const zs = new ZoomState(rect as any, state, refresh);
@@ -115,17 +115,17 @@ describe("ZoomState", () => {
   it("reset sets transform to identity and triggers zoom event", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const ny = { onZoomPan: vi.fn() };
+    const seriesA = { onZoomPan: vi.fn() };
     const state: any = {
       dimensions: { width: 10, height: 10 },
-      transforms: { ny },
+      transforms: { seriesA },
     };
     const refresh = vi.fn();
     const zs = new ZoomState(rect as any, state, refresh);
 
     const transformSpy = zs.zoomBehavior.transform as any;
     transformSpy.mockClear();
-    ny.onZoomPan.mockClear();
+    seriesA.onZoomPan.mockClear();
     refresh.mockClear();
 
     zs.reset();
@@ -135,7 +135,7 @@ describe("ZoomState", () => {
       rect,
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
-    expect(ny.onZoomPan).toHaveBeenCalledWith(
+    expect(seriesA.onZoomPan).toHaveBeenCalledWith(
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
     expect((zs as any).currentPanZoomTransformState).toEqual(

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -51,8 +51,8 @@ export class ZoomState {
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.currentPanZoomTransformState = event.transform;
-    this.state.transforms.ny.onZoomPan(event.transform);
-    this.state.transforms.sf?.onZoomPan(event.transform);
+    this.state.transforms.seriesA.onZoomPan(event.transform);
+    this.state.transforms.seriesB?.onZoomPan(event.transform);
     if (event.sourceEvent) {
       this.scheduleRefresh();
     }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -72,8 +72,8 @@ export class TimeSeriesChart {
     };
   }
 
-  public updateChartWithNewData(ny: number, sf?: number) {
-    this.data.append(ny, sf);
+  public updateChartWithNewData(seriesA: number, seriesB?: number) {
+    this.data.append(seriesA, seriesB);
     this.drawNewData();
   }
 
@@ -93,7 +93,7 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    const idx = this.state.transforms.ny.fromScreenToModelX(x);
+    const idx = this.state.transforms.seriesA.fromScreenToModelX(x);
     this.legendController.onHover(idx);
   };
 


### PR DESCRIPTION
## Summary
- replace ny/sf identifiers with generic seriesA/seriesB across chart code
- update chart data and rendering utilities to use primary/secondary trees
- adjust zoom behavior, draw API, sample legend and tests
- restore dataset-specific NY/SF legend controller in samples

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689501339db0832b90b261ea76627bac