### PR TITLE
feat: use named interface for chart time points

### DIFF
--- a/samples/benchmarks/bench.ts
+++ b/samples/benchmarks/bench.ts
@@ -1,15 +1,16 @@
 import { csv } from "d3-request";
 import { timer as runTimer } from "d3-timer";
+import type { TimePoint } from "svg-time-series";
 
 export { measure, measureOnce } from "../measure.ts";
 
-export function onCsv(f: (csv: number[][]) => void): void {
+export function onCsv(f: (csv: TimePoint[]) => void): void {
   csv("../../demos/ny-vs-sf.csv")
-    .row((d: { NY: string; SF: string }) => [
-      parseFloat(d.NY.split(";")[0]),
-      parseFloat(d.SF.split(";")[0]),
-    ])
-    .get((error: null, data: number[][]) => {
+    .row((d: { NY: string; SF: string }) => ({
+      ny: parseFloat(d.NY.split(";")[0]),
+      sf: parseFloat(d.SF.split(";")[0]),
+    }))
+    .get((error: null, data: TimePoint[]) => {
       if (error != null) {
         alert("Data can't be downloaded or parsed");
         return;

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -1,9 +1,9 @@
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import { TimeSeriesChart, IDataSource, TimePoint } from "svg-time-series";
 import { LegendController } from "../../LegendController.ts";
 import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
 import { select, Selection } from "d3-selection";
 
-onCsv((data: [number, number][]) => {
+onCsv((data: TimePoint[]) => {
   const svg = select(".chart-drawing svg") as Selection<
     SVGSVGElement,
     unknown,
@@ -23,7 +23,7 @@ onCsv((data: [number, number][]) => {
     timeStep: 86400000,
     length: data.length,
     seriesCount: 2,
-    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+    getSeries: (i, seriesIdx) => (seriesIdx === 0 ? data[i].ny : data[i].sf!),
   };
   const chart = new TimeSeriesChart(
     svg,
@@ -37,7 +37,7 @@ onCsv((data: [number, number][]) => {
   let j = 0;
   animateBench(() => {
     const point = data[j % data.length];
-    chart.updateChartWithNewData(point[0], point[1]);
+    chart.updateChartWithNewData(point.ny, point.sf);
     j++;
   });
 

--- a/samples/benchmarks/path-draw-transform-d3/index.ts
+++ b/samples/benchmarks/path-draw-transform-d3/index.ts
@@ -3,18 +3,19 @@ import { line } from "d3-shape";
 
 import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
+import type { TimePoint } from "svg-time-series";
 
-onCsv((data: number[][]) => {
+onCsv((data: TimePoint[]) => {
   const path = selectAll("g.view")
     .selectAll("path")
     .data([0, 1])
     .enter()
     .append("path")
     .attr("d", (cityIdx: number) =>
-      line<number[]>()
-        .defined((d) => !isNaN(d[cityIdx]))
-        .x((d, i) => i)
-        .y((d) => d[cityIdx])
+      line<TimePoint>()
+        .defined((d) => !isNaN(cityIdx === 0 ? d.ny : d.sf!))
+        .x((_, i) => i)
+        .y((d) => (cityIdx === 0 ? d.ny : d.sf!))
         .call(null, data),
     );
 

--- a/samples/benchmarks/path-recreate-dom/index.ts
+++ b/samples/benchmarks/path-recreate-dom/index.ts
@@ -1,15 +1,16 @@
 ﻿import { select, selectAll } from "d3-selection";
 import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
+import type { TimePoint } from "svg-time-series";
 
-onCsv((data) => {
+onCsv((data: TimePoint[]) => {
   const dataLength = data.length;
 
   const pathsData: any[][] = [[], []];
   let previousPointIsValid = [true, true];
-  data.forEach((d: number[], i: number, arr: number[][]) => {
-    const y0 = arr[i][0];
-    const y1 = arr[i][1];
+  data.forEach((d: TimePoint, i: number, arr: TimePoint[]) => {
+    const y0 = arr[i].ny;
+    const y1 = arr[i].sf!;
     const currentPointIsValid = [!isNaN(y0), !isNaN(y1)];
 
     if (!previousPointIsValid[0] && currentPointIsValid[0]) {

--- a/samples/benchmarks/path-segment-recreate-dom/index.ts
+++ b/samples/benchmarks/path-segment-recreate-dom/index.ts
@@ -1,15 +1,16 @@
 import { Selection, select, selectAll } from "d3-selection";
 import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
+import type { TimePoint } from "svg-time-series";
 
-onCsv((data) => {
+onCsv((data: TimePoint[]) => {
   const dataLength = data.length;
 
   const pathsData: any[][] = [[], []];
   let previousPointIsValid = [true, true];
-  data.forEach((d: number[], i: number, arr: number[][]) => {
-    const y0 = arr[i][0];
-    const y1 = arr[i][1];
+  data.forEach((d: TimePoint, i: number, arr: TimePoint[]) => {
+    const y0 = arr[i].ny;
+    const y1 = arr[i].sf!;
     const currentPointIsValid = [!isNaN(y0), !isNaN(y1)];
 
     if (!previousPointIsValid[0] && currentPointIsValid[0]) {

--- a/samples/benchmarks/segment-tree-queries/draw.ts
+++ b/samples/benchmarks/segment-tree-queries/draw.ts
@@ -1,15 +1,20 @@
 import { BaseType, Selection } from "d3-selection";
 
 import { SegmentTree } from "segment-tree-rmq";
-import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
+import type {
+  IMinMax,
+  TimePoint,
+} from "../../../svg-time-series/src/chart/data.ts";
 import { animateBench, animateCosDown } from "../bench.ts";
 import { ViewWindowTransform } from "../../ViewWindowTransform.ts";
 
-function buildSegmentTreeTuple(index: number, elements: number[][]): IMinMax {
-  const nyMinValue = isNaN(elements[index][0]) ? Infinity : elements[index][0];
-  const nyMaxValue = isNaN(elements[index][0]) ? -Infinity : elements[index][0];
-  const sfMinValue = isNaN(elements[index][1]) ? Infinity : elements[index][1];
-  const sfMaxValue = isNaN(elements[index][1]) ? -Infinity : elements[index][1];
+function buildSegmentTreeTuple(index: number, elements: TimePoint[]): IMinMax {
+  const ny = elements[index].ny;
+  const sf = elements[index].sf!;
+  const nyMinValue = isNaN(ny) ? Infinity : ny;
+  const nyMaxValue = isNaN(ny) ? -Infinity : ny;
+  const sfMinValue = isNaN(sf) ? Infinity : sf;
+  const sfMaxValue = isNaN(sf) ? -Infinity : sf;
   return {
     min: Math.min(nyMinValue, sfMinValue),
     max: Math.max(nyMaxValue, sfMaxValue),
@@ -23,7 +28,7 @@ function buildMinMax(a: IMinMax, b: IMinMax): IMinMax {
 const minMaxIdentity: IMinMax = { min: Infinity, max: -Infinity };
 
 function createSegmentTree(
-  elements: number[][],
+  elements: TimePoint[],
   size: number,
 ): SegmentTree<IMinMax> {
   const data: IMinMax[] = new Array(size);
@@ -36,7 +41,7 @@ function createSegmentTree(
 export class TimeSeriesChart {
   constructor(
     svg: Selection<BaseType, {}, HTMLElement, any>,
-    data: number[][],
+    data: TimePoint[],
   ) {
     const node: SVGSVGElement = svg.node() as SVGSVGElement;
     const div: HTMLElement = node.parentNode as HTMLElement;

--- a/samples/benchmarks/segment-tree-queries/index.ts
+++ b/samples/benchmarks/segment-tree-queries/index.ts
@@ -3,8 +3,9 @@ import { line } from "d3-shape";
 
 import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
+import type { TimePoint } from "svg-time-series";
 
-onCsv((data: number[][]) => {
+onCsv((data: TimePoint[]) => {
   const filteredData = data.filter((_, i) => i % 10 == 0);
   const path = selectAll("g.view")
     .selectAll("path")
@@ -12,10 +13,10 @@ onCsv((data: number[][]) => {
     .enter()
     .append("path")
     .attr("d", (cityIdx: number) =>
-      line<number[]>()
-        .defined((d) => !isNaN(d[cityIdx]))
-        .x((d, i) => i * 10)
-        .y((d) => d[cityIdx])
+      line<TimePoint>()
+        .defined((d) => !isNaN(cityIdx === 0 ? d.ny : d.sf!))
+        .x((_, i) => i * 10)
+        .y((d) => (cityIdx === 0 ? d.ny : d.sf!))
         .call(null, filteredData),
     );
 

--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -5,6 +5,7 @@ import { bench, describe } from "vitest";
 import { select } from "d3-selection";
 import { renderPaths } from "../src/chart/render/utils.ts";
 import type { RenderState } from "../src/chart/render.ts";
+import type { TimePoint } from "../src/chart/data.ts";
 
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -17,8 +18,8 @@ describe("renderPaths performance", () => {
   const state = { paths: { path: pathSelection } } as unknown as RenderState;
 
   const sizes = [100, 1_000, 10_000];
-  const datasets = sizes.map((n) =>
-    Array.from({ length: n }, (_, i) => [i, i] as [number, number]),
+  const datasets = sizes.map<TimePoint[]>((n) =>
+    Array.from({ length: n }, (_, i) => ({ ny: i, sf: i })),
   );
 
   sizes.forEach((size, idx) => {

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import type { TimePoint } from "./data.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -79,7 +80,7 @@ vi.mock("d3-zoom", () => ({
   },
 }));
 
-function createChart(data: Array<[number]>) {
+function createChart(data: TimePoint[]) {
   currentDataLength = data.length;
   const parent = document.createElement("div");
   const w = Math.max(currentDataLength - 1, 0);
@@ -104,7 +105,7 @@ function createChart(data: Array<[number]>) {
     timeStep: 1,
     length: data.length,
     seriesCount: 1,
-    getSeries: (i) => data[i][0],
+    getSeries: (i) => data[i].ny,
   };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
@@ -141,7 +142,7 @@ afterEach(() => {
 
 describe("chart interaction single-axis", () => {
   it("zoom updates transform and axes", () => {
-    const { zoom } = createChart([[0], [1]]);
+    const { zoom } = createChart([{ ny: 0 }, { ny: 1 }]);
     vi.runAllTimers();
 
     const xAxis = axisInstances[0];
@@ -162,7 +163,7 @@ describe("chart interaction single-axis", () => {
   });
 
   it("onHover updates legend text and dot position", () => {
-    const data: Array<[number]> = [[10], [30]];
+    const data: TimePoint[] = [{ ny: 10 }, { ny: 30 }];
     const { onHover, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
@@ -180,7 +181,7 @@ describe("chart interaction single-axis", () => {
   });
 
   it("updates circle after appending data", () => {
-    const data: Array<[number]> = [[10], [30]];
+    const data: TimePoint[] = [{ ny: 10 }, { ny: 30 }];
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
@@ -201,7 +202,7 @@ describe("chart interaction single-axis", () => {
   });
 
   it("handles NaN data", () => {
-    const { onHover, svgEl, legend } = createChart([[NaN]]);
+    const { onHover, svgEl, legend } = createChart([{ ny: NaN }]);
     vi.runAllTimers();
 
     onHover(0);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import type { TimePoint } from "./data.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -80,7 +81,7 @@ vi.mock("d3-zoom", () => ({
 }));
 
 function createChart(
-  data: Array<[number, number]>,
+  data: TimePoint[],
   formatTime?: (timestamp: number) => string,
 ) {
   currentDataLength = data.length;
@@ -108,7 +109,7 @@ function createChart(
     timeStep: 1,
     length: data.length,
     seriesCount: 2,
-    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+    getSeries: (i, seriesIdx) => (seriesIdx === 0 ? data[i].ny : data[i].sf!),
   };
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
@@ -146,8 +147,8 @@ afterEach(() => {
 describe("chart interaction", () => {
   it("zoom updates transforms and axes", () => {
     const { zoom } = createChart([
-      [0, 0],
-      [1, 1],
+      { ny: 0, sf: 0 },
+      { ny: 1, sf: 1 },
     ]);
     vi.runAllTimers();
 
@@ -170,9 +171,9 @@ describe("chart interaction", () => {
   });
 
   it("onHover updates legend text and dot positions", () => {
-    const data: Array<[number, number]> = [
-      [10, 20],
-      [30, 40],
+    const data: TimePoint[] = [
+      { ny: 10, sf: 20 },
+      { ny: 30, sf: 40 },
     ];
     const { onHover, svgEl, legend } = createChart(data);
     vi.runAllTimers();
@@ -197,9 +198,9 @@ describe("chart interaction", () => {
   });
 
   it("updates circles after appending data", () => {
-    const data: Array<[number, number]> = [
-      [10, 20],
-      [30, 40],
+    const data: TimePoint[] = [
+      { ny: 10, sf: 20 },
+      { ny: 30, sf: 40 },
     ];
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
@@ -227,9 +228,9 @@ describe("chart interaction", () => {
   });
 
   it("uses custom time formatter when provided", () => {
-    const data: Array<[number, number]> = [
-      [10, 20],
-      [30, 40],
+    const data: TimePoint[] = [
+      { ny: 10, sf: 20 },
+      { ny: 30, sf: 40 },
     ];
     const formatter = vi.fn((ts: number) => `ts:${ts}`);
     const { onHover, legend } = createChart(data, formatter);
@@ -245,7 +246,7 @@ describe("chart interaction", () => {
   });
 
   it("handles NaN data", () => {
-    const { onHover, svgEl, legend } = createChart([[NaN, NaN]]);
+    const { onHover, svgEl, legend } = createChart([{ ny: NaN, sf: NaN }]);
     vi.runAllTimers();
 
     onHover(0);
@@ -266,10 +267,10 @@ describe("chart interaction", () => {
   });
 
   it("clamps hover index to data bounds", () => {
-    const data: Array<[number, number]> = [
-      [10, 20],
-      [30, 40],
-      [50, 60],
+    const data: TimePoint[] = [
+      { ny: 10, sf: 20 },
+      { ny: 30, sf: 40 },
+      { ny: 50, sf: 60 },
     ];
     const { onHover, svgEl, legend } = createChart(data);
     vi.runAllTimers();

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from "vitest";
 import { select } from "d3-selection";
 import { renderPaths } from "./render/utils.ts";
 import type { RenderState } from "./render.ts";
+import type { TimePoint } from "./data.ts";
 
 describe("renderPaths", () => {
   it("skips segments for NaN values", () => {
@@ -16,10 +17,10 @@ describe("renderPaths", () => {
       .append("path");
 
     const state = { paths: { path: pathSelection } } as unknown as RenderState;
-    const data: Array<[number, number]> = [
-      [0, 0],
-      [NaN, NaN],
-      [2, 2],
+    const data: TimePoint[] = [
+      { ny: 0, sf: 0 },
+      { ny: NaN, sf: NaN },
+      { ny: 2, sf: 2 },
     ];
 
     renderPaths(state, data);

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -4,19 +4,19 @@ import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import { SegmentTree } from "segment-tree-rmq";
 import { ViewportTransform } from "../../ViewportTransform.ts";
-import type { IMinMax } from "../data.ts";
+import type { IMinMax, TimePoint } from "../data.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
-const lineNy = line<[number, number?]>()
-  .defined((d) => !(isNaN(d[0]!) || d[0] == null))
+const lineNy = line<TimePoint>()
+  .defined((d) => !(isNaN(d.ny) || d.ny == null))
   .x((_, i) => i)
-  .y((d) => d[0]!);
+  .y((d) => d.ny);
 
-const lineSf = line<[number, number?]>()
-  .defined((d) => !(isNaN(d[1]!) || d[1] == null))
+const lineSf = line<TimePoint>()
+  .defined((d) => !(isNaN(d.sf!) || d.sf == null))
   .x((_, i) => i)
-  .y((d) => d[1]!);
+  .y((d) => d.sf!);
 
 const lineGenerators = {
   ny: lineNy,
@@ -116,10 +116,7 @@ export function initPaths(
   return { path, viewNy, viewSf };
 }
 
-export function renderPaths(
-  state: RenderState,
-  dataArr: Array<[number, number?]>,
-) {
+export function renderPaths(state: RenderState, dataArr: TimePoint[]) {
   const paths = state.paths.path.nodes() as SVGPathElement[];
   const pathMap: Record<
     keyof typeof lineGenerators,

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,14 +1,14 @@
 import { Selection } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 
-import { ChartData, IMinMax, IDataSource } from "./chart/data.ts";
+import { ChartData, IMinMax, IDataSource, TimePoint } from "./chart/data.ts";
 import { setupRender, refreshChart } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
 import type { ILegendController } from "./chart/legend.ts";
 import { ZoomState } from "./chart/zoomState.ts";
 
-export type { IMinMax, IDataSource } from "./chart/data.ts";
+export type { IMinMax, IDataSource, TimePoint } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
 
 export interface IPublicInteraction {


### PR DESCRIPTION
## Summary
- define `TimePoint` interface and replace tuple-based chart data with named properties
- update rendering utilities, tests, and samples to consume `TimePoint[]`
- export `TimePoint` from library for sample usage

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6894ff224ad0832b910a6420a984a060