### PR TITLE
feat: require explicit second series data

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -91,22 +91,22 @@ describe("ChartData", () => {
     expect(cd.treeSf!.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
 
-  it("warns and uses NaN when sf is missing", () => {
+  it("throws when ny is invalid", () => {
     const source = makeSource([
       [0, 0],
       [1, 1],
     ]);
     const cd = new ChartData(source);
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    expect(() => cd.append(undefined as unknown as number, 2)).toThrow(/ny/);
+  });
 
-    cd.append(2);
-
-    expect(warnSpy).toHaveBeenCalledOnce();
-    expect(cd.data).toEqual([
+  it("throws when sf is invalid", () => {
+    const source = makeSource([
+      [0, 0],
       [1, 1],
-      [2, NaN],
     ]);
-    warnSpy.mockRestore();
+    const cd = new ChartData(source);
+    expect(() => cd.append(2, undefined as unknown as number)).toThrow(/sf/);
   });
 
   it("computes visible temperature bounds", () => {
@@ -247,7 +247,7 @@ describe("ChartData", () => {
         [0, undefined],
         [1, undefined],
       ]);
-      cd.append(2);
+      cd.append(2, 0);
       expect(cd.data).toEqual([
         [1, undefined],
         [2, undefined],

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -73,16 +73,12 @@ export class ChartData {
     this.rebuildSegmentTrees();
   }
 
-  append(ny: number, sf?: number): void {
-    if (!this.hasSf && sf !== undefined) {
-      console.warn(
-        "ChartData: sf parameter provided but data source has only one series. sf value will be ignored.",
-      );
-    } else if (this.hasSf && sf === undefined) {
-      console.warn(
-        "ChartData: sf parameter missing but data source has two series. Using NaN as fallback.",
-      );
-      sf = NaN;
+  append(ny: number, sf: number): void {
+    if (ny == null || !Number.isFinite(ny)) {
+      throw new Error("ChartData.append requires ny to be a finite number");
+    }
+    if (sf == null || !Number.isFinite(sf)) {
+      throw new Error("ChartData.append requires sf to be a finite number");
     }
     this.data.push([ny, this.hasSf ? sf : undefined]);
     this.data.shift();

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -184,7 +184,7 @@ describe("chart interaction single-axis", () => {
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData(50);
+    chart.updateChartWithNewData(50, 0);
     vi.runAllTimers();
 
     onHover(1);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -72,7 +72,7 @@ export class TimeSeriesChart {
     };
   }
 
-  public updateChartWithNewData(ny: number, sf?: number) {
+  public updateChartWithNewData(ny: number, sf: number) {
     this.data.append(ny, sf);
     this.drawNewData();
   }


### PR DESCRIPTION
## Summary
- require NY and SF values in `ChartData.append`
- validate inputs and remove warning branches
- update chart and tests to pass second series explicitly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950eb4f180832bab8d40bb02ce2010