### PR TITLE
refactor: rename legend hover to highlightIndex

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -51,7 +51,7 @@ export class LegendController implements ILegendController {
     this.cancelRefresh = cancel;
   }
 
-  public onHover = (idx: number) => {
+  public highlightIndex = (idx: number) => {
     this.highlightedDataIdx = Math.min(Math.max(idx, 0), this.data.length - 1);
     this.scheduleRefresh();
   };

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -65,7 +65,7 @@ let legendRefresh: any;
 vi.mock("../../../samples/LegendController.ts", () => ({
   LegendController: class {
     refresh = vi.fn();
-    onHover = vi.fn();
+    highlightIndex = vi.fn();
     destroy = vi.fn();
     constructor() {
       legendRefresh = this.refresh;

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,5 +1,5 @@
 export interface ILegendController {
-  onHover: (idx: number) => void;
+  highlightIndex: (idx: number) => void;
   refresh: () => void;
   destroy: () => void;
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -103,7 +103,7 @@ export class TimeSeriesChart {
 
   public onHover = (x: number) => {
     const idx = this.state.transforms.ny.fromScreenToModelX(x);
-    this.legendController.onHover(idx);
+    this.legendController.highlightIndex(idx);
   };
 
   private drawNewData = () => {


### PR DESCRIPTION
## Summary
- rename ILegendController.onHover to highlightIndex
- update draw.ts and LegendController to use highlightIndex
- adjust reset-zoom interaction test for new method

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950ff1de10832b83a24bc98d3268ab