### PR TITLE
feat: add legend highlight clearing

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -60,6 +60,17 @@ export class LegendController implements ILegendController {
     this.scheduleRefresh();
   };
 
+  public clearHighlight = () => {
+    this.cancelRefresh();
+    this.legendTime.text("");
+    this.legendGreen.text("");
+    this.legendBlue.text("");
+    this.highlightedGreenDot.style.display = "none";
+    if (this.highlightedBlueDot) {
+      this.highlightedBlueDot.style.display = "none";
+    }
+  };
+
   private update() {
     const {
       ny: greenData,
@@ -79,6 +90,7 @@ export class LegendController implements ILegendController {
     ) => {
       legendSel.text(fixNaN(val, " "));
       if (node) {
+        node.style.display = "";
         const y = yScale(fixNaN(val, 0) as number);
         const ySafe = isNaN(y) ? 0 : y;
         updateNode(node, this.identityMatrix.translate(screenX, ySafe));

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,5 +1,6 @@
 export interface ILegendController {
   onHover: (idx: number) => void;
   refresh: () => void;
+  clearHighlight: () => void;
   destroy: () => void;
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -46,9 +46,12 @@ export class TimeSeriesChart {
       .attr("class", "zoom")
       .attr("width", this.state.dimensions.width)
       .attr("height", this.state.dimensions.height);
-    this.zoomArea.on("mousemove", mouseMoveHandler);
 
     this.legendController = legendControllerFactory(this.state, this.data);
+
+    this.zoomArea
+      .on("mousemove", mouseMoveHandler)
+      .on("mouseleave", () => this.legendController.clearHighlight());
 
     this.zoomState = new ZoomState(
       this.zoomArea,
@@ -79,7 +82,7 @@ export class TimeSeriesChart {
 
   public dispose() {
     this.zoomState.destroy();
-    this.zoomArea.on("mousemove", null);
+    this.zoomArea.on("mousemove", null).on("mouseleave", null);
     this.zoomArea.remove();
     this.legendController.destroy();
   }


### PR DESCRIPTION
## Summary
- extend ILegendController with clearHighlight
- hide dots and clear legend text when leaving chart
- clear legend highlights on zoom area mouseleave

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950fe4246c832b90286623ca88822e