### PR TITLE
feat: handle viewport resize

### DIFF
--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -65,6 +65,18 @@ export function createScales(
   return { x, yNy, ySf };
 }
 
+export function updateScaleRanges(
+  scales: ScaleSet,
+  bScreenXVisible: AR1Basis,
+  bScreenYVisible: AR1Basis,
+) {
+  scales.x.range(bScreenXVisible.toArr());
+  scales.yNy.range(bScreenYVisible.toArr());
+  if (scales.ySf) {
+    scales.ySf.range(bScreenYVisible.toArr());
+  }
+}
+
 export function updateScaleX(
   x: ScaleTime<number, number>,
   bIndexVisible: AR1Basis,

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -63,6 +63,8 @@ class DummyLegendController {
   refresh = vi.fn();
   onHover = vi.fn();
   destroy = vi.fn();
+  highlightIndex = vi.fn();
+  clearHighlight = vi.fn();
 }
 
 function createChart() {

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const transformInstances: any[] = [];
+vi.mock("../ViewportTransform.ts", () => ({
+  ViewportTransform: class {
+    matrix = {};
+    constructor() {
+      transformInstances.push(this);
+    }
+    onZoomPan = vi.fn();
+    fromScreenToModelX = vi.fn((x: number) => x);
+    fromScreenToModelBasisX = vi.fn((b: any) => b);
+    onViewPortResize = vi.fn();
+    onReferenceViewWindowResize = vi.fn();
+  },
+}));
+
+const axisInstances: any[] = [];
+vi.mock("../axis.ts", () => ({
+  Orientation: { Bottom: 0, Right: 1, Left: 2 },
+  MyAxis: class {
+    axisUpCalls = 0;
+    constructor() {
+      axisInstances.push(this);
+    }
+    setScale = vi.fn(() => this);
+    axis = vi.fn();
+    axisUp = vi.fn(() => {
+      this.axisUpCalls++;
+    });
+    ticks = vi.fn(() => this);
+    setTickSize = vi.fn(() => this);
+    setTickPadding = vi.fn(() => this);
+  },
+}));
+
+vi.mock("./render/utils.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./render/utils.ts")>();
+  return { ...actual, renderPaths: vi.fn() };
+});
+
+vi.mock("../utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
+vi.mock("d3-zoom", () => ({
+  zoom: () => {
+    const behavior: any = () => {};
+    behavior.scaleExtent = () => behavior;
+    behavior.translateExtent = () => behavior;
+    behavior.on = () => behavior;
+    behavior.transform = () => {};
+    return behavior;
+  },
+}));
+
+import { select } from "d3-selection";
+import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { renderPaths } from "./render/utils.ts";
+import { updateNode } from "../utils/domNodeTransform.ts";
+
+class DummyLegendController {
+  refresh = vi.fn();
+  onHover = vi.fn();
+  destroy = vi.fn();
+}
+
+function createChart() {
+  const parent = document.createElement("div");
+  Object.defineProperty(parent, "clientWidth", {
+    value: 100,
+    configurable: true,
+  });
+  Object.defineProperty(parent, "clientHeight", {
+    value: 50,
+    configurable: true,
+  });
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  parent.appendChild(svg);
+  const source: IDataSource = {
+    startTime: 0,
+    timeStep: 1,
+    length: 3,
+    seriesCount: 2,
+    getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+  };
+  return new TimeSeriesChart(
+    select(svg) as any,
+    source,
+    () => new DummyLegendController(),
+    true,
+    () => {},
+    () => {},
+  );
+}
+
+const renderPathsMock = vi.mocked(renderPaths);
+
+beforeEach(() => {
+  transformInstances.length = 0;
+  axisInstances.length = 0;
+  renderPathsMock.mockClear();
+  vi.mocked(updateNode).mockClear();
+});
+
+describe("resize", () => {
+  it("updates transforms, scales, axes and paths", () => {
+    const chart = createChart();
+    const state = (chart as any).state;
+    const ny = transformInstances[0];
+    const sf = transformInstances[1];
+    const xAxis = axisInstances[0];
+    const yAxis = axisInstances[1];
+    const yRight = axisInstances[2];
+
+    const renderBefore = renderPathsMock.mock.calls.length;
+    const nyCalls = ny.onViewPortResize.mock.calls.length;
+    const sfCalls = sf.onViewPortResize.mock.calls.length;
+    const xAxisCalls = xAxis.axisUpCalls;
+    const yAxisCalls = yAxis.axisUpCalls;
+    const yRightCalls = yRight.axisUpCalls;
+
+    chart.resize({ width: 200, height: 100 });
+
+    expect(ny.onViewPortResize.mock.calls.length).toBe(nyCalls + 1);
+    expect(sf.onViewPortResize.mock.calls.length).toBe(sfCalls + 1);
+    const arg = ny.onViewPortResize.mock.calls.at(-1)![0];
+    expect(arg.toArr()).toEqual([
+      [0, 200],
+      [100, 0],
+    ]);
+
+    expect(state.scales.x.range()).toEqual([0, 200]);
+    expect(state.scales.yNy.range()).toEqual([100, 0]);
+    expect(state.scales.ySf!.range()).toEqual([100, 0]);
+
+    expect(xAxis.axisUpCalls).toBeGreaterThan(xAxisCalls);
+    expect(yAxis.axisUpCalls).toBeGreaterThan(yAxisCalls);
+    expect(yRight.axisUpCalls).toBeGreaterThan(yRightCalls);
+
+    expect(renderPathsMock.mock.calls.length).toBe(renderBefore + 1);
+    expect(vi.mocked(updateNode).mock.calls.length).toBeGreaterThan(0);
+  });
+});

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,9 +4,10 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IMinMax, IDataSource } from "./chart/data.ts";
 import { setupRender, refreshChart } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { renderPaths } from "./chart/render/utils.ts";
+import { renderPaths, updateScaleRanges } from "./chart/render/utils.ts";
 import type { ILegendController } from "./chart/legend.ts";
 import { ZoomState } from "./chart/zoomState.ts";
+import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 
 export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
@@ -99,6 +100,32 @@ export class TimeSeriesChart {
       .attr("width", dimensions.width)
       .attr("height", dimensions.height);
     this.zoomState.updateExtents(dimensions);
+
+    const bScreenXVisible = new AR1Basis(0, dimensions.width);
+    const bScreenYVisible = new AR1Basis(dimensions.height, 0);
+    const bScreenVisibleDp = DirectProductBasis.fromProjections(
+      bScreenXVisible,
+      bScreenYVisible,
+    );
+    this.state.transforms.bScreenXVisible = bScreenXVisible;
+    this.state.transforms.ny.onViewPortResize(bScreenVisibleDp);
+    this.state.transforms.sf?.onViewPortResize(bScreenVisibleDp);
+
+    updateScaleRanges(this.state.scales, bScreenXVisible, bScreenYVisible);
+
+    this.state.axes.x
+      .setTickSize(dimensions.height)
+      .setTickPadding(8 - dimensions.height);
+    this.state.axes.y
+      .setTickSize(dimensions.width)
+      .setTickPadding(2 - dimensions.width);
+    this.state.axes.yRight
+      ?.setTickSize(dimensions.width)
+      .setTickPadding(2 - dimensions.width);
+
+    refreshChart(this.state, this.data);
+    renderPaths(this.state, this.data.data);
+    this.legendController.refresh();
   };
 
   public onHover = (x: number) => {


### PR DESCRIPTION
## Summary
- adjust scales and transforms when chart viewport is resized
- refresh axes and redraw paths on resize
- add tests for resize handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950f1c0640832baa0664872af5dcf0