### PR TITLE
feat: support custom zoom extents

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -62,6 +62,7 @@ vi.mock("../axis.ts", () => ({
 
 let zoomReset: any;
 let legendRefresh: any;
+let zoomOptions: any;
 vi.mock("../../../samples/LegendController.ts", () => ({
   LegendController: class {
     refresh = vi.fn();
@@ -92,16 +93,18 @@ vi.mock("./zoomState.ts", () => ({
       state: any,
       refreshChart: () => void,
       zoomCallback: (e: any) => void,
+      options?: any,
     ) {
       this.state = state;
       this.refreshChart = refreshChart;
       this.zoomCallback = zoomCallback;
       zoomReset = this.reset;
+      zoomOptions = options;
     }
   },
 }));
 
-function createChart(data: Array<[number, number]>) {
+function createChart(data: Array<[number, number]>, options?: any) {
   currentDataLength = data.length;
   const parent = document.createElement("div");
   const w = Math.max(currentDataLength - 1, 0);
@@ -137,6 +140,7 @@ function createChart(data: Array<[number, number]>) {
     true,
     () => {},
     () => {},
+    options,
   );
 
   return { interaction: chart.interaction };
@@ -146,6 +150,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   nodeTransforms.clear();
   transformInstances.length = 0;
+  zoomOptions = undefined;
   (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
 });
 
@@ -171,5 +176,18 @@ describe("interaction.resetZoom", () => {
     expect(zoomReset).toHaveBeenCalled();
     expect(transform.onZoomPan).toHaveBeenCalledWith({ x: 0, k: 1 });
     expect(legendRefresh).toHaveBeenCalled();
+  });
+});
+
+describe("TimeSeriesChart zoom options", () => {
+  it("forwards custom scale extents to ZoomState", () => {
+    createChart(
+      [
+        [10, 20],
+        [30, 40],
+      ],
+      { scaleExtent: [2, 80] },
+    );
+    expect(zoomOptions).toEqual({ scaleExtent: [2, 80] });
   });
 });

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -168,4 +168,26 @@ describe("ZoomState", () => {
       [20, 30],
     ]);
   });
+
+  it("uses provided scale extents", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const ny = { onZoomPan: vi.fn() };
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny },
+    };
+    const zs = new ZoomState(rect as any, state, vi.fn(), undefined, {
+      scaleExtent: [0.5, 20],
+    });
+
+    const scaleSpy = (zs.zoomBehavior as any).scaleExtent as any;
+    expect(scaleSpy).toHaveBeenCalledWith([0.5, 20]);
+
+    scaleSpy.mockClear();
+
+    zs.updateExtents({ width: 15, height: 25 });
+
+    expect(scaleSpy).toHaveBeenCalledWith([0.5, 20]);
+  });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -9,11 +9,16 @@ import {
 import { drawProc } from "../utils/drawProc.ts";
 import type { RenderState } from "./render.ts";
 
+export interface IZoomStateOptions {
+  scaleExtent?: [number, number];
+}
+
 export class ZoomState {
   public zoomBehavior: ZoomBehavior<SVGRectElement, unknown>;
   private currentPanZoomTransformState: ZoomTransform | null = null;
   private scheduleRefresh: () => void;
   private cancelRefresh: () => void;
+  private scaleExtent: [number, number];
 
   constructor(
     private zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -22,9 +27,11 @@ export class ZoomState {
     private zoomCallback: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
+    options: IZoomStateOptions = {},
   ) {
+    this.scaleExtent = options.scaleExtent ?? [1, 40];
     this.zoomBehavior = d3zoom<SVGRectElement, unknown>()
-      .scaleExtent([1, 40])
+      .scaleExtent(this.scaleExtent)
       .translateExtent([
         [0, 0],
         [state.dimensions.width, state.dimensions.height],
@@ -69,7 +76,7 @@ export class ZoomState {
   public updateExtents = (dimensions: { width: number; height: number }) => {
     this.state.dimensions.width = dimensions.width;
     this.state.dimensions.height = dimensions.height;
-    this.zoomBehavior.scaleExtent([1, 40]).translateExtent([
+    this.zoomBehavior.scaleExtent(this.scaleExtent).translateExtent([
       [0, 0],
       [dimensions.width, dimensions.height],
     ]);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -6,10 +6,11 @@ import { setupRender, refreshChart } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
 import type { ILegendController } from "./chart/legend.ts";
-import { ZoomState } from "./chart/zoomState.ts";
+import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
 
 export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
+export type { IZoomStateOptions } from "./chart/zoomState.ts";
 
 export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
@@ -36,6 +37,7 @@ export class TimeSeriesChart {
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
+    zoomOptions: IZoomStateOptions = {},
   ) {
     this.data = new ChartData(data);
 
@@ -58,6 +60,7 @@ export class TimeSeriesChart {
         zoomHandler(event);
         this.legendController.refresh();
       },
+      zoomOptions,
     );
 
     this.drawNewData();


### PR DESCRIPTION
## Summary
- allow configuring zoom scale extents via `IZoomStateOptions`
- forward zoom options through `TimeSeriesChart`
- test custom scale extents and option forwarding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68950f01cad0832b875dc52b742e1a43