### PR TITLE
refactor: unify series rendering

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -3,7 +3,7 @@
  */
 import { bench, describe } from "vitest";
 import { select } from "d3-selection";
-import { renderPaths } from "../src/chart/render/utils.ts";
+import { renderPaths, lineNy, lineSf } from "../src/chart/render/utils.ts";
 import type { RenderState } from "../src/chart/render.ts";
 import { sizes, datasets } from "./timeSeriesData.ts";
 
@@ -14,8 +14,14 @@ describe("renderPaths performance", () => {
     .data([0, 1])
     .enter()
     .append("path");
+  const nodes = pathSelection.nodes() as SVGPathElement[];
 
-  const state = { paths: { path: pathSelection } } as unknown as RenderState;
+  const state = {
+    series: [
+      { path: nodes[0], line: lineNy },
+      { path: nodes[1], line: lineSf },
+    ],
+  } as unknown as RenderState;
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -109,16 +109,18 @@ describe("refreshChart", () => {
     refreshChart(state, data);
 
     expect(state.series[0].tree).toBe(data.treeNy);
+    expect(state.series[1].tree).toBe(data.treeSf);
     expect(state.series[0].scale.domain()).toEqual([1, 30]);
+    expect(state.series[1].scale.domain()).toEqual([1, 30]);
     expect(updateNodeMock).toHaveBeenCalledTimes(2);
     expect(updateNodeMock).toHaveBeenNthCalledWith(
       1,
-      state.paths.viewSf,
+      state.series[0].view,
       state.transforms.ny.matrix,
     );
     expect(updateNodeMock).toHaveBeenNthCalledWith(
       2,
-      state.series[0].view,
+      state.series[1].view,
       state.transforms.ny.matrix,
     );
   });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -80,7 +80,7 @@ function createSvg() {
 }
 
 describe("buildSeries", () => {
-  it("returns single series for combined axis", () => {
+  it("returns two series for combined axis", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
@@ -100,12 +100,20 @@ describe("buildSeries", () => {
       state.axes,
       state.dualYAxis,
     );
-    expect(series.length).toBe(1);
+    expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
       tree: data.treeNy,
       transform: state.transforms.ny,
       scale: state.scales.yNy,
       view: state.paths.viewNy,
+      axis: state.axes.y,
+      gAxis: state.axes.gY,
+    });
+    expect(series[1]).toMatchObject({
+      tree: data.treeSf,
+      transform: state.transforms.ny,
+      scale: state.scales.yNy,
+      view: state.paths.viewSf,
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
@@ -142,8 +150,8 @@ describe("buildSeries", () => {
     });
     expect(series[1]).toMatchObject({
       tree: data.treeSf,
-      transform: state.transforms.sf,
-      scale: state.scales.ySf,
+      transform: state.transforms.sf!,
+      scale: state.scales.ySf!,
       view: state.paths.viewSf,
       axis: state.axes.yRight,
       gAxis: state.axes.gYRight,

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
-import { initPaths, renderPaths } from "./render/utils.ts";
+import { initPaths, renderPaths, lineNy, lineSf } from "./render/utils.ts";
 import type { RenderState } from "./render.ts";
 
 describe("renderPaths", () => {
@@ -14,8 +14,13 @@ describe("renderPaths", () => {
       .data([0, 1])
       .enter()
       .append("path");
-
-    const state = { paths: { path: pathSelection } } as unknown as RenderState;
+    const nodes = pathSelection.nodes() as SVGPathElement[];
+    const state = {
+      series: [
+        { path: nodes[0], line: lineNy },
+        { path: nodes[1], line: lineSf },
+      ],
+    } as unknown as RenderState;
     const data: Array<[number, number]> = [
       [0, 0],
       [NaN, NaN],
@@ -35,8 +40,14 @@ describe("renderPaths", () => {
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
     const svg = svgSelection.node()!;
     const { path } = initPaths(svgSelection, false);
-    const state = { paths: { path } } as unknown as RenderState;
-    const pathNode = path.node()!;
+    const nodes = path.nodes() as SVGPathElement[];
+    const state = {
+      series: [
+        { path: nodes[0], line: lineNy },
+        { path: undefined, line: lineSf },
+      ],
+    } as unknown as RenderState;
+    const pathNode = nodes[0];
     const spy = vi.spyOn(pathNode, "setAttribute");
 
     renderPaths(state, [[0], [1]]);

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -8,20 +8,15 @@ import type { IMinMax } from "../data.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
-const lineNy = line<[number, number?]>()
+export const lineNy = line<[number, number?]>()
   .defined((d) => !(isNaN(d[0]!) || d[0] == null))
   .x((_, i) => i)
   .y((d) => d[0]!);
 
-const lineSf = line<[number, number?]>()
+export const lineSf = line<[number, number?]>()
   .defined((d) => !(isNaN(d[1]!) || d[1] == null))
   .x((_, i) => i)
   .y((d) => d[1]!);
-
-const lineGenerators = {
-  ny: lineNy,
-  sf: lineSf,
-} as const;
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -120,19 +115,9 @@ export function renderPaths(
   state: RenderState,
   dataArr: Array<[number, number?]>,
 ) {
-  const paths = state.paths.path.nodes() as SVGPathElement[];
-  const pathMap: Record<
-    keyof typeof lineGenerators,
-    SVGPathElement | undefined
-  > = {
-    ny: paths[0],
-    sf: paths[1],
-  };
-
-  for (const [seriesKey, generator] of Object.entries(lineGenerators)) {
-    const path = pathMap[seriesKey as keyof typeof lineGenerators];
-    if (path) {
-      path.setAttribute("d", generator(dataArr) ?? "");
+  for (const s of state.series) {
+    if (s.path) {
+      s.path.setAttribute("d", s.line(dataArr) ?? "");
     }
   }
 }


### PR DESCRIPTION
## Summary
- always build two Series objects with path, transform, scale, axis and generator
- iterate over series in setupRender/refreshChart
- simplify renderPaths to use generator on each series

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950ed6712c832bb9583c439f0f3cb4