### PR TITLE
refactor: move refresh logic into RenderState

### DIFF
--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
-import { setupRender, refreshChart } from "./render.ts";
+import { setupRender } from "./render.ts";
 import * as domNode from "../utils/domNodeTransform.ts";
 
 class Matrix {
@@ -80,7 +80,7 @@ function createSvg() {
   return select(div).select("svg");
 }
 
-describe("refreshChart integration", () => {
+describe("RenderState.refresh integration", () => {
   it("updates scales, axes and series views", () => {
     const svg = createSvg();
     const source: IDataSource = {
@@ -102,7 +102,7 @@ describe("refreshChart integration", () => {
     const ySfBefore = state.scales.ySf!.domain().slice();
 
     data.append(100, 200);
-    refreshChart(state, data);
+    state.refresh(data);
 
     const xAfter = state.scales.x.domain();
     const yNyAfter = state.scales.yNy.domain();

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -21,7 +21,7 @@ vi.mock("../axis.ts", () => {
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, type IDataSource } from "./data.ts";
-import { setupRender, refreshChart } from "./render.ts";
+import { setupRender } from "./render.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 
 class Matrix {
@@ -91,7 +91,7 @@ function createSvg() {
   return select(div).select("svg");
 }
 
-describe("refreshChart", () => {
+describe("RenderState.refresh", () => {
   it("handles single series with secondary data", () => {
     const svg = createSvg();
     const source: IDataSource = {
@@ -106,7 +106,7 @@ describe("refreshChart", () => {
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
-    refreshChart(state, data);
+    state.refresh(data);
 
     expect(state.series[0].tree).toBe(data.treeNy);
     expect(state.series[1].tree).toBe(data.treeSf);
@@ -139,7 +139,7 @@ describe("refreshChart", () => {
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
-    refreshChart(state, data);
+    state.refresh(data);
 
     expect(state.series[0].tree).toBe(data.treeNy);
     expect(state.series[1].tree).toBe(data.treeSf);
@@ -169,7 +169,7 @@ describe("refreshChart", () => {
     };
     const data1 = new ChartData(source1);
     const state = setupRender(svg as any, data1, true);
-    refreshChart(state, data1);
+    state.refresh(data1);
     const source2: IDataSource = {
       startTime: 0,
       timeStep: 1,
@@ -181,7 +181,7 @@ describe("refreshChart", () => {
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
-    refreshChart(state, data2);
+    state.refresh(data2);
 
     expect(state.series[0].tree).toBe(data2.treeNy);
     expect(state.series[1].tree).toBe(data2.treeSf);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -2,7 +2,7 @@ import { Selection } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 
 import { ChartData, IMinMax, IDataSource } from "./chart/data.ts";
-import { setupRender, refreshChart } from "./chart/render.ts";
+import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
 import type { ILegendController } from "./chart/legend.ts";
@@ -58,7 +58,7 @@ export class TimeSeriesChart {
     this.zoomState = new ZoomState(
       this.zoomArea,
       this.state,
-      () => refreshChart(this.state, this.data),
+      () => this.state.refresh(this.data),
       (event) => {
         zoomHandler(event);
         this.legendController.refresh();


### PR DESCRIPTION
## Summary
- migrate standalone refreshChart to RenderState.refresh method
- update draw chart to call state.refresh and drop free function
- adjust tests for new refresh API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689518711d70832b9de03c5b68de8dd4