### PR TITLE
feat: validate segment tree indices

### DIFF
--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -32,6 +32,9 @@ export class SegmentTree<T> {
   }
 
   update(index: number, value: T): void {
+    if (!Number.isInteger(index)) {
+      throw new Error("Index must be an integer");
+    }
     if (index < 0 || index >= this.size) {
       throw new Error("Index is out of range");
     }
@@ -45,6 +48,12 @@ export class SegmentTree<T> {
   }
 
   query(left: number, right: number): T {
+    if (!Number.isInteger(left)) {
+      throw new Error("Left index must be an integer");
+    }
+    if (!Number.isInteger(right)) {
+      throw new Error("Right index must be an integer");
+    }
     if (left < 0 || right >= this.size || left > right) {
       throw new Error("Range is not valid");
     }

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -126,6 +126,15 @@ describe("Segment Tree Tests", () => {
     expect(() => tree.update(3, 5)).toThrow("Index is out of range");
   });
 
+  it("should throw an error when updating with a non-integer index", () => {
+    const data = [1, 2, 3];
+    const sumOperator = (a: number, b: number) => a + b;
+    const identity = 0;
+    const tree = new SegmentTree(data, sumOperator, identity);
+
+    expect(() => tree.update(1.5, 5)).toThrow("Index must be an integer");
+  });
+
   it("should throw an error for invalid ranges", () => {
     const data = [1, 2, 3, 4, 5];
     const sumOperator = (a: number, b: number) => a + b;
@@ -135,6 +144,16 @@ describe("Segment Tree Tests", () => {
     expect(() => tree.query(3, 2)).toThrow("Range is not valid");
     expect(() => tree.query(-1, 2)).toThrow("Range is not valid");
     expect(() => tree.query(0, 5)).toThrow("Range is not valid");
+  });
+
+  it("should throw an error when querying with non-integer indices", () => {
+    const data = [1, 2, 3, 4, 5];
+    const sumOperator = (a: number, b: number) => a + b;
+    const identity = 0;
+    const tree = new SegmentTree(data, sumOperator, identity);
+
+    expect(() => tree.query(1.2, 3)).toThrow("Left index must be an integer");
+    expect(() => tree.query(1, 2.8)).toThrow("Right index must be an integer");
   });
 
   it("should support min queries and updates", () => {


### PR DESCRIPTION
## Summary
- ensure SegmentTree update and query indices are integers
- cover invalid index cases with new tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689519623cd8832baba76ce8c8b349be