### PR TITLE
feat: make secondary series optional

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -247,12 +247,25 @@ describe("ChartData", () => {
         [0, undefined],
         [1, undefined],
       ]);
-      cd.append(2, 0);
+      cd.append(2);
       expect(cd.data).toEqual([
         [1, undefined],
         [2, undefined],
       ]);
       expect(cd.treeNy.query(0, 1)).toEqual({ min: 1, max: 2 });
+    });
+
+    it("ignores provided sf when single-axis", () => {
+      const source: IDataSource = {
+        startTime: 0,
+        timeStep: 1,
+        length: 1,
+        seriesCount: 1,
+        getSeries: (i) => [0][i],
+      };
+      const cd = new ChartData(source);
+      expect(() => cd.append(1, NaN)).not.toThrow();
+      expect(cd.data).toEqual([[1, undefined]]);
     });
   });
 });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -73,14 +73,16 @@ export class ChartData {
     this.rebuildSegmentTrees();
   }
 
-  append(ny: number, sf: number): void {
+  append(ny: number, sf?: number): void {
     if (ny == null || !Number.isFinite(ny)) {
       throw new Error("ChartData.append requires ny to be a finite number");
     }
-    if (sf == null || !Number.isFinite(sf)) {
-      throw new Error("ChartData.append requires sf to be a finite number");
+    if (this.hasSf) {
+      if (sf == null || !Number.isFinite(sf)) {
+        throw new Error("ChartData.append requires sf to be a finite number");
+      }
     }
-    this.data.push([ny, this.hasSf ? sf : undefined]);
+    this.data.push([ny, this.hasSf ? sf! : undefined]);
     this.data.shift();
     this.idxToTime = this.idxShift.composeWith(this.idxToTime);
     this.rebuildSegmentTrees();

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -184,7 +184,7 @@ describe("chart interaction single-axis", () => {
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData(50, 0);
+    chart.updateChartWithNewData(50);
     vi.runAllTimers();
 
     onHover(1);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -78,7 +78,7 @@ export class TimeSeriesChart {
     };
   }
 
-  public updateChartWithNewData(ny: number, sf: number) {
+  public updateChartWithNewData(ny: number, sf?: number) {
     this.data.append(ny, sf);
     this.drawNewData();
   }


### PR DESCRIPTION
## Summary
- allow appending data without a secondary series and validate sf only when needed
- support optional secondary values when updating the chart
- test appending new points for single-series datasets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951985d098832b9f58fcdef1c58f43