### PR TITLE
fix: validate index in getPoint

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -69,6 +69,39 @@ describe("ChartData", () => {
     expect(cd.getPoint(-5)).toEqual({ ny: 10, sf: 20, timestamp: 0 });
   });
 
+  it("throws when index is not finite", () => {
+    const cd = new ChartData(
+      makeSource([
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ]),
+    );
+    expect(() => cd.getPoint(NaN)).toThrow(/idx/);
+    expect(() => cd.getPoint(Infinity)).toThrow(/idx/);
+    expect(() => cd.getPoint(-Infinity)).toThrow(/idx/);
+  });
+
+  it("clamps extreme out-of-range indices", () => {
+    const cd = new ChartData(
+      makeSource([
+        [10, 20],
+        [30, 40],
+        [50, 60],
+      ]),
+    );
+    expect(cd.getPoint(1_000_000)).toEqual({
+      ny: 50,
+      sf: 60,
+      timestamp: 2,
+    });
+    expect(cd.getPoint(-1_000_000)).toEqual({
+      ny: 10,
+      sf: 20,
+      timestamp: 0,
+    });
+  });
+
   it("reflects latest window after multiple appends", () => {
     const cd = new ChartData(
       makeSource([

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -95,6 +95,9 @@ export class ChartData {
     sf?: number;
     timestamp: number;
   } {
+    if (!Number.isFinite(idx)) {
+      throw new Error("ChartData.getPoint requires idx to be a finite number");
+    }
     const clamped = this.clampIndex(Math.round(idx));
     const [ny, sf] = this.data[clamped];
     return {


### PR DESCRIPTION
## Summary
- validate idx in `ChartData.getPoint` using `Number.isFinite`
- add unit tests for NaN and extreme out-of-range indices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895197c6744832b91fe30f7be931802