### PR TITLE
feat: support optional secondary series

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -92,14 +92,14 @@ function createSvg() {
 }
 
 describe("RenderState.refresh", () => {
-  it("handles single series with secondary data", () => {
+  it("handles single series", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      seriesCount: 1,
+      getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
@@ -108,19 +108,13 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
+    expect(state.series.length).toBe(1);
     expect(state.series[0].tree).toBe(data.treeNy);
-    expect(state.series[1].tree).toBe(data.treeSf);
-    expect(state.series[0].scale.domain()).toEqual([1, 30]);
-    expect(state.series[1].scale.domain()).toEqual([1, 30]);
-    expect(updateNodeMock).toHaveBeenCalledTimes(2);
+    expect(state.series[0].scale.domain()).toEqual([1, 3]);
+    expect(updateNodeMock).toHaveBeenCalledTimes(1);
     expect(updateNodeMock).toHaveBeenNthCalledWith(
       1,
       state.series[0].view,
-      state.transforms.ny.matrix,
-    );
-    expect(updateNodeMock).toHaveBeenNthCalledWith(
-      2,
-      state.series[1].view,
       state.transforms.ny.matrix,
     );
   });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -80,6 +80,37 @@ function createSvg() {
 }
 
 describe("buildSeries", () => {
+  it("returns single series when hasSf is false", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      seriesCount: 1,
+      getSeries: (i) => [1, 2, 3][i],
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+    const series = buildSeries(
+      data,
+      state.transforms,
+      state.scales,
+      state.paths,
+      false,
+      state.axes,
+      state.dualYAxis,
+    );
+    expect(series.length).toBe(1);
+    expect(series[0]).toMatchObject({
+      tree: data.treeNy,
+      transform: state.transforms.ny,
+      scale: state.scales.yNy,
+      view: state.paths.viewNy,
+      axis: state.axes.y,
+      gAxis: state.axes.gY,
+    });
+  });
+
   it("returns two series for combined axis", () => {
     const svg = createSvg();
     const source: IDataSource = {
@@ -97,6 +128,7 @@ describe("buildSeries", () => {
       state.transforms,
       state.scales,
       state.paths,
+      true,
       state.axes,
       state.dualYAxis,
     );
@@ -136,6 +168,7 @@ describe("buildSeries", () => {
       state.transforms,
       state.scales,
       state.paths,
+      true,
       state.axes,
       state.dualYAxis,
     );

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -42,10 +42,7 @@ describe("renderPaths", () => {
     const { path } = initPaths(svgSelection, false);
     const nodes = path.nodes() as SVGPathElement[];
     const state = {
-      series: [
-        { path: nodes[0], line: lineNy },
-        { path: undefined, line: lineSf },
-      ],
+      series: [{ path: nodes[0], line: lineNy }],
     } as unknown as RenderState;
     const pathNode = nodes[0];
     const spy = vi.spyOn(pathNode, "setAttribute");

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -108,6 +108,7 @@ export function buildSeries(
   transforms: TransformPair,
   scales: ScaleSet,
   paths: PathSet,
+  hasSf: boolean,
   axes?: AxisSet,
   dualYAxis = false,
 ): Series[] {
@@ -123,7 +124,10 @@ export function buildSeries(
       gAxis: axes?.gY,
       line: lineNy,
     },
-    {
+  ];
+
+  if (hasSf) {
+    series.push({
       tree: data.treeSf,
       transform: dualYAxis && transforms.sf ? transforms.sf : transforms.ny,
       scale: dualYAxis && scales.ySf ? scales.ySf : scales.yNy,
@@ -132,8 +136,8 @@ export function buildSeries(
       axis: axes?.yRight ?? axes?.y,
       gAxis: axes?.gYRight ?? axes?.gY,
       line: lineSf,
-    },
-  ];
+    });
+  }
 
   return series;
 }
@@ -176,11 +180,12 @@ export function setupRender(
     transformsInner,
     scales,
     paths,
+    hasSf,
     undefined,
     dualYAxis,
   );
 
-  if (series[0].scale === series[1].scale && data.treeSf) {
+  if (series.length > 1 && series[0].scale === series[1].scale && data.treeSf) {
     const { combined, dp } = data.combinedTemperatureDp(data.bIndexFull);
     for (const s of series) {
       s.transform.onReferenceViewWindowResize(dp);
@@ -241,9 +246,15 @@ export function setupRender(
 
       // Update tree references in case data has changed
       series[0].tree = data.treeNy;
-      series[1].tree = data.treeSf;
+      if (series.length > 1) {
+        series[1].tree = data.treeSf;
+      }
 
-      if (series[0].scale === series[1].scale && data.treeSf) {
+      if (
+        series.length > 1 &&
+        series[0].scale === series[1].scale &&
+        data.treeSf
+      ) {
         const { combined, dp } = data.combinedTemperatureDp(bIndexVisible);
         for (const s of series) {
           s.transform.onReferenceViewWindowResize(dp);


### PR DESCRIPTION
## Summary
- allow charts to build a single series when no secondary field is present
- update render setup and refresh logic to loop over available series
- adjust unit tests for single-series scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951df132e4832b9623aa63cda91197