### PR TITLE
feat: allow optional secondary series

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -297,7 +297,7 @@ describe("ChartData", () => {
         getSeries: (i) => [0][i],
       };
       const cd = new ChartData(source);
-      expect(() => cd.append(1, NaN)).not.toThrow();
+      expect(() => cd.append(1)).not.toThrow();
       expect(cd.data).toEqual([[1, undefined]]);
     });
   });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -82,7 +82,8 @@ export class ChartData {
         throw new Error("ChartData.append requires sf to be a finite number");
       }
     }
-    this.data.push([ny, this.hasSf ? sf! : undefined]);
+    const point: [number, number?] = this.hasSf ? [ny, sf!] : [ny, undefined];
+    this.data.push(point);
     this.data.shift();
     this.idxToTime = this.idxShift.composeWith(this.idxToTime);
     this.rebuildSegmentTrees();

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -78,7 +78,7 @@ export class TimeSeriesChart {
     };
   }
 
-  public updateChartWithNewData(ny: number, sf?: number) {
+  public updateChartWithNewData(ny: number, sf?: number): void {
     this.data.append(ny, sf);
     this.drawNewData();
   }


### PR DESCRIPTION
## Summary
- support appending data without secondary series via optional parameter
- wire optional secondary series through chart update method
- adjust tests for single-series charts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951de9c8b0832b97fa500e3189f85e