### PR TITLE
chore: enable ESLint warnings for unused vars and const/spread

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,10 +12,10 @@ export default tsEslint.config(
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-empty-object-type": "off",
-      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "warn",
       "@typescript-eslint/no-unsafe-function-type": "off",
-      "prefer-const": "off",
-      "prefer-spread": "off",
+      "prefer-const": "warn",
+      "prefer-spread": "warn",
     },
   },
 );


### PR DESCRIPTION
## Summary
- turn on `@typescript-eslint/no-unused-vars` rule
- enable `prefer-const` and `prefer-spread` warnings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689523f4db40832bb9750019173df484