### PR TITLE
fix highlight dot y-axis orientation

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import { JSDOM } from "jsdom";
+import { select } from "d3-selection";
+
+import { LegendController } from "./LegendController.ts";
+import { ChartData, IDataSource } from "../svg-time-series/src/chart/data.ts";
+import { setupRender } from "../svg-time-series/src/chart/render.ts";
+import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
+
+class Matrix {
+  constructor(
+    public a = 1,
+    public b = 0,
+    public c = 0,
+    public d = 1,
+    public e = 0,
+    public f = 0,
+  ) {}
+
+  multiply(m: Matrix) {
+    return new Matrix(
+      this.a * m.a + this.c * m.b,
+      this.b * m.a + this.d * m.b,
+      this.a * m.c + this.c * m.d,
+      this.b * m.c + this.d * m.d,
+      this.a * m.e + this.c * m.f + this.e,
+      this.b * m.e + this.d * m.f + this.f,
+    );
+  }
+
+  translate(tx: number, ty: number) {
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
+  }
+
+  scale(sx: number, sy: number) {
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
+  }
+
+  inverse() {
+    const det = this.a * this.d - this.b * this.c;
+    return new Matrix(
+      this.d / det,
+      -this.b / det,
+      -this.c / det,
+      this.a / det,
+      (this.c * this.f - this.d * this.e) / det,
+      (this.b * this.e - this.a * this.f) / det,
+    );
+  }
+}
+
+class Point {
+  constructor(
+    public x = 0,
+    public y = 0,
+  ) {}
+
+  matrixTransform(m: Matrix) {
+    return new Point(
+      this.x * m.a + this.y * m.c + m.e,
+      this.x * m.b + this.y * m.d + m.f,
+    );
+  }
+}
+
+beforeAll(() => {
+  (globalThis as any).DOMMatrix = Matrix;
+  (globalThis as any).DOMPoint = Point;
+  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+});
+
+function createSvgAndLegend() {
+  const dom = new JSDOM(
+    `<div id="c"><svg></svg></div><div id="l"><div class="chart-legend__time"></div><div class="chart-legend__green_value"></div><div class="chart-legend__blue_value"></div></div>`,
+    {
+      pretendToBeVisual: true,
+      contentType: "text/html",
+    },
+  );
+  const div = dom.window.document.getElementById("c") as any;
+  Object.defineProperty(div, "clientWidth", { value: 100 });
+  Object.defineProperty(div, "clientHeight", { value: 100 });
+  const svg = select(div).select("svg");
+  const legendDiv = select(dom.window.document.getElementById("l")!);
+  return { svg, legendDiv };
+}
+
+describe("LegendController", () => {
+  it("positions highlight dot using inverted y-axis", () => {
+    const { svg, legendDiv } = createSvgAndLegend();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      seriesCount: 1,
+      getSeries: (i) => [10, 20][i],
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+    const lc = new LegendController(legendDiv as any, state, data);
+
+    const updateSpy = vi
+      .spyOn(domNode, "updateNode")
+      .mockImplementation(() => {});
+
+    vi.useFakeTimers();
+    lc.highlightIndex(1);
+    vi.runAllTimers();
+
+    const lastCall = updateSpy.mock.calls[updateSpy.mock.calls.length - 1];
+    const matrix = lastCall[1] as Matrix;
+    const expectedY =
+      state.dimensions.height - state.scales.yNy(data.getPoint(1).ny);
+    expect(matrix.f).toBeCloseTo(expectedY);
+
+    vi.useRealTimers();
+    updateSpy.mockRestore();
+    lc.destroy();
+  });
+});

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -92,7 +92,7 @@ export class LegendController implements ILegendController {
       if (node) {
         node.style.display = "";
         const y = yScale(fixNaN(val, 0) as number);
-        const ySafe = isNaN(y) ? 0 : y;
+        const ySafe = isNaN(y) ? 0 : this.state.dimensions.height - y;
         updateNode(node, this.identityMatrix.translate(screenX, ySafe));
       }
     };

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -176,7 +176,7 @@ describe("chart interaction single-axis", () => {
     const circle = svgEl.querySelector("circle")! as SVGCircleElement;
     const transform = nodeTransforms.get(circle)!;
     expect(transform.tx).toBe(1);
-    expect(transform.ty).toBe(0);
+    expect(transform.ty).toBe(50);
   });
 
   it("updates circle after appending data", () => {
@@ -197,7 +197,7 @@ describe("chart interaction single-axis", () => {
     const circle = svgEl.querySelector("circle")! as SVGCircleElement;
     const transform = nodeTransforms.get(circle)!;
     expect(transform.tx).toBe(1);
-    expect(transform.ty).toBe(0);
+    expect(transform.ty).toBe(50);
   });
 
   it("handles NaN data", () => {

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -191,9 +191,9 @@ describe("chart interaction", () => {
     const greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
     const blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
     expect(greenTransform.tx).toBe(1);
-    expect(greenTransform.ty).toBe(0);
+    expect(greenTransform.ty).toBe(50);
     expect(blueTransform.tx).toBe(1);
-    expect(blueTransform.ty).toBe(0);
+    expect(blueTransform.ty).toBe(50);
   });
 
   it("updates circles after appending data", () => {
@@ -221,9 +221,9 @@ describe("chart interaction", () => {
     const greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
     const blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
     expect(greenTransform.tx).toBe(1);
-    expect(greenTransform.ty).toBe(0);
+    expect(greenTransform.ty).toBe(50);
     expect(blueTransform.tx).toBe(1);
-    expect(blueTransform.ty).toBe(0);
+    expect(blueTransform.ty).toBe(50);
   });
 
   it("uses custom time formatter when provided", () => {
@@ -286,9 +286,9 @@ describe("chart interaction", () => {
       "20",
     );
     expect(greenTransform.tx).toBe(0);
-    expect(greenTransform.ty).toBe(50);
+    expect(greenTransform.ty).toBe(0);
     expect(blueTransform.tx).toBe(0);
-    expect(blueTransform.ty).toBe(50);
+    expect(blueTransform.ty).toBe(0);
 
     onHover(100);
     vi.runAllTimers();
@@ -302,9 +302,9 @@ describe("chart interaction", () => {
       "60",
     );
     expect(greenTransform.tx).toBe(2);
-    expect(greenTransform.ty).toBe(0);
+    expect(greenTransform.ty).toBe(50);
     expect(blueTransform.tx).toBe(2);
-    expect(blueTransform.ty).toBe(0);
+    expect(blueTransform.ty).toBe(50);
   });
 
   it("throws on zero-length dataset", () => {


### PR DESCRIPTION
## Summary
- fix highlight dot positioning by inverting y-axis reference
- cover highlight orientation with unit tests and adjust existing expectations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689525260560832b92e39eb6a3c3a97f