### PR TITLE
ci: cache dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check


### PR DESCRIPTION
## Summary
- cache Node dependencies in CI workflow

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689528788244832b9ba0f539054c2314