### PR TITLE
refactor: compute timestamps with start index

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -43,7 +43,7 @@ describe("ChartData", () => {
       [0, 0],
       [1, 1],
     ]);
-    expect(cd.idxToTime.applyToPoint(0)).toBe(0);
+    expect(cd.getPoint(0).timestamp).toBe(0);
 
     cd.append(2, 2);
 
@@ -52,8 +52,8 @@ describe("ChartData", () => {
       [2, 2],
     ]);
     // appending shifts the index-to-time mapping one step forward
-    expect(cd.idxToTime.applyToPoint(0)).toBe(1);
-    expect(cd.idxToTime.applyToPoint(1)).toBe(2);
+    expect(cd.getPoint(0).timestamp).toBe(1);
+    expect(cd.getPoint(1).timestamp).toBe(2);
   });
 
   it("provides clamped point data and timestamp", () => {
@@ -118,8 +118,8 @@ describe("ChartData", () => {
       [3, 3],
       [4, 4],
     ]);
-    expect(cd.idxToTime.applyToPoint(0)).toBe(3);
-    expect(cd.idxToTime.applyToPoint(1)).toBe(4);
+    expect(cd.getPoint(0).timestamp).toBe(3);
+    expect(cd.getPoint(1).timestamp).toBe(4);
     expect(cd.treeNy.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(cd.treeSf!.query(0, 1)).toEqual({ min: 3, max: 4 });
   });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -65,8 +65,10 @@ export function updateScaleX(
   bIndexVisible: AR1Basis,
   data: ChartData,
 ) {
-  const bTimeVisible = bIndexVisible.transformWith(data.idxToTime);
-  x.domain(bTimeVisible.toArr());
+  const [minIdx, maxIdx] = bIndexVisible.toArr();
+  const start = data.startTime + (data.startIndex + minIdx) * data.timeStep;
+  const end = data.startTime + (data.startIndex + maxIdx) * data.timeStep;
+  x.domain([start, end]);
 }
 
 export function updateScaleY(


### PR DESCRIPTION
## Summary
- track startIndex with startTime/timeStep for timestamp calculation
- update scale generation to use startIndex-based times
- adjust tests to validate timestamp formula via getPoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68952bebf774832b8bb83060c37cb5b3