### PR TITLE
fix: handle optional secondary series

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -111,12 +111,14 @@ describe("RenderState.refresh", () => {
     expect(state.series.length).toBe(1);
     expect(state.series[0].tree).toBe(data.treeNy);
     expect(state.series[0].scale.domain()).toEqual([1, 3]);
-    expect(updateNodeMock).toHaveBeenCalledTimes(1);
-    expect(updateNodeMock).toHaveBeenNthCalledWith(
-      1,
-      state.series[0].view,
-      state.transforms.ny.matrix,
-    );
+    expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
+    state.series.forEach((s, i) => {
+      expect(updateNodeMock).toHaveBeenNthCalledWith(
+        i + 1,
+        s.view,
+        s.transform.matrix,
+      );
+    });
   });
 
   it("updates dual-axis series independently", () => {
@@ -139,17 +141,14 @@ describe("RenderState.refresh", () => {
     expect(state.series[1].tree).toBe(data.treeSf);
     expect(state.series[0].scale.domain()).toEqual([1, 3]);
     expect(state.series[1].scale.domain()).toEqual([10, 30]);
-    expect(updateNodeMock).toHaveBeenCalledTimes(2);
-    expect(updateNodeMock).toHaveBeenNthCalledWith(
-      1,
-      state.series[0].view,
-      state.transforms.ny.matrix,
-    );
-    expect(updateNodeMock).toHaveBeenNthCalledWith(
-      2,
-      state.series[1].view,
-      state.transforms.sf!.matrix,
-    );
+    expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
+    state.series.forEach((s, i) => {
+      expect(updateNodeMock).toHaveBeenNthCalledWith(
+        i + 1,
+        s.view,
+        s.transform.matrix,
+      );
+    });
   });
 
   it("refreshes after data changes", () => {
@@ -181,6 +180,6 @@ describe("RenderState.refresh", () => {
     expect(state.series[1].tree).toBe(data2.treeSf);
     expect(state.series[0].scale.domain()).toEqual([4, 6]);
     expect(state.series[1].scale.domain()).toEqual([40, 60]);
-    expect(updateNodeMock).toHaveBeenCalledTimes(2);
+    expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -3,9 +3,10 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender, buildSeries } from "./render.ts";
+import { initPaths } from "./render/utils.ts";
 
 class Matrix {
   constructor(
@@ -189,5 +190,33 @@ describe("buildSeries", () => {
       axis: state.axes.yRight,
       gAxis: state.axes.gYRight,
     });
+  });
+
+  it("omits secondary series when path is missing", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      seriesCount: 2,
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+    const svg2 = select(document.createElement("div")).append(
+      "svg",
+    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+    const singlePaths = initPaths(svg2, false);
+    const series = buildSeries(
+      data,
+      state.transforms,
+      state.scales,
+      singlePaths,
+      true,
+      state.axes,
+      state.dualYAxis,
+    );
+    expect(series.length).toBe(1);
   });
 });

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -49,7 +49,7 @@ describe("renderPaths", () => {
 
     renderPaths(state, [[0], [1]]);
 
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledTimes(state.series.length);
     expect(path.attr("d")).not.toBe("");
     expect(svg.querySelectorAll("path").length).toBe(1);
 

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -126,7 +126,7 @@ export function buildSeries(
     },
   ];
 
-  if (hasSf) {
+  if (hasSf && data.treeSf && nodes[1]) {
     series.push({
       tree: data.treeSf,
       transform: dualYAxis && transforms.sf ? transforms.sf : transforms.ny,
@@ -202,8 +202,12 @@ export function setupRender(
   const axes = setupAxes(svg, scales, width, height, hasSf, dualYAxis);
 
   // Attach axes to series after scales have been initialized
-  const axisArr = [axes.y, axes.yRight ?? axes.y];
-  const gAxisArr = [axes.gY, axes.gYRight ?? axes.gY];
+  const axisArr = [axes.y];
+  const gAxisArr = [axes.gY];
+  if (series.length > 1) {
+    axisArr.push(axes.yRight ?? axes.y);
+    gAxisArr.push(axes.gYRight ?? axes.gY);
+  }
   series.forEach((s, i) => {
     s.axis = axisArr[i];
     s.gAxis = gAxisArr[i];

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -115,7 +115,9 @@ export function renderPaths(
   state: RenderState,
   dataArr: Array<[number, number?]>,
 ) {
-  for (const s of state.series) {
+  const series = state.series;
+  for (let i = 0; i < series.length; i++) {
+    const s = series[i];
     if (s.path) {
       s.path.setAttribute("d", s.line(dataArr) ?? "");
     }


### PR DESCRIPTION
## Summary
- avoid creating secondary series when its tree or SVG path is missing
- drive axis attachment by actual series length
- iterate paths based on existing series and extend tests for dynamic length

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68952bffa0c0832b8896376fca9381ba