### PR TITLE
ci: fetch full history for commitlint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -25,4 +27,5 @@ jobs:
       - run: npm run format:check
       - run: npm run typecheck
       - run: npm run commitlint -- --from origin/${{ github.base_ref }} --to HEAD
+        if: ${{ github.event_name == 'pull_request' }}
       - run: npm test


### PR DESCRIPTION
## Summary
- checkout full history so commitlint can compare against base branch
- run commitlint only for pull requests

## Testing
- `npm run format`
- `git commit -am "ci: fetch full history for commitlint" && git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6895a7c8e924832ba04a53901672a6fb