### PR TITLE
chore: format YAML files

### DIFF
--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,4 +1,5 @@
 module.exports = {
   "*.{js,jsx,ts,tsx}": ["eslint --fix", "prettier --write"],
   "*.{cjs,mjs,json,css,md}": ["prettier --write"],
+  "*.{yml,yaml}": ["prettier --write"],
 };


### PR DESCRIPTION
## Summary
- ensure YAML files are formatted by prettier in lint-staged

## Testing
- `npm run format`
- `git commit -am "chore: format YAML files"`


------
https://chatgpt.com/codex/tasks/task_e_6895ec6d32ec832b82ec8015da5e2b40