### PR TITLE
fix: align legend highlight dots with model coordinates

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -113,11 +113,12 @@ describe("LegendController", () => {
 
     const lastCall = updateSpy.mock.calls[updateSpy.mock.calls.length - 1];
     const matrix = lastCall[1] as Matrix;
-    const expectedY =
-      state.dimensions.height - state.scales.yNy(data.getPoint(1).ny);
-    const screenX = state.scales.x(data.getPoint(1).timestamp);
-    expect(matrix.e).toBeCloseTo(screenX);
-    expect(matrix.f).toBeCloseTo(expectedY);
+    const modelPoint = new Point(1, data.getPoint(1).ny);
+    const expected = modelPoint.matrixTransform(
+      state.transforms.ny.matrix as any,
+    );
+    expect(matrix.e).toBeCloseTo(expected.x);
+    expect(matrix.f).toBeCloseTo(expected.y);
     const circle = svg.select("circle").node() as SVGCircleElement;
     expect(circle.getAttribute("stroke")).toBe("green");
     expect(circle.getAttribute("r")).toBe("2");

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -90,19 +90,20 @@ export class LegendController implements ILegendController {
 
     const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
       isNaN(n) ? valueForNaN : n;
-    const screenX = this.state.scales.x(timestamp);
+    const x = this.highlightedDataIdx;
     const updateDot = (
       val: number,
       legendSel: Selection<HTMLElement, unknown, HTMLElement, unknown>,
       node: SVGGraphicsElement | null,
-      yScale: (n: number) => number,
+      matrix: DOMMatrix,
     ) => {
       legendSel.text(fixNaN(val, " "));
       if (node) {
         node.style.display = "";
-        const y = yScale(fixNaN(val, 0) as number);
-        const ySafe = isNaN(y) ? 0 : this.state.dimensions.height - y;
-        updateNode(node, this.identityMatrix.translate(screenX, ySafe));
+        const point = new DOMPoint(x, fixNaN(val, 0) as number).matrixTransform(
+          matrix,
+        );
+        updateNode(node, this.identityMatrix.translate(point.x, point.y));
       }
     };
 
@@ -110,14 +111,15 @@ export class LegendController implements ILegendController {
       greenData,
       this.legendGreen,
       this.highlightedGreenDot,
-      this.state.scales.yNy,
+      this.state.transforms.ny.matrix,
     );
     if (this.highlightedBlueDot) {
+      const tf = this.state.transforms.sf ?? this.state.transforms.ny;
       updateDot(
         blueData as number,
         this.legendBlue,
         this.highlightedBlueDot,
-        this.state.scales.ySf ?? this.state.scales.yNy,
+        tf.matrix,
       );
     }
   }

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -189,7 +189,7 @@ describe("chart interaction single-axis", () => {
     const circle = svgEl.querySelector("circle")! as SVGCircleElement;
     const transform = nodeTransforms.get(circle)!;
     expect(transform.tx).toBe(1);
-    expect(transform.ty).toBe(50);
+    expect(transform.ty).toBe(30);
   });
 
   it("updates circle after appending data", () => {

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -204,9 +204,9 @@ describe("chart interaction", () => {
     const greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
     const blueTransform = nodeTransforms.get(circles[1] as SVGCircleElement)!;
     expect(greenTransform.tx).toBe(1);
-    expect(greenTransform.ty).toBe(50);
+    expect(greenTransform.ty).toBe(30);
     expect(blueTransform.tx).toBe(1);
-    expect(blueTransform.ty).toBe(50);
+    expect(blueTransform.ty).toBe(40);
   });
 
   it("updates circles after appending data", () => {
@@ -236,7 +236,7 @@ describe("chart interaction", () => {
     expect(greenTransform.tx).toBe(1);
     expect(greenTransform.ty).toBe(50);
     expect(blueTransform.tx).toBe(1);
-    expect(blueTransform.ty).toBe(50);
+    expect(blueTransform.ty).toBe(60);
   });
 
   it("uses custom time formatter when provided", () => {
@@ -299,9 +299,9 @@ describe("chart interaction", () => {
       "20",
     );
     expect(greenTransform.tx).toBe(0);
-    expect(greenTransform.ty).toBe(0);
+    expect(greenTransform.ty).toBe(10);
     expect(blueTransform.tx).toBe(0);
-    expect(blueTransform.ty).toBe(0);
+    expect(blueTransform.ty).toBe(20);
 
     onHover(100);
     vi.runAllTimers();
@@ -317,7 +317,7 @@ describe("chart interaction", () => {
     expect(greenTransform.tx).toBe(2);
     expect(greenTransform.ty).toBe(50);
     expect(blueTransform.tx).toBe(2);
-    expect(blueTransform.ty).toBe(50);
+    expect(blueTransform.ty).toBe(60);
   });
 
   it("throws on zero-length dataset", () => {


### PR DESCRIPTION
## Summary
- use viewport transform matrix to position legend highlight dots
- adjust tests to expect model-space coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ec3232e4832b93c2c2a1e9cbb933