### PR TITLE
fix(build): exclude tests from compilation

### DIFF
--- a/svg-time-series/tsconfig.json
+++ b/svg-time-series/tsconfig.json
@@ -18,5 +18,5 @@
     "declaration": true,
     "declarationDir": "dist"
   },
-  "exclude": ["vite.config.ts"]
+  "exclude": ["vite.config.ts", "**/*.test.ts", "**/*.bench.ts"]
 }


### PR DESCRIPTION
## Summary
- exclude tests and benches from the svg-time-series workspace's TypeScript config to avoid missing dev dependencies during builds

## Testing
- `npm ci --workspaces --if-present --include-workspace-root`
- `npm run build --workspace svg-time-series`


------
https://chatgpt.com/codex/tasks/task_e_6895f35e3ddc832baa96beaa2a94475d