### PR TITLE
chore: centralize lint deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,10 @@
       "devDependencies": {
         "@commitlint/cli": "^19.8.1",
         "@commitlint/config-conventional": "^19.8.1",
+        "@eslint/js": "^9.32.0",
         "@types/jsdom": "^21.1.7",
         "eslint": "^9.32.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-vitest": "^0.5.4",
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
@@ -22,6 +24,7 @@
         "prettier": "^3.6.2",
         "tachometer": "^0.7.2",
         "typescript": "^5.9.2",
+        "typescript-eslint": "^8.39.0",
         "vitest": "^3.2.4"
       }
     },
@@ -12157,12 +12160,7 @@
     },
     "segment-tree-rmq": {
       "version": "0.1.0",
-      "license": "WTFPL",
-      "devDependencies": {
-        "@eslint/js": "^9.32.0",
-        "eslint-config-prettier": "^10.1.8",
-        "typescript-eslint": "^8.39.0"
-      }
+      "license": "WTFPL"
     },
     "svg-time-series": {
       "version": "0.1.0",
@@ -12176,15 +12174,12 @@
         "segment-tree-rmq": "^0.1.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.32.0",
         "@types/d3-scale": "^4.0.9",
         "@types/d3-selection": "^3.0.11",
         "@types/d3-shape": "^3.1.7",
         "@types/d3-timer": "^3.0.2",
         "@types/d3-zoom": "^3.0.8",
-        "eslint-config-prettier": "^10.1.8",
         "rollup-plugin-node-externals": "^8.0.1",
-        "typescript-eslint": "^8.39.0",
         "vite": "^7.0.6",
         "vite-plugin-dts": "^4.5.4"
       }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
     "@commitlint/config-conventional": "^19.8.1",
+    "@eslint/js": "^9.32.0",
     "@types/jsdom": "^21.1.7",
     "eslint": "^9.32.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-vitest": "^0.5.4",
     "husky": "^9.1.7",
     "jsdom": "^26.1.0",
@@ -31,6 +33,7 @@
     "prettier": "^3.6.2",
     "tachometer": "^0.7.2",
     "typescript": "^5.9.2",
+    "typescript-eslint": "^8.39.0",
     "vitest": "^3.2.4"
   }
 }

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -15,10 +15,5 @@
     "typecheck": "tsc --noEmit",
     "bench": "npm run bench:segment-tree",
     "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts --run"
-  },
-  "devDependencies": {
-    "@eslint/js": "^9.32.0",
-    "eslint-config-prettier": "^10.1.8",
-    "typescript-eslint": "^8.39.0"
   }
 }

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -22,15 +22,12 @@
     "segment-tree-rmq": "^0.1.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.32.0",
     "@types/d3-scale": "^4.0.9",
     "@types/d3-selection": "^3.0.11",
     "@types/d3-shape": "^3.1.7",
     "@types/d3-timer": "^3.0.2",
     "@types/d3-zoom": "^3.0.8",
-    "eslint-config-prettier": "^10.1.8",
     "rollup-plugin-node-externals": "^8.0.1",
-    "typescript-eslint": "^8.39.0",
     "vite": "^7.0.6",
     "vite-plugin-dts": "^4.5.4"
   },


### PR DESCRIPTION
## Summary
- centralize eslint and prettier dev dependencies at workspace root
- drop per-package lint dependencies from svg-time-series and segment-tree-rmq

## Testing
- `git commit -m "chore: centralize lint deps"`


------
https://chatgpt.com/codex/tasks/task_e_6895f7d01a4c832bb8c22aa06b644e3b