### PR TITLE
ci: fix commitlint on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,10 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm run typecheck
-      - run: npm run commitlint -- --from origin/${{ github.base_ref }} --to HEAD
+      - run: |
+          BASE_REF="${{ github.base_ref }}"
+          if [ -z "$BASE_REF" ]; then
+            BASE_REF="${{ github.ref_name }}"
+          fi
+          npm run commitlint -- --from origin/$BASE_REF --to HEAD
       - run: npm test


### PR DESCRIPTION
## Summary
- ensure commitlint runs on push workflows

## Testing
- `git commit -am "ci: fix commitlint on push" && git status --short`


------
https://chatgpt.com/codex/tasks/task_e_689602358e54832bbb2e8692dfe87016