### PR TITLE
fix: handle all-NaN segments

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -265,6 +265,20 @@ describe("ChartData", () => {
     expect(dp.y().toArr()).toEqual([-3, 10]);
   });
 
+  it("returns neutral min/max when both series are all NaN", () => {
+    const cd = new ChartData(
+      makeSource([
+        [NaN, NaN],
+        [NaN, NaN],
+      ]),
+    );
+    const range = new AR1Basis(0, 1);
+    expect(cd.treeNy.query(0, 1)).toEqual({ min: 0, max: 0 });
+    expect(cd.treeSf!.query(0, 1)).toEqual({ min: 0, max: 0 });
+    expect(cd.bTemperatureVisible(range, cd.treeNy).toArr()).toEqual([0, 0]);
+    expect(cd.bTemperatureVisible(range, cd.treeSf!).toArr()).toEqual([0, 0]);
+  });
+
   describe("single-axis", () => {
     it("handles data without second series", () => {
       const source: IDataSource = {
@@ -299,6 +313,13 @@ describe("ChartData", () => {
       const cd = new ChartData(source);
       expect(() => cd.append(1)).not.toThrow();
       expect(cd.data).toEqual([[1, undefined]]);
+    });
+
+    it("returns neutral min/max when data is all NaN", () => {
+      const cd = new ChartData(makeSource([[NaN], [NaN]]));
+      const range = new AR1Basis(0, 1);
+      expect(cd.treeNy.query(0, 1)).toEqual({ min: 0, max: 0 });
+      expect(cd.bTemperatureVisible(range, cd.treeNy).toArr()).toEqual([0, 0]);
     });
   });
 });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -109,11 +109,20 @@ export class ChartData {
 
   private buildSeriesMinMax(seriesIdx: 0 | 1): IMinMax[] {
     const result: IMinMax[] = new Array(this.data.length);
+    let hasFinite = false;
     for (let i = 0; i < this.data.length; i++) {
       const val = this.data[i][seriesIdx]!;
-      const minVal = isNaN(val) ? Infinity : val;
-      const maxVal = isNaN(val) ? -Infinity : val;
-      result[i] = { min: minVal, max: maxVal } as IMinMax;
+      if (Number.isNaN(val) || !Number.isFinite(val)) {
+        result[i] = { min: Infinity, max: -Infinity } as IMinMax;
+      } else {
+        hasFinite = true;
+        result[i] = { min: val, max: val } as IMinMax;
+      }
+    }
+    if (!hasFinite) {
+      for (let i = 0; i < result.length; i++) {
+        result[i] = { min: 0, max: 0 } as IMinMax;
+      }
     }
     return result;
   }

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -182,4 +182,35 @@ describe("RenderState.refresh", () => {
     expect(state.series[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
+
+  it("produces finite domain when series is all NaN", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      seriesCount: 1,
+      getSeries: () => NaN,
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+    state.refresh(data);
+    expect(state.series[0].scale.domain()).toEqual([0, 0]);
+  });
+
+  it("produces finite domains for dual-axis all NaN data", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      seriesCount: 2,
+      getSeries: () => NaN,
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, true);
+    state.refresh(data);
+    expect(state.series[0].scale.domain()).toEqual([0, 0]);
+    expect(state.series[1].scale.domain()).toEqual([0, 0]);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent NaN-only ranges from producing Infinity/-Infinity min/max
- test NaN series to ensure finite scale domains

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895fbb11fe4832ba38a61469e083882