### PR TITLE
feat(cli): handle missing commands gracefully

### DIFF
--- a/cli/bin/vz
+++ b/cli/bin/vz
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+export function handleError(err) {
+  const code = Number.parseInt(err?.code, 10);
+  process.exit(Number.isNaN(code) ? 1 : code);
+}
+
+const command = process.argv[2];
+
+if (!command) {
+  handleError({ code: undefined });
+}

--- a/cli/tests/cli.test.js
+++ b/cli/tests/cli.test.js
@@ -1,0 +1,12 @@
+import { expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+it("exits with non-zero code when command is missing", () => {
+  const cliPath = resolve(__dirname, "../bin/vz");
+  const result = spawnSync("node", [cliPath], { encoding: "utf8" });
+  expect(result.status).not.toBe(0);
+});


### PR DESCRIPTION
## Summary
- coerce CLI error codes to integers and default to 1 when parsing fails
- add test ensuring CLI exits non-zero when invoked without a command

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961f366758832b950b43a0db8bd054