### PR TITLE
feat(zoom): allow updating scale extent at runtime

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -190,4 +190,25 @@ describe("ZoomState", () => {
 
     expect(scaleSpy).toHaveBeenCalledWith([0.5, 20]);
   });
+
+  it("updates scale extent at runtime", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const ny = { onZoomPan: vi.fn() };
+    const state: any = {
+      dimensions: { width: 10, height: 10 },
+      transforms: { ny },
+    };
+    const zs = new ZoomState(rect as any, state, vi.fn());
+
+    const scaleSpy = (zs.zoomBehavior as any).scaleExtent as any;
+    scaleSpy.mockClear();
+
+    zs.setScaleExtent([2, 80]);
+    expect(scaleSpy).toHaveBeenCalledWith([2, 80]);
+
+    scaleSpy.mockClear();
+    zs.updateExtents({ width: 20, height: 30 });
+    expect(scaleSpy).toHaveBeenCalledWith([2, 80]);
+  });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -73,6 +73,11 @@ export class ZoomState {
     this.scheduleRefresh();
   };
 
+  public setScaleExtent = (extent: [number, number]) => {
+    this.scaleExtent = extent;
+    this.zoomBehavior.scaleExtent(extent);
+  };
+
   public updateExtents = (dimensions: { width: number; height: number }) => {
     this.state.dimensions.width = dimensions.width;
     this.state.dimensions.height = dimensions.height;


### PR DESCRIPTION
## Summary
- add `setScaleExtent` helper to `ZoomState` to update zoom scale bounds dynamically
- cover runtime scale extent update with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963aae80f8832b92a1fcf852bfd810