### PR TITLE
feat: enable strict TS lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,13 +8,16 @@ import vitest from "@vitest/eslint-plugin";
 export default tsEslint.config(
   eslint.configs.recommended,
   ...tsEslint.configs.recommended,
+  ...tsEslint.configs.strict,
   prettierConfig,
   {
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-empty-object-type": "off",
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-empty-object-type": "warn",
       "@typescript-eslint/no-unused-vars": "warn",
-      "@typescript-eslint/no-unsafe-function-type": "off",
+      "@typescript-eslint/no-unsafe-function-type": "warn",
+      "@typescript-eslint/no-non-null-assertion": "warn",
+      "@typescript-eslint/no-useless-constructor": "warn",
       "prefer-const": "warn",
       "prefer-spread": "warn",
     },


### PR DESCRIPTION
## Summary
- adopt TypeScript ESLint strict config for stronger safety
- warn on explicit `any`, empty object types, unsafe function types, non-null assertions and useless constructors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963ced97b8832b9daf0e9946d52497