### PR TITLE
chore(ci): streamline npm caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check


### PR DESCRIPTION
## Summary
- remove explicit actions/cache step
- enable npm cache in actions/setup-node with package-lock tracking

## Testing
- `npm run format`
- `git commit -m "chore(ci): use setup-node npm cache"`

------
https://chatgpt.com/codex/tasks/task_e_68963ef027ec832ba06b24c6f846910c