### PR TITLE
fix: apply pan after zoom

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -23,11 +23,11 @@ class Matrix {
   }
 
   translate(tx: number, ty: number) {
-    return new Matrix(1, 0, 0, 1, tx, ty).multiply(this);
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
   }
 
   scale(sx: number, sy: number) {
-    return new Matrix(sx, 0, 0, sy, 0, 0).multiply(this);
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
   }
 
   inverse() {
@@ -146,5 +146,12 @@ describe("ViewportTransform", () => {
     const t2 = vt.matrix.e;
     expect(t1).toBeCloseTo(50);
     expect(t2).toBeCloseTo(50);
+  });
+
+  it("applies translation after scaling", () => {
+    const vt = new ViewportTransform();
+    vt.onZoomPan({ x: 10, k: 2 } as any);
+    expect(vt.matrix.a).toBeCloseTo(2);
+    expect(vt.matrix.e).toBeCloseTo(10);
   });
 });

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -40,7 +40,8 @@ export class ViewportTransform {
   }
 
   public onZoomPan(t: ZoomTransform): void {
-    this.zoomTransform = new DOMMatrix().scale(t.k, 1).translate(t.x, 0);
+    // Apply translation after scaling to ensure pan offsets are not affected by zoom.
+    this.zoomTransform = new DOMMatrix().translate(t.x, 0).scale(t.k, 1);
     this.updateComposedMatrix();
   }
 


### PR DESCRIPTION
## Summary
- ensure DOMMatrix translation happens after scaling in `ViewportTransform`
- update tests to use post-multiply DOMMatrix semantics and cover zoom+pan combinations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963de2fb34832bb021af7865575263