### PR TITLE
chore(samples): fix eslint warnings

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -33,7 +33,10 @@ export class LegendController implements ILegendController {
     this.legendGreen = legend.select(".chart-legend__green_value");
     this.legendBlue = legend.select(".chart-legend__blue_value");
 
-    const svg = state.paths.viewNy.ownerSVGElement!;
+    const svg = state.paths.viewNy.ownerSVGElement;
+    if (!svg) {
+      throw new Error("SVG element not found");
+    }
     const makeDot = (path: SVGPathElement) => {
       const color =
         path.getAttribute("stroke") || getComputedStyle(path).stroke || "black";

--- a/samples/ViewWindowTransform.ts
+++ b/samples/ViewWindowTransform.ts
@@ -22,9 +22,6 @@
     this.uMax = uMax;
     this.vMin = vMin;
     this.vMax = vMax;
-
-    const uMinString = new Date(uMin).toDateString();
-
     this.updateNPC();
   }
 

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -31,8 +31,10 @@ onCsv((data: [number, number][]) => {
     (state, chartData) => new LegendController(legend, state, chartData),
   );
   const renderMs = performance.now() - start;
-  document.getElementById("render-time")!.textContent =
-    `render: ${renderMs.toFixed(1)}ms`;
+  const renderTimeEl = document.getElementById("render-time");
+  if (renderTimeEl) {
+    renderTimeEl.textContent = `render: ${renderMs.toFixed(1)}ms`;
+  }
 
   let j = 0;
   animateBench(() => {
@@ -42,7 +44,10 @@ onCsv((data: [number, number][]) => {
   });
 
   measure(3, ({ fps }) => {
-    document.getElementById("fps").textContent = fps.toFixed(2);
+    const fpsEl = document.getElementById("fps");
+    if (fpsEl) {
+      fpsEl.textContent = fps.toFixed(2);
+    }
   });
 
   measureOnce(60, ({ fps }) => {


### PR DESCRIPTION
## Summary
- remove unused `uMinString` from `ViewWindowTransform`
- add null checks for SVG and DOM lookups to satisfy eslint

## Testing
- `npx eslint samples/ViewWindowTransform.ts samples/LegendController.ts samples/benchmarks/chart-components/index.ts && echo 'done'`
- `git commit -am "chore(samples): fix eslint warnings"`


------
https://chatgpt.com/codex/tasks/task_e_68964737ae14832ba8e19d8150feeb49