### PR TITLE
feat: support unlimited series

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -108,9 +108,7 @@ describe("LegendController", () => {
       .spyOn(domNode, "updateNode")
       .mockImplementation(() => {});
 
-    vi.useFakeTimers();
     lc.highlightIndex(1);
-    vi.runAllTimers();
 
     const lastCall = updateSpy.mock.calls[updateSpy.mock.calls.length - 1];
     const matrix = lastCall[1] as Matrix;
@@ -124,7 +122,6 @@ describe("LegendController", () => {
     expect(circle.getAttribute("stroke")).toBe("green");
     expect(circle.getAttribute("r")).toBe("2");
 
-    vi.useRealTimers();
     updateSpy.mockRestore();
     lc.destroy();
   });
@@ -153,12 +150,9 @@ describe("LegendController", () => {
       .spyOn(domNode, "updateNode")
       .mockImplementation(() => {});
 
-    vi.useFakeTimers();
     expect(() => {
       lc.highlightIndex(1);
-      vi.runAllTimers();
     }).not.toThrow();
-    vi.useRealTimers();
     updateSpy.mockRestore();
     lc.destroy();
   });
@@ -183,12 +177,9 @@ describe("LegendController", () => {
     select(state.paths.viewNy).select("path").attr("stroke", "green");
     const lc = new LegendController(legendDiv as any, state, data);
 
-    vi.useFakeTimers();
     expect(() => {
       lc.highlightIndex(1);
-      vi.runAllTimers();
     }).not.toThrow();
-    vi.useRealTimers();
     lc.destroy();
   });
 });

--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
 import { describe, it, expect, vi, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
@@ -113,7 +114,7 @@ describe("LegendController", () => {
 
     const lastCall = updateSpy.mock.calls[updateSpy.mock.calls.length - 1];
     const matrix = lastCall[1] as Matrix;
-    const modelPoint = new Point(1, data.getPoint(1).ny);
+    const modelPoint = new Point(1, data.getPoint(1).values[0]);
     const expected = modelPoint.matrixTransform(
       state.transforms.ny.matrix as any,
     );
@@ -123,6 +124,40 @@ describe("LegendController", () => {
     expect(circle.getAttribute("stroke")).toBe("green");
     expect(circle.getAttribute("r")).toBe("2");
 
+    vi.useRealTimers();
+    updateSpy.mockRestore();
+    lc.destroy();
+  });
+
+  it("handles legacy tuple return from getPoint", () => {
+    const { svg, legendDiv } = createSvgAndLegend();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      seriesCount: 1,
+      getSeries: (i) => [10, 20][i],
+    };
+    const data = new ChartData(source);
+    const originalGetPoint = data.getPoint.bind(data);
+    // mimic old API returning [timestamp, value...]
+    data.getPoint = ((idx: number) => {
+      const { values, timestamp } = originalGetPoint(idx);
+      return [timestamp, ...values] as any;
+    }) as any;
+    const state = setupRender(svg as any, data, false);
+    select(state.paths.viewNy).select("path").attr("stroke", "green");
+    const lc = new LegendController(legendDiv as any, state, data);
+
+    const updateSpy = vi
+      .spyOn(domNode, "updateNode")
+      .mockImplementation(() => {});
+
+    vi.useFakeTimers();
+    expect(() => {
+      lc.highlightIndex(1);
+      vi.runAllTimers();
+    }).not.toThrow();
     vi.useRealTimers();
     updateSpy.mockRestore();
     lc.destroy();

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -33,7 +33,7 @@ export class LegendController implements ILegendController {
     this.legendGreen = legend.select(".chart-legend__green_value");
     this.legendBlue = legend.select(".chart-legend__blue_value");
 
-    const svg = state.paths.viewNy.ownerSVGElement!;
+    const svg = state.paths.viewNy.ownerSVGElement as SVGSVGElement;
     const makeDot = (path: SVGPathElement) => {
       const color =
         path.getAttribute("stroke") || getComputedStyle(path).stroke || "black";
@@ -81,11 +81,21 @@ export class LegendController implements ILegendController {
   }
 
   private update() {
-    const {
-      ny: greenData,
-      sf: blueData,
-      timestamp,
-    } = this.data.getPoint(this.highlightedDataIdx);
+    const rawPoint = this.data.getPoint(this.highlightedDataIdx) as unknown;
+    let values: number[];
+    let timestamp: number;
+    if (Array.isArray(rawPoint)) {
+      const arr = rawPoint as number[];
+      timestamp = arr[0];
+      values = arr.slice(1);
+    } else {
+      ({ values, timestamp } = rawPoint as {
+        values: number[];
+        timestamp: number;
+      });
+    }
+    const greenData = values[0];
+    const blueData = values[1];
     this.legendTime.text(this.formatTime(timestamp));
 
     const fixNaN = <T>(n: number, valueForNaN: T): number | T =>

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -1,5 +1,4 @@
 import { Selection, select } from "d3-selection";
-import { drawProc } from "../svg-time-series/src/utils/drawProc.ts";
 import { updateNode } from "../svg-time-series/src/utils/domNodeTransform.ts";
 import type { ChartData } from "../svg-time-series/src/chart/data.ts";
 import type { RenderState } from "../svg-time-series/src/chart/render.ts";
@@ -19,8 +18,6 @@ export class LegendController implements ILegendController {
     .createSVGMatrix();
 
   private highlightedDataIdx = 0;
-  private scheduleRefresh: () => void;
-  private cancelRefresh: () => void;
 
   constructor(
     legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
@@ -52,25 +49,20 @@ export class LegendController implements ILegendController {
     this.highlightedBlueDot = state.paths.viewSf
       ? makeDot(state.paths.viewSf.querySelector("path") as SVGPathElement)
       : null;
-
-    const { wrapped, cancel } = drawProc(() => {
-      this.update();
-    });
-    this.scheduleRefresh = wrapped;
-    this.cancelRefresh = cancel;
   }
 
   public highlightIndex(idx: number): void {
-    this.highlightedDataIdx = Math.min(Math.max(idx, 0), this.data.length - 1);
-    this.scheduleRefresh();
+    this.highlightedDataIdx = Math.round(
+      Math.min(Math.max(idx, 0), this.data.length - 1),
+    );
+    this.update();
   }
 
   public refresh(): void {
-    this.scheduleRefresh();
+    this.update();
   }
 
   public clearHighlight(): void {
-    this.cancelRefresh();
     this.legendTime.text("");
     this.legendGreen.text("");
     this.legendBlue.text("");
@@ -143,7 +135,6 @@ export class LegendController implements ILegendController {
   }
 
   public destroy(): void {
-    this.cancelRefresh();
     this.highlightedGreenDot.remove();
     this.highlightedBlueDot?.remove();
   }

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -82,17 +82,25 @@ export class LegendController implements ILegendController {
 
   private update() {
     const rawPoint = this.data.getPoint(this.highlightedDataIdx) as unknown;
-    let values: number[];
-    let timestamp: number;
+    let values: number[] | undefined;
+    let timestamp: number | undefined;
     if (Array.isArray(rawPoint)) {
       const arr = rawPoint as number[];
       timestamp = arr[0];
       values = arr.slice(1);
-    } else {
+    } else if (
+      rawPoint &&
+      typeof rawPoint === "object" &&
+      "values" in (rawPoint as Record<string, unknown>) &&
+      "timestamp" in (rawPoint as Record<string, unknown>)
+    ) {
       ({ values, timestamp } = rawPoint as {
         values: number[];
         timestamp: number;
       });
+    }
+    if (!values || timestamp === undefined) {
+      return;
     }
     const greenData = values[0];
     const blueData = values[1];

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 
 vi.mock("../utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
@@ -109,7 +110,7 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.series.length).toBe(1);
-    expect(state.series[0].tree).toBe(data.treeNy);
+    expect(state.series[0].tree).toBe(data.treeAxis0);
     expect(state.series[0].scale.domain()).toEqual([1, 3]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
@@ -137,8 +138,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].tree).toBe(data.treeNy);
-    expect(state.series[1].tree).toBe(data.treeSf);
+    expect(state.series[0].tree).toBe(data.treeAxis0);
+    expect(state.series[1].tree).toBe(data.treeAxis1);
     expect(state.series[0].scale.domain()).toEqual([1, 3]);
     expect(state.series[1].scale.domain()).toEqual([10, 30]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
@@ -176,8 +177,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data2);
 
-    expect(state.series[0].tree).toBe(data2.treeNy);
-    expect(state.series[1].tree).toBe(data2.treeSf);
+    expect(state.series[0].tree).toBe(data2.treeAxis0);
+    expect(state.series[1].tree).toBe(data2.treeAxis1);
     expect(state.series[0].scale.domain()).toEqual([4, 6]);
     expect(state.series[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
@@ -103,7 +104,7 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(1);
     expect(series[0]).toMatchObject({
-      tree: data.treeNy,
+      tree: data.treeAxis0,
       transform: state.transforms.ny,
       scale: state.scales.yNy,
       view: state.paths.viewNy,
@@ -135,7 +136,7 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeNy,
+      tree: data.treeAxis0,
       transform: state.transforms.ny,
       scale: state.scales.yNy,
       view: state.paths.viewNy,
@@ -143,7 +144,7 @@ describe("buildSeries", () => {
       gAxis: state.axes.gY,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeSf,
+      tree: data.treeAxis1,
       transform: state.transforms.ny,
       scale: state.scales.yNy,
       view: state.paths.viewSf,
@@ -175,7 +176,7 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeNy,
+      tree: data.treeAxis0,
       transform: state.transforms.ny,
       scale: state.scales.yNy,
       view: state.paths.viewNy,
@@ -183,7 +184,7 @@ describe("buildSeries", () => {
       gAxis: state.axes.gY,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeSf,
+      tree: data.treeAxis1,
       transform: state.transforms.sf!,
       scale: state.scales.ySf!,
       view: state.paths.viewSf,

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -61,12 +61,12 @@ describe("createScales", () => {
   it("creates ySf when dual axis enabled", () => {
     const scales = createScales(bX, bY, true);
     expect(scales.ySf).toBeDefined();
-    expect(scales.ySf!.range()).toEqual([100, 0]);
+    expect(scales.ySf?.range()).toEqual([100, 0]);
   });
 });
 
 describe("updateScaleX", () => {
-  const makeSource = (data: Array<[number, number?]>): IDataSource => ({
+  const makeSource = (data: number[][]): IDataSource => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -85,7 +85,7 @@ describe("updateScaleX", () => {
 });
 
 describe("updateScaleY", () => {
-  const makeSource = (data: Array<[number, number?]>): IDataSource => ({
+  const makeSource = (data: number[][]): IDataSource => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -99,7 +99,7 @@ describe("updateScaleY", () => {
     const vt = {
       onReferenceViewWindowResize: vi.fn(),
     } as unknown as ViewportTransform;
-    updateScaleY(new AR1Basis(0, 2), cd.treeNy, vt, y, cd);
+    updateScaleY(new AR1Basis(0, 2), cd.treeAxis0, vt, y, cd);
     expect(y.domain()).toEqual([10, 40]);
   });
 });
@@ -132,7 +132,7 @@ describe("initPaths", () => {
     const { path, viewNy, viewSf } = initPaths(selection, true);
     expect(path.nodes()).toHaveLength(2);
     expect(viewNy.tagName).toBe("g");
-    expect(viewSf!.tagName).toBe("g");
+    expect(viewSf?.tagName).toBe("g");
     expect(svg.querySelectorAll("g.view")).toHaveLength(2);
     expect(svg.querySelectorAll("path")).toHaveLength(2);
   });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -8,15 +8,15 @@ import type { IMinMax } from "../data.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
-export const lineNy = line<[number, number?]>()
-  .defined((d) => !(isNaN(d[0]!) || d[0] == null))
+export const lineNy = line<number[]>()
+  .defined((d) => !(isNaN(d[0]) || d[0] == null))
   .x((_, i) => i)
-  .y((d) => d[0]!);
+  .y((d) => d[0] as number);
 
-export const lineSf = line<[number, number?]>()
-  .defined((d) => !(isNaN(d[1]!) || d[1] == null))
+export const lineSf = line<number[]>()
+  .defined((d) => !(isNaN(d[1]) || d[1] == null))
   .x((_, i) => i)
-  .y((d) => d[1]!);
+  .y((d) => d[1] as number);
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -78,11 +78,12 @@ export function updateScaleY(
   yScale: ScaleLinear<number, number>,
   data: ChartData,
 ) {
-  const bTemperatureVisible = data.bTemperatureVisible(bIndexVisible, tree);
+  const axis = data.trees.indexOf(tree);
+  const bAxisVisible = data.bAxisVisible(bIndexVisible, axis);
   pathTransform.onReferenceViewWindowResize(
-    DirectProductBasis.fromProjections(data.bIndexFull, bTemperatureVisible),
+    DirectProductBasis.fromProjections(data.bIndexFull, bAxisVisible),
   );
-  yScale.domain(bTemperatureVisible.toArr());
+  yScale.domain(bAxisVisible.toArr());
 }
 
 export interface PathSet {
@@ -113,10 +114,7 @@ export function initPaths(
   return { path, viewNy, viewSf };
 }
 
-export function renderPaths(
-  state: RenderState,
-  dataArr: Array<[number, number?]>,
-) {
+export function renderPaths(state: RenderState, dataArr: number[][]) {
   const series = state.series;
   for (let i = 0; i < series.length; i++) {
     const s = series[i];

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,7 +1,7 @@
 import { Selection } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 
-import { ChartData, IMinMax, IDataSource } from "./chart/data.ts";
+import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
@@ -78,8 +78,8 @@ export class TimeSeriesChart {
     };
   }
 
-  public updateChartWithNewData(ny: number, sf?: number): void {
-    this.data.append(ny, sf);
+  public updateChartWithNewData(...values: number[]): void {
+    this.data.append(...values);
     this.drawNewData();
   }
 


### PR DESCRIPTION
## Summary
- group series by axis and expose `treeAxis0`/`treeAxis1` for per-axis min/max tracking
- add `bAxisVisible` and `combinedAxisDp` helpers and update rendering to consume axis trees
- extend tests to cover multiple series per axis and verify aggregated bounds
- handle tuple return shapes in LegendController and add regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68964a01b224832bb692dff51bf5bc98