### PR TITLE
ci: split workflow into lint and test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main, master]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,4 +28,16 @@ jobs:
             BASE_REF="${{ github.ref_name }}"
           fi
           npm run commitlint -- --from origin/$BASE_REF --to HEAD
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
## Summary
- run lint, typecheck, and commitlint in their own job
- move tests into a dedicated job

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689660a4dd08832baa4c3e2efa5d0d96