### PR TITLE
refactor: centralize y-scale updates

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -152,6 +152,25 @@ describe("RenderState.refresh", () => {
     });
   });
 
+  it("updates combined series on shared scale", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      seriesCount: 2,
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+
+    state.refresh(data);
+
+    expect(state.series[0].scale).toBe(state.series[1].scale);
+    expect(state.series[0].scale.domain()).toEqual([1, 30]);
+    expect(state.series[1].scale.domain()).toEqual([1, 30]);
+  });
+
   it("refreshes after data changes", () => {
     const svg = createSvg();
     const source1: IDataSource = {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -154,6 +154,26 @@ export interface RenderState {
   refresh: (data: ChartData) => void;
 }
 
+function updateYScales(series: Series[], bIndex: AR1Basis, data: ChartData) {
+  if (
+    series.length > 1 &&
+    series[0].scale === series[1].scale &&
+    data.treeAxis1
+  ) {
+    const { combined, dp } = data.combinedAxisDp(bIndex);
+    for (const s of series) {
+      s.transform.onReferenceViewWindowResize(dp);
+      s.scale.domain(combined.toArr());
+    }
+  } else {
+    for (const s of series) {
+      if (s.tree) {
+        updateScaleY(bIndex, s.tree, s.transform, s.scale, data);
+      }
+    }
+  }
+}
+
 export function setupRender(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   data: ChartData,
@@ -186,23 +206,7 @@ export function setupRender(
     dualYAxis,
   );
 
-  if (
-    series.length > 1 &&
-    series[0].scale === series[1].scale &&
-    data.treeAxis1
-  ) {
-    const { combined, dp } = data.combinedAxisDp(data.bIndexFull);
-    for (const s of series) {
-      s.transform.onReferenceViewWindowResize(dp);
-      s.scale.domain(combined.toArr());
-    }
-  } else {
-    for (const s of series) {
-      if (s.tree) {
-        updateScaleY(data.bIndexFull, s.tree, s.transform, s.scale, data);
-      }
-    }
-  }
+  updateYScales(series, data.bIndexFull, data);
 
   const axes = setupAxes(svg, scales, width, height, hasSf, dualYAxis);
 
@@ -259,23 +263,7 @@ export function setupRender(
         series[1].tree = data.treeAxis1;
       }
 
-      if (
-        series.length > 1 &&
-        series[0].scale === series[1].scale &&
-        data.treeAxis1
-      ) {
-        const { combined, dp } = data.combinedAxisDp(bIndexVisible);
-        for (const s of series) {
-          s.transform.onReferenceViewWindowResize(dp);
-          s.scale.domain(combined.toArr());
-        }
-      } else {
-        for (const s of series) {
-          if (s.tree) {
-            updateScaleY(bIndexVisible, s.tree, s.transform, s.scale, data);
-          }
-        }
-      }
+      updateYScales(series, bIndexVisible, data);
 
       for (const s of series) {
         if (s.view) {


### PR DESCRIPTION
## Summary
- extract `updateYScales` helper to handle combined and dual-axis cases
- call helper from `setupRender` and `RenderState.refresh`
- cover combined-axis refresh scenario with a new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689670c73440832bb720bb599a932fa8