### PR TITLE
feat(chart): validate series axis indices

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -23,6 +23,22 @@ describe("ChartData", () => {
     expect(() => new ChartData(source)).toThrow(/non-empty data array/);
   });
 
+  it("throws when seriesAxes length does not match seriesCount", () => {
+    const source = makeSource([
+      [0, 0],
+      [1, 1],
+    ]);
+    expect(() => new ChartData(source, [0])).toThrow(/seriesAxes length/);
+  });
+
+  it("throws when seriesAxes contains unsupported axis index", () => {
+    const source = makeSource([
+      [0, 0],
+      [1, 1],
+    ]);
+    expect(() => new ChartData(source, [0, 2])).toThrow(/0 or 1/);
+  });
+
   it("updates data and time mapping on append", () => {
     const source = makeSource([
       [0, 0],

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -74,7 +74,12 @@ export class ChartData {
     }
     for (let i = 0; i < this.seriesAxes.length; i++) {
       const axis = this.seriesAxes[i];
-      this.seriesByAxis[axis]?.push(i);
+      if (axis !== 0 && axis !== 1) {
+        throw new Error(
+          `ChartData seriesAxes[${i}] must be 0 or 1; received ${axis}`,
+        );
+      }
+      this.seriesByAxis[axis as 0 | 1].push(i);
     }
     this.data = new Array(source.length);
     for (let i = 0; i < source.length; i++) {


### PR DESCRIPTION
## Summary
- validate that `seriesAxes` entries are either 0 or 1
- add tests for invalid `seriesAxes` configurations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896709c3880832b814efbb44ba307fd