### PR TITLE
refactor: simplify scale creation for multiple y axes

### DIFF
--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
@@ -98,15 +99,15 @@ describe("RenderState.refresh integration", () => {
       .mockImplementation(() => {});
 
     const xBefore = state.scales.x.domain().slice();
-    const yNyBefore = state.scales.yNy.domain().slice();
-    const ySfBefore = state.scales.ySf!.domain().slice();
+    const yNyBefore = state.scales.y[0].domain().slice();
+    const ySfBefore = state.scales.y[1].domain().slice();
 
     data.append(100, 200);
     state.refresh(data);
 
     const xAfter = state.scales.x.domain();
-    const yNyAfter = state.scales.yNy.domain();
-    const ySfAfter = state.scales.ySf!.domain();
+    const yNyAfter = state.scales.y[0].domain();
+    const ySfAfter = state.scales.y[1].domain();
 
     expect(xAfter).not.toEqual(xBefore);
     expect(yNyAfter).not.toEqual(yNyBefore);

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -106,7 +106,7 @@ describe("buildSeries", () => {
     expect(series[0]).toMatchObject({
       tree: data.treeAxis0,
       transform: state.transforms.ny,
-      scale: state.scales.yNy,
+      scale: state.scales.y[0],
       view: state.paths.viewNy,
       axis: state.axes.y,
       gAxis: state.axes.gY,
@@ -138,7 +138,7 @@ describe("buildSeries", () => {
     expect(series[0]).toMatchObject({
       tree: data.treeAxis0,
       transform: state.transforms.ny,
-      scale: state.scales.yNy,
+      scale: state.scales.y[0],
       view: state.paths.viewNy,
       axis: state.axes.y,
       gAxis: state.axes.gY,
@@ -146,7 +146,7 @@ describe("buildSeries", () => {
     expect(series[1]).toMatchObject({
       tree: data.treeAxis1,
       transform: state.transforms.ny,
-      scale: state.scales.yNy,
+      scale: state.scales.y[0],
       view: state.paths.viewSf,
       axis: state.axes.y,
       gAxis: state.axes.gY,
@@ -178,7 +178,7 @@ describe("buildSeries", () => {
     expect(series[0]).toMatchObject({
       tree: data.treeAxis0,
       transform: state.transforms.ny,
-      scale: state.scales.yNy,
+      scale: state.scales.y[0],
       view: state.paths.viewNy,
       axis: state.axes.y,
       gAxis: state.axes.gY,
@@ -186,7 +186,7 @@ describe("buildSeries", () => {
     expect(series[1]).toMatchObject({
       tree: data.treeAxis1,
       transform: state.transforms.sf!,
-      scale: state.scales.ySf!,
+      scale: state.scales.y[1],
       view: state.paths.viewSf,
       axis: state.axes.yRight,
       gAxis: state.axes.gYRight,

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -51,9 +51,9 @@ function setupAxes(
   xAxis.setScale(scales.x);
   const gX = svg.append("g").attr("class", "axis").call(xAxis.axis.bind(xAxis));
 
-  if (hasSf && dualYAxis && scales.ySf) {
-    const yLeft = createYAxis(Orientation.Left, scales.yNy, width);
-    const yRight = createYAxis(Orientation.Right, scales.ySf, width);
+  if (hasSf && dualYAxis && scales.y[1]) {
+    const yLeft = createYAxis(Orientation.Left, scales.y[0], width);
+    const yRight = createYAxis(Orientation.Right, scales.y[1], width);
 
     const gY = svg
       .append("g")
@@ -67,7 +67,7 @@ function setupAxes(
     return { x: xAxis, y: yLeft, gX, gY, yRight, gYRight };
   }
 
-  const yAxis = createYAxis(Orientation.Right, scales.yNy, width);
+  const yAxis = createYAxis(Orientation.Right, scales.y[0], width);
   const gY = svg.append("g").attr("class", "axis").call(yAxis.axis.bind(yAxis));
 
   return { x: xAxis, y: yAxis, gX, gY };
@@ -118,7 +118,7 @@ export function buildSeries(
     {
       tree: data.treeAxis0,
       transform: transforms.ny,
-      scale: scales.yNy,
+      scale: scales.y[0],
       view: paths.viewNy,
       path: nodes[0],
       axis: axes?.y,
@@ -131,7 +131,7 @@ export function buildSeries(
     series.push({
       tree: data.treeAxis1,
       transform: dualYAxis && transforms.sf ? transforms.sf : transforms.ny,
-      scale: dualYAxis && scales.ySf ? scales.ySf : scales.yNy,
+      scale: dualYAxis && scales.y[1] ? scales.y[1] : scales.y[0],
       view: paths.viewSf,
       path: nodes[1],
       axis: axes?.yRight ?? axes?.y,
@@ -183,12 +183,12 @@ export function setupRender(
 
   const { width, height, bScreenXVisible, bScreenYVisible } =
     createDimensions(svg);
-  const paths = initPaths(svg, hasSf);
-  const scales = createScales(
+  const bScreenVisibleDp = DirectProductBasis.fromProjections(
     bScreenXVisible,
     bScreenYVisible,
-    hasSf && dualYAxis,
   );
+  const paths = initPaths(svg, hasSf);
+  const scales = createScales(bScreenVisibleDp, hasSf && dualYAxis ? 2 : 1);
   const sharedTransform = new ViewportTransform();
   const transformsInner: TransformPair = {
     ny: sharedTransform,
@@ -222,10 +222,6 @@ export function setupRender(
     s.gAxis = gAxisArr[i];
   });
 
-  const bScreenVisibleDp = DirectProductBasis.fromProjections(
-    bScreenXVisible,
-    bScreenYVisible,
-  );
   transformsInner.ny.onViewPortResize(bScreenVisibleDp);
   transformsInner.sf?.onViewPortResize(bScreenVisibleDp);
   const refDp = DirectProductBasis.fromProjections(

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from "vitest";
 import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
-import { AR1Basis } from "../math/affine.ts";
+import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
 import type { ViewportTransform } from "../ViewportTransform.ts";
 import { vi } from "vitest";
@@ -50,18 +50,19 @@ describe("createDimensions", () => {
 describe("createScales", () => {
   const bX = new AR1Basis(0, 100);
   const bY = new AR1Basis(100, 0);
+  const b = DirectProductBasis.fromProjections(bX, bY);
 
-  it("omits ySf when dual axis disabled", () => {
-    const scales = createScales(bX, bY, false);
-    expect(scales.ySf).toBeUndefined();
+  it("creates single y scale when count is 1", () => {
+    const scales = createScales(b, 1);
+    expect(scales.y).toHaveLength(1);
     expect(scales.x.range()).toEqual([0, 100]);
-    expect(scales.yNy.range()).toEqual([100, 0]);
+    expect(scales.y[0].range()).toEqual([100, 0]);
   });
 
-  it("creates ySf when dual axis enabled", () => {
-    const scales = createScales(bX, bY, true);
-    expect(scales.ySf).toBeDefined();
-    expect(scales.ySf?.range()).toEqual([100, 0]);
+  it("creates multiple y scales when count > 1", () => {
+    const scales = createScales(b, 2);
+    expect(scales.y).toHaveLength(2);
+    expect(scales.y[1].range()).toEqual([100, 0]);
   });
 });
 

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
@@ -89,8 +90,8 @@ describe("setupRender Y-axis modes", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    expect(state.scales.yNy.domain()).toEqual([1, 30]);
-    expect(state.scales.ySf).toBeUndefined();
+    expect(state.scales.y[0].domain()).toEqual([1, 30]);
+    expect(state.scales.y[1]).toBeUndefined();
   });
 
   it("separates scales when dualYAxis is true", () => {
@@ -105,7 +106,7 @@ describe("setupRender Y-axis modes", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    expect(state.scales.yNy.domain()).toEqual([1, 3]);
-    expect(state.scales.ySf!.domain()).toEqual([10, 30]);
+    expect(state.scales.y[0].domain()).toEqual([1, 3]);
+    expect(state.scales.y[1].domain()).toEqual([10, 30]);
   });
 });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -38,26 +38,19 @@ export function createDimensions(
 
 export interface ScaleSet {
   x: ScaleTime<number, number>;
-  yNy: ScaleLinear<number, number>;
-  ySf?: ScaleLinear<number, number>;
+  y: ScaleLinear<number, number>[];
 }
 
 export function createScales(
-  bScreenXVisible: AR1Basis,
-  bScreenYVisible: AR1Basis,
-  dualAxis: boolean,
+  bScreenVisible: DirectProductBasis,
+  yScaleCount: number,
 ): ScaleSet {
-  const x: ScaleTime<number, number> = scaleTime().range(
-    bScreenXVisible.toArr(),
+  const [xRange, yRange] = bScreenVisible.toArr();
+  const x: ScaleTime<number, number> = scaleTime().range(xRange);
+  const y = Array.from({ length: yScaleCount }, () =>
+    scaleLinear<number, number>().range(yRange),
   );
-  const yNy: ScaleLinear<number, number> = scaleLinear().range(
-    bScreenYVisible.toArr(),
-  );
-  let ySf: ScaleLinear<number, number> | undefined;
-  if (dualAxis) {
-    ySf = scaleLinear().range(bScreenYVisible.toArr());
-  }
-  return { x, yNy, ySf };
+  return { x, y };
 }
 
 export function updateScaleX(


### PR DESCRIPTION
## Summary
- refactor createScales to accept a DirectProductBasis and yScaleCount
- change ScaleSet to store an array of y scales and update chart rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68967be7e26c832b8c6b3e0ebb0c1a8c