### PR TITLE
refactor: generalize initPaths

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -101,7 +101,7 @@ describe("LegendController", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    select(state.paths.viewNy).select("path").attr("stroke", "green");
+    select(state.paths.nodes[0]).select("path").attr("stroke", "green");
     const lc = new LegendController(legendDiv as any, state, data);
 
     const updateSpy = vi
@@ -143,7 +143,7 @@ describe("LegendController", () => {
       return [timestamp, ...values] as any;
     }) as any;
     const state = setupRender(svg as any, data, false);
-    select(state.paths.viewNy).select("path").attr("stroke", "green");
+    select(state.paths.nodes[0]).select("path").attr("stroke", "green");
     const lc = new LegendController(legendDiv as any, state, data);
 
     const updateSpy = vi
@@ -174,7 +174,7 @@ describe("LegendController", () => {
       return { timestamp } as any;
     }) as any;
     const state = setupRender(svg as any, data, false);
-    select(state.paths.viewNy).select("path").attr("stroke", "green");
+    select(state.paths.nodes[0]).select("path").attr("stroke", "green");
     const lc = new LegendController(legendDiv as any, state, data);
 
     expect(() => {

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -30,7 +30,7 @@ export class LegendController implements ILegendController {
     this.legendGreen = legend.select(".chart-legend__green_value");
     this.legendBlue = legend.select(".chart-legend__blue_value");
 
-    const svg = state.paths.viewNy.ownerSVGElement as SVGSVGElement;
+    const svg = state.paths.nodes[0].ownerSVGElement as SVGSVGElement;
     if (!svg) {
       throw new Error("SVG element not found");
     }
@@ -47,10 +47,10 @@ export class LegendController implements ILegendController {
         .node() as SVGCircleElement;
     };
     this.highlightedGreenDot = makeDot(
-      state.paths.viewNy.querySelector("path") as SVGPathElement,
+      state.paths.nodes[0].querySelector("path") as SVGPathElement,
     );
-    this.highlightedBlueDot = state.paths.viewSf
-      ? makeDot(state.paths.viewSf.querySelector("path") as SVGPathElement)
+    this.highlightedBlueDot = state.paths.nodes[1]
+      ? makeDot(state.paths.nodes[1].querySelector("path") as SVGPathElement)
       : null;
   }
 

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -107,7 +107,7 @@ describe("buildSeries", () => {
       tree: data.treeAxis0,
       transform: state.transforms.ny,
       scale: state.scales.y[0],
-      view: state.paths.viewNy,
+      view: state.paths.nodes[0],
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
@@ -139,7 +139,7 @@ describe("buildSeries", () => {
       tree: data.treeAxis0,
       transform: state.transforms.ny,
       scale: state.scales.y[0],
-      view: state.paths.viewNy,
+      view: state.paths.nodes[0],
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
@@ -147,7 +147,7 @@ describe("buildSeries", () => {
       tree: data.treeAxis1,
       transform: state.transforms.ny,
       scale: state.scales.y[0],
-      view: state.paths.viewSf,
+      view: state.paths.nodes[1],
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
@@ -179,7 +179,7 @@ describe("buildSeries", () => {
       tree: data.treeAxis0,
       transform: state.transforms.ny,
       scale: state.scales.y[0],
-      view: state.paths.viewNy,
+      view: state.paths.nodes[0],
       axis: state.axes.y,
       gAxis: state.axes.gY,
     });
@@ -187,7 +187,7 @@ describe("buildSeries", () => {
       tree: data.treeAxis1,
       transform: state.transforms.sf!,
       scale: state.scales.y[1],
-      view: state.paths.viewSf,
+      view: state.paths.nodes[1],
       axis: state.axes.yRight,
       gAxis: state.axes.gYRight,
     });
@@ -208,7 +208,7 @@ describe("buildSeries", () => {
     const svg2 = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const singlePaths = initPaths(svg2, false);
+    const singlePaths = initPaths(svg2, 1);
     const series = buildSeries(
       data,
       state.transforms,

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -38,8 +38,8 @@ describe("renderPaths", () => {
     const svgSelection = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const svg = svgSelection.node()!;
-    const { path } = initPaths(svgSelection, false);
+    const svg = svgSelection.node() as SVGSVGElement;
+    const { path } = initPaths(svgSelection, 1);
     const nodes = path.nodes() as SVGPathElement[];
     const state = {
       series: [{ path: nodes[0], line: lineNy }],
@@ -62,10 +62,11 @@ describe("initPaths", () => {
     const svgSelection = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const { path, viewNy, viewSf } = initPaths(svgSelection, false);
+    const { path, nodes } = initPaths(svgSelection, 1);
 
     expect(path.size()).toBe(1);
-    expect(viewNy.tagName).toBe("g");
-    expect(viewSf).toBeUndefined();
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].tagName).toBe("g");
+    expect(nodes[1]).toBeUndefined();
   });
 });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -113,27 +113,28 @@ export function buildSeries(
   axes?: AxisSet,
   dualYAxis = false,
 ): Series[] {
-  const nodes = paths.path.nodes() as SVGPathElement[];
+  const pathNodes = paths.path.nodes() as SVGPathElement[];
+  const views = paths.nodes;
   const series: Series[] = [
     {
       tree: data.treeAxis0,
       transform: transforms.ny,
       scale: scales.y[0],
-      view: paths.viewNy,
-      path: nodes[0],
+      view: views[0],
+      path: pathNodes[0],
       axis: axes?.y,
       gAxis: axes?.gY,
       line: lineNy,
     },
   ];
 
-  if (hasSf && data.treeAxis1 && nodes[1]) {
+  if (hasSf && data.treeAxis1 && pathNodes[1] && views[1]) {
     series.push({
       tree: data.treeAxis1,
       transform: dualYAxis && transforms.sf ? transforms.sf : transforms.ny,
       scale: dualYAxis && scales.y[1] ? scales.y[1] : scales.y[0],
-      view: paths.viewSf,
-      path: nodes[1],
+      view: views[1],
+      path: pathNodes[1],
       axis: axes?.yRight ?? axes?.y,
       gAxis: axes?.gYRight ?? axes?.gY,
       line: lineSf,
@@ -181,13 +182,15 @@ export function setupRender(
 ): RenderState {
   const hasSf = data.treeAxis1 != null;
 
+  const seriesCount = data.seriesCount;
+
   const { width, height, bScreenXVisible, bScreenYVisible } =
     createDimensions(svg);
   const bScreenVisibleDp = DirectProductBasis.fromProjections(
     bScreenXVisible,
     bScreenYVisible,
   );
-  const paths = initPaths(svg, hasSf);
+  const paths = initPaths(svg, seriesCount);
   const scales = createScales(bScreenVisibleDp, hasSf && dualYAxis ? 2 : 1);
   const sharedTransform = new ViewportTransform();
   const transformsInner: TransformPair = {

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -114,10 +114,11 @@ describe("initPaths", () => {
       HTMLElement,
       unknown
     >;
-    const { path, viewNy, viewSf } = initPaths(selection, false);
+    const { path, nodes } = initPaths(selection, 1);
     expect(path.nodes()).toHaveLength(1);
-    expect(viewNy.tagName).toBe("g");
-    expect(viewSf).toBeUndefined();
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].tagName).toBe("g");
+    expect(nodes[1]).toBeUndefined();
     expect(svg.querySelectorAll("g.view")).toHaveLength(1);
     expect(svg.querySelectorAll("path")).toHaveLength(1);
   });
@@ -130,10 +131,11 @@ describe("initPaths", () => {
       HTMLElement,
       unknown
     >;
-    const { path, viewNy, viewSf } = initPaths(selection, true);
+    const { path, nodes } = initPaths(selection, 2);
     expect(path.nodes()).toHaveLength(2);
-    expect(viewNy.tagName).toBe("g");
-    expect(viewSf?.tagName).toBe("g");
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].tagName).toBe("g");
+    expect(nodes[1].tagName).toBe("g");
     expect(svg.querySelectorAll("g.view")).toHaveLength(2);
     expect(svg.querySelectorAll("path")).toHaveLength(2);
   });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -81,8 +81,7 @@ export function updateScaleY(
 
 export interface PathSet {
   path: Selection<SVGPathElement, number, SVGGElement, unknown>;
-  viewNy: SVGGElement;
-  viewSf?: SVGGElement;
+  nodes: SVGGElement[];
 }
 
 export interface TransformPair {
@@ -92,19 +91,17 @@ export interface TransformPair {
 
 export function initPaths(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-  hasSf: boolean,
+  seriesCount: number,
 ): PathSet {
   const views = svg
-    .selectAll("g")
-    .data(hasSf ? [0, 1] : [0])
+    .selectAll<SVGGElement, number>("g")
+    .data(Array.from({ length: seriesCount }, (_, i) => i))
     .enter()
     .append("g")
     .attr("class", "view");
   const nodes = views.nodes() as SVGGElement[];
-  const viewNy = nodes[0];
-  const viewSf = hasSf ? nodes[1] : undefined;
-  const path = views.append("path");
-  return { path, viewNy, viewSf };
+  const path = views.append<SVGPathElement>("path");
+  return { path, nodes };
 }
 
 export function renderPaths(state: RenderState, dataArr: number[][]) {


### PR DESCRIPTION
## Summary
- allow initPaths to accept a series count and return path plus view nodes
- adjust renderer and legend to use array of nodes
- update tests for new initPaths signature

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896816b002c832b9db4284f45f4afc9