### PR TITLE
refactor: move updateScaleY into ChartData

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -193,6 +193,15 @@ export class ChartData {
     return new AR1Basis(min, max);
   }
 
+  updateScaleY(
+    bIndexVisible: AR1Basis,
+    tree: SegmentTree<IMinMax>,
+  ): DirectProductBasis {
+    const axis = this.trees.indexOf(tree);
+    const bAxisVisible = this.bAxisVisible(bIndexVisible, axis);
+    return DirectProductBasis.fromProjections(this.bIndexFull, bAxisVisible);
+  }
+
   combinedAxisDp(bIndexVisible: AR1Basis): {
     combined: AR1Basis;
     dp: DirectProductBasis;

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -12,7 +12,6 @@ import {
   createDimensions,
   createScales,
   updateScaleX,
-  updateScaleY,
   initPaths,
   lineNy,
   lineSf,
@@ -169,7 +168,9 @@ function updateYScales(series: Series[], bIndex: AR1Basis, data: ChartData) {
   } else {
     for (const s of series) {
       if (s.tree) {
-        updateScaleY(bIndex, s.tree, s.transform, s.scale, data);
+        const dp = data.updateScaleY(bIndex, s.tree);
+        s.transform.onReferenceViewWindowResize(dp);
+        s.scale.domain(dp.y().toArr());
       }
     }
   }

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -12,7 +12,6 @@ import {
   createDimensions,
   createScales,
   updateScaleX,
-  updateScaleY,
   initPaths,
 } from "./render/utils.ts";
 
@@ -100,8 +99,11 @@ describe("updateScaleY", () => {
     const vt = {
       onReferenceViewWindowResize: vi.fn(),
     } as unknown as ViewportTransform;
-    updateScaleY(new AR1Basis(0, 2), cd.treeAxis0, vt, y, cd);
+    const dp = cd.updateScaleY(new AR1Basis(0, 2), cd.treeAxis0);
+    vt.onReferenceViewWindowResize(dp);
+    y.domain(dp.y().toArr());
     expect(y.domain()).toEqual([10, 40]);
+    expect(vt.onReferenceViewWindowResize).toHaveBeenCalledWith(dp);
   });
 });
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -2,9 +2,7 @@ import { Selection } from "d3-selection";
 import { line } from "d3-shape";
 import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
-import { SegmentTree } from "segment-tree-rmq";
-import { ViewportTransform } from "../../ViewportTransform.ts";
-import type { IMinMax } from "../data.ts";
+import type { ViewportTransform } from "../../ViewportTransform.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
@@ -62,21 +60,6 @@ export function updateScaleX(
   const start = data.startTime + (data.startIndex + minIdx) * data.timeStep;
   const end = data.startTime + (data.startIndex + maxIdx) * data.timeStep;
   x.domain([start, end]);
-}
-
-export function updateScaleY(
-  bIndexVisible: AR1Basis,
-  tree: SegmentTree<IMinMax>,
-  pathTransform: ViewportTransform,
-  yScale: ScaleLinear<number, number>,
-  data: ChartData,
-) {
-  const axis = data.trees.indexOf(tree);
-  const bAxisVisible = data.bAxisVisible(bIndexVisible, axis);
-  pathTransform.onReferenceViewWindowResize(
-    DirectProductBasis.fromProjections(data.bIndexFull, bAxisVisible),
-  );
-  yScale.domain(bAxisVisible.toArr());
 }
 
 export interface PathSet {


### PR DESCRIPTION
## Summary
- move updateScaleY from render utilities into the ChartData class
- return a DirectProductBasis from updateScaleY and update callers to use it
- update unit tests for the new updateScaleY API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689686588d58832b9f0d9694c15c6913