### PR TITLE
refactor: derive scale domain via basis transform

### DIFF
--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,7 +1,11 @@
 import { Selection } from "d3-selection";
 import { line } from "d3-shape";
 import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
-import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
+import {
+  AR1Basis,
+  DirectProductBasis,
+  betweenTBasesAR1,
+} from "../../math/affine.ts";
 import type { ViewportTransform } from "../../ViewportTransform.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
@@ -56,10 +60,11 @@ export function updateScaleX(
   bIndexVisible: AR1Basis,
   data: ChartData,
 ) {
-  const [minIdx, maxIdx] = bIndexVisible.toArr();
-  const start = data.startTime + (data.startIndex + minIdx) * data.timeStep;
-  const end = data.startTime + (data.startIndex + maxIdx) * data.timeStep;
-  x.domain([start, end]);
+  const bIndex = new AR1Basis(data.startIndex, data.startIndex + 1);
+  const bTime = new AR1Basis(data.startTime, data.startTime + data.timeStep);
+  const indexToTime = betweenTBasesAR1(bIndex, bTime);
+  const bTimeVisible = bIndexVisible.transformWith(indexToTime);
+  x.domain(bTimeVisible.toArr());
 }
 
 export interface PathSet {


### PR DESCRIPTION
## Summary
- import `betweenTBasesAR1` for basis-derived transformations
- derive scale domain by transforming the visible index basis through an index→time basis pair
- offset index basis by `startIndex` so the transform uses absolute indices

## Testing
- `npm run format`
- `git commit -am "fix: incorporate startIndex into index basis"` (runs lint, typecheck, and tests)


------
https://chatgpt.com/codex/tasks/task_e_6896f22132fc832b815e93677e5f2327