### PR TITLE
refactor: return DirectProductBasis from createDimensions

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -178,12 +178,11 @@ export function setupRender(
 
   const seriesCount = data.seriesCount;
 
-  const { width, height, bScreenXVisible, bScreenYVisible } =
-    createDimensions(svg);
-  const bScreenVisibleDp = DirectProductBasis.fromProjections(
-    bScreenXVisible,
-    bScreenYVisible,
-  );
+  const bScreenVisibleDp = createDimensions(svg);
+  const bScreenXVisible = bScreenVisibleDp.x();
+  const bScreenYVisible = bScreenVisibleDp.y();
+  const width = bScreenXVisible.getRange();
+  const height = bScreenYVisible.getRange();
   const paths = initPaths(svg, seriesCount);
   const axisCount = hasSf && dualYAxis ? 2 : 1;
   const scales = createScales(bScreenVisibleDp, axisCount);

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./render/utils.ts";
 
 describe("createDimensions", () => {
-  it("propagates width and height and returns bases", () => {
+  it("sets width and height and returns screen basis", () => {
     const width = 400;
     const height = 300;
     const div = document.createElement("div");
@@ -30,19 +30,12 @@ describe("createDimensions", () => {
       HTMLElement,
       unknown
     >;
-    const {
-      width: w,
-      height: h,
-      bScreenXVisible,
-      bScreenYVisible,
-    } = createDimensions(selection);
+    const dp = createDimensions(selection);
 
-    expect(w).toBe(width);
-    expect(h).toBe(height);
     expect(svg.getAttribute("width")).toBe(String(width));
     expect(svg.getAttribute("height")).toBe(String(height));
-    expect(bScreenXVisible.toArr()).toEqual([0, width]);
-    expect(bScreenYVisible.toArr()).toEqual([height, 0]);
+    expect(dp.x().toArr()).toEqual([0, width]);
+    expect(dp.y().toArr()).toEqual([height, 0]);
   });
 });
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -6,7 +6,6 @@ import {
   DirectProductBasis,
   betweenTBasesAR1,
 } from "../../math/affine.ts";
-import type { ViewportTransform } from "../../ViewportTransform.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
@@ -22,7 +21,7 @@ export const lineSf = line<number[]>()
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-) {
+): DirectProductBasis {
   const node: SVGSVGElement = svg.node() as SVGSVGElement;
   const div: HTMLElement = node.parentNode as HTMLElement;
 
@@ -35,7 +34,7 @@ export function createDimensions(
   const bScreenXVisible = new AR1Basis(0, width);
   const bScreenYVisible = new AR1Basis(height, 0);
 
-  return { width, height, bScreenXVisible, bScreenYVisible };
+  return DirectProductBasis.fromProjections(bScreenXVisible, bScreenYVisible);
 }
 
 export interface ScaleSet {


### PR DESCRIPTION
## Summary
- make `createDimensions` return a `DirectProductBasis` only
- derive width, height, and projections from the returned basis during render setup
- update unit test for new `createDimensions` behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897080197d0832b978a1bd606d519c3