### PR TITLE
refactor: centralize index-to-time conversion

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,4 +1,8 @@
-import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import {
+  AR1Basis,
+  DirectProductBasis,
+  betweenTBasesAR1,
+} from "../math/affine.ts";
 import { SegmentTree } from "segment-tree-rmq";
 
 export interface IMinMax {
@@ -134,6 +138,16 @@ export class ChartData {
       values: this.data[clamped],
       timestamp: this.startTime + (this.startIndex + clamped) * this.timeStep,
     };
+  }
+
+  indexToTime(bIndex: AR1Basis): AR1Basis {
+    const bIndexBase = new AR1Basis(this.startIndex, this.startIndex + 1);
+    const bTimeBase = new AR1Basis(
+      this.startTime,
+      this.startTime + this.timeStep,
+    );
+    const transform = betweenTBasesAR1(bIndexBase, bTimeBase);
+    return bIndex.transformWith(transform);
   }
 
   private clampIndex(idx: number): number {

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,12 +1,7 @@
 import { Selection } from "d3-selection";
 import { line } from "d3-shape";
 import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
-import {
-  AR1Basis,
-  DirectProductBasis,
-  betweenTBasesAR1,
-} from "../../math/affine.ts";
-import type { ViewportTransform } from "../../ViewportTransform.ts";
+import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
@@ -60,10 +55,7 @@ export function updateScaleX(
   bIndexVisible: AR1Basis,
   data: ChartData,
 ) {
-  const bIndex = new AR1Basis(data.startIndex, data.startIndex + 1);
-  const bTime = new AR1Basis(data.startTime, data.startTime + data.timeStep);
-  const indexToTime = betweenTBasesAR1(bIndex, bTime);
-  const bTimeVisible = bIndexVisible.transformWith(indexToTime);
+  const bTimeVisible = data.indexToTime(bIndexVisible);
   x.domain(bTimeVisible.toArr());
 }
 


### PR DESCRIPTION
## Summary
- move index-to-time basis conversion into `ChartData`
- simplify `updateScaleX` to delegate time domain computation to `ChartData`

## Testing
- `git commit -am "refactor: move index to time basis to chart data"`


------
https://chatgpt.com/codex/tasks/task_e_689706e4ce24832bb92794542d511e4d