### PR TITLE
refactor: expose index-to-time transform

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,4 +1,5 @@
 import {
+  AR1,
   AR1Basis,
   DirectProductBasis,
   betweenTBasesAR1,
@@ -143,14 +144,13 @@ export class ChartData {
     };
   }
 
-  indexToTime(bIndex: AR1Basis): AR1Basis {
+  indexToTime(): AR1 {
     const bIndexBase = new AR1Basis(this.startIndex, this.startIndex + 1);
     const bTimeBase = new AR1Basis(
       this.startTime,
       this.startTime + this.timeStep,
     );
-    const transform = betweenTBasesAR1(bIndexBase, bTimeBase);
-    return bIndex.transformWith(transform);
+    return betweenTBasesAR1(bIndexBase, bTimeBase);
   }
 
   private clampIndex(idx: number): number {

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -55,7 +55,8 @@ export function updateScaleX(
   bIndexVisible: AR1Basis,
   data: ChartData,
 ) {
-  const bTimeVisible = data.indexToTime(bIndexVisible);
+  const transform = data.indexToTime();
+  const bTimeVisible = bIndexVisible.transformWith(transform);
   x.domain(bTimeVisible.toArr());
 }
 


### PR DESCRIPTION
## Summary
- return a reusable index-to-time transform
- apply the transform before updating scale domains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689722abc398832ba4647f980313dd8c