### PR TITLE
refactor: restructure AxisSet return type

### DIFF
--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -114,9 +114,9 @@ describe("RenderState.refresh integration", () => {
     expect(yNyAfter).not.toEqual(yNyBefore);
     expect(ySfAfter).not.toEqual(ySfBefore);
 
-    expect((state.axes.x as any).scale1.domain()).toEqual(xAfter);
-    expect((state.axes.y as any).scale1.domain()).toEqual(yNyAfter);
-    expect((state.axes.yRight as any).scale1.domain()).toEqual(ySfAfter);
+    expect((state.axes.x.axis as any).scale1.domain()).toEqual(xAfter);
+    expect((state.axes.y[0].axis as any).scale1.domain()).toEqual(yNyAfter);
+    expect((state.axes.y[1].axis as any).scale1.domain()).toEqual(ySfAfter);
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);
     for (const s of state.series) {

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -108,8 +108,8 @@ describe("buildSeries", () => {
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y,
-      gAxis: state.axes.gY,
+      axis: state.axes.y[0].axis,
+      gAxis: state.axes.y[0].g,
     });
   });
 
@@ -140,16 +140,16 @@ describe("buildSeries", () => {
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y,
-      gAxis: state.axes.gY,
+      axis: state.axes.y[0].axis,
+      gAxis: state.axes.y[0].g,
     });
     expect(series[1]).toMatchObject({
       tree: data.treeAxis1,
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[1],
-      axis: state.axes.y,
-      gAxis: state.axes.gY,
+      axis: state.axes.y[0].axis,
+      gAxis: state.axes.y[0].g,
     });
   });
 
@@ -180,16 +180,16 @@ describe("buildSeries", () => {
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y,
-      gAxis: state.axes.gY,
+      axis: state.axes.y[0].axis,
+      gAxis: state.axes.y[0].g,
     });
     expect(series[1]).toMatchObject({
       tree: data.treeAxis1,
       transform: state.transforms[1]!,
       scale: state.scales.y[1],
       view: state.paths.nodes[1],
-      axis: state.axes.yRight,
-      gAxis: state.axes.gYRight,
+      axis: state.axes.y[1].axis,
+      gAxis: state.axes.y[1].g,
     });
   });
 


### PR DESCRIPTION
## Summary
- represent axes as { x: AxisData, y: AxisData[] }
- update series builder and state refresh for new axis structure
- consolidate setupAxes to a single return branch
- adjust tests for revised AxisSet API
- unify y-axis construction so the primary (right) axis always uses the first scale and the optional left axis uses the second
- attach y-axes to series by axis count instead of series length

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68971c04a1ec832bb4970469b7da1fbe