### PR TITLE
refactor line generator to handle arbitrary series

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -3,7 +3,7 @@
  */
 import { bench, describe } from "vitest";
 import { select } from "d3-selection";
-import { renderPaths, lineNy, lineSf } from "../src/chart/render/utils.ts";
+import { renderPaths, createLine } from "../src/chart/render/utils.ts";
 import type { RenderState } from "../src/chart/render.ts";
 import { sizes, datasets } from "./timeSeriesData.ts";
 
@@ -18,8 +18,8 @@ describe("renderPaths performance", () => {
 
   const state = {
     series: [
-      { path: nodes[0], line: lineNy },
-      { path: nodes[1], line: lineSf },
+      { path: nodes[0], line: createLine(0) },
+      { path: nodes[1], line: createLine(1) },
     ],
   } as unknown as RenderState;
 

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -99,7 +99,6 @@ describe("buildSeries", () => {
       state.transforms,
       state.scales,
       state.paths,
-      false,
       state.axes,
     );
     expect(series.length).toBe(1);
@@ -131,7 +130,6 @@ describe("buildSeries", () => {
       state.transforms,
       state.scales,
       state.paths,
-      true,
       state.axes,
     );
     expect(series.length).toBe(2);
@@ -171,7 +169,6 @@ describe("buildSeries", () => {
       state.transforms,
       state.scales,
       state.paths,
-      true,
       state.axes,
     );
     expect(series.length).toBe(2);
@@ -215,7 +212,6 @@ describe("buildSeries", () => {
       state.transforms,
       state.scales,
       singlePaths,
-      true,
       state.axes,
     );
     expect(series.length).toBe(1);

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
-import { initPaths, renderPaths, lineNy, lineSf } from "./render/utils.ts";
+import { initPaths, renderPaths, createLine } from "./render/utils.ts";
 import type { RenderState } from "./render.ts";
 
 describe("renderPaths", () => {
@@ -17,8 +17,8 @@ describe("renderPaths", () => {
     const nodes = pathSelection.nodes() as SVGPathElement[];
     const state = {
       series: [
-        { path: nodes[0], line: lineNy },
-        { path: nodes[1], line: lineSf },
+        { path: nodes[0], line: createLine(0) },
+        { path: nodes[1], line: createLine(1) },
       ],
     } as unknown as RenderState;
     const data: Array<[number, number]> = [
@@ -42,7 +42,7 @@ describe("renderPaths", () => {
     const { path } = initPaths(svgSelection, 1);
     const nodes = path.nodes() as SVGPathElement[];
     const state = {
-      series: [{ path: nodes[0], line: lineNy }],
+      series: [{ path: nodes[0], line: createLine(0) }],
     } as unknown as RenderState;
     const pathNode = nodes[0];
     const spy = vi.spyOn(pathNode, "setAttribute");

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,19 +1,16 @@
 import { Selection } from "d3-selection";
-import { line } from "d3-shape";
+import { line, type Line } from "d3-shape";
 import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
 
-export const lineNy = line<number[]>()
-  .defined((d) => !(isNaN(d[0]) || d[0] == null))
-  .x((_, i) => i)
-  .y((d) => d[0] as number);
-
-export const lineSf = line<number[]>()
-  .defined((d) => !(isNaN(d[1]) || d[1] == null))
-  .x((_, i) => i)
-  .y((d) => d[1] as number);
+export function createLine(seriesIdx: number): Line<number[]> {
+  return line<number[]>()
+    .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
+    .x((_, i) => i)
+    .y((d) => d[seriesIdx] as number);
+}
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,


### PR DESCRIPTION
## Summary
- replace hard-coded `lineNy`/`lineSf` with generic `createLine`
- build series dynamically, assigning a line generator per dataset
- update tests and benchmarks to use the new line creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68972e412528832bb3a0b810b8a4e3b8