### PR TITLE
refactor: separate axis state from series

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -111,14 +111,15 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.series.length).toBe(1);
-    expect(state.series[0].tree).toBe(data.treeAxis0);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 3]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
+      const axis = state.axisStates[s.axisIdx];
       expect(updateNodeMock).toHaveBeenNthCalledWith(
         i + 1,
         s.view,
-        s.transform.matrix,
+        axis.transform.matrix,
       );
     });
   });
@@ -140,16 +141,17 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].tree).toBe(data.treeAxis0);
-    expect(state.series[1].tree).toBe(data.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
-    expect(state.series[1].scale.domain()).toEqual([10, 30]);
+    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
+    expect(state.axisStates[1].tree).toBe(data.treeAxis1);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[1].scale.domain()).toEqual([10, 30]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
+      const axis = state.axisStates[s.axisIdx];
       expect(updateNodeMock).toHaveBeenNthCalledWith(
         i + 1,
         s.view,
-        s.transform.matrix,
+        axis.transform.matrix,
       );
     });
   });
@@ -169,9 +171,9 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].scale).toBe(state.series[1].scale);
-    expect(state.series[0].scale.domain()).toEqual([1, 30]);
-    expect(state.series[1].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates[0].scale).toBe(state.axisStates[1].scale);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates[1].scale.domain()).toEqual([1, 30]);
   });
 
   it("refreshes after data changes", () => {
@@ -201,10 +203,10 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data2);
 
-    expect(state.series[0].tree).toBe(data2.treeAxis0);
-    expect(state.series[1].tree).toBe(data2.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([4, 6]);
-    expect(state.series[1].scale.domain()).toEqual([40, 60]);
+    expect(state.axisStates[0].tree).toBe(data2.treeAxis0);
+    expect(state.axisStates[1].tree).toBe(data2.treeAxis1);
+    expect(state.axisStates[0].scale.domain()).toEqual([4, 6]);
+    expect(state.axisStates[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
@@ -221,7 +223,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
@@ -237,7 +239,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
-    expect(state.series[1].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[1].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 });

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -17,8 +17,8 @@ describe("renderPaths", () => {
     const nodes = pathSelection.nodes() as SVGPathElement[];
     const state = {
       series: [
-        { path: nodes[0], line: lineNy },
-        { path: nodes[1], line: lineSf },
+        { path: nodes[0], line: lineNy, axisIdx: 0 },
+        { path: nodes[1], line: lineSf, axisIdx: 1 },
       ],
     } as unknown as RenderState;
     const data: Array<[number, number]> = [
@@ -42,7 +42,7 @@ describe("renderPaths", () => {
     const { path } = initPaths(svgSelection, 1);
     const nodes = path.nodes() as SVGPathElement[];
     const state = {
-      series: [{ path: nodes[0], line: lineNy }],
+      series: [{ path: nodes[0], line: lineNy, axisIdx: 0 }],
     } as unknown as RenderState;
     const pathNode = nodes[0];
     const spy = vi.spyOn(pathNode, "setAttribute");


### PR DESCRIPTION
## Summary
- introduce AxisState to hold per-axis tree, scale, and transform
- simplify Series to rendering fields and axisIdx
- build series per dataset and reference shared axis state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68972e1dd2c0832b99868225bad689a0