### PR TITLE
refactor: update axis scaling logic

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -111,7 +111,7 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.series.length).toBe(1);
-    expect(state.series[0].tree).toBe(data.treeAxis0);
+    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
     expect(state.series[0].scale.domain()).toEqual([1, 3]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
@@ -140,8 +140,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].tree).toBe(data.treeAxis0);
-    expect(state.series[1].tree).toBe(data.treeAxis1);
+    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
+    expect(state.axisStates[1].tree).toBe(data.treeAxis1);
     expect(state.series[0].scale.domain()).toEqual([1, 3]);
     expect(state.series[1].scale.domain()).toEqual([10, 30]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
@@ -201,8 +201,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data2);
 
-    expect(state.series[0].tree).toBe(data2.treeAxis0);
-    expect(state.series[1].tree).toBe(data2.treeAxis1);
+    expect(state.axisStates[0].tree).toBe(data2.treeAxis0);
+    expect(state.axisStates[1].tree).toBe(data2.treeAxis1);
     expect(state.series[0].scale.domain()).toEqual([4, 6]);
     expect(state.series[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -103,7 +103,7 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(1);
     expect(series[0]).toMatchObject({
-      tree: data.treeAxis0,
+      axisIdx: 0,
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[0],
@@ -134,7 +134,7 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeAxis0,
+      axisIdx: 0,
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[0],
@@ -142,7 +142,7 @@ describe("buildSeries", () => {
       gAxis: state.axes.y[0].g,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeAxis1,
+      axisIdx: 1,
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[1],
@@ -173,7 +173,7 @@ describe("buildSeries", () => {
     );
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeAxis0,
+      axisIdx: 0,
       transform: state.transforms[0],
       scale: state.scales.y[0],
       view: state.paths.nodes[0],
@@ -181,7 +181,7 @@ describe("buildSeries", () => {
       gAxis: state.axes.y[0].g,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeAxis1,
+      axisIdx: 1,
       transform: state.transforms[1]!,
       scale: state.scales.y[1],
       view: state.paths.nodes[1],


### PR DESCRIPTION
## Summary
- compute Y-axis domains per axis state from its segment tree
- reference axes via `series.axisIdx` and refresh axes directly
- drop shared-scale special case and update tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689731340054832baba68d0a8d0a4236