### PR TITLE
refactor: separate axis state from series

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -111,14 +111,15 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.series.length).toBe(1);
-    expect(state.series[0].tree).toBe(data.treeAxis0);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 3]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
+      const axis = state.axisStates[s.axisIdx];
       expect(updateNodeMock).toHaveBeenNthCalledWith(
         i + 1,
         s.view,
-        s.transform.matrix,
+        axis.transform.matrix,
       );
     });
   });
@@ -140,16 +141,17 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].tree).toBe(data.treeAxis0);
-    expect(state.series[1].tree).toBe(data.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
-    expect(state.series[1].scale.domain()).toEqual([10, 30]);
+    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
+    expect(state.axisStates[1].tree).toBe(data.treeAxis1);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[1].scale.domain()).toEqual([10, 30]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
+      const axis = state.axisStates[s.axisIdx];
       expect(updateNodeMock).toHaveBeenNthCalledWith(
         i + 1,
         s.view,
-        s.transform.matrix,
+        axis.transform.matrix,
       );
     });
   });
@@ -169,9 +171,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].scale).toBe(state.series[1].scale);
-    expect(state.series[0].scale.domain()).toEqual([1, 30]);
-    expect(state.series[1].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates).toHaveLength(1);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 30]);
   });
 
   it("refreshes after data changes", () => {
@@ -201,10 +202,10 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data2);
 
-    expect(state.series[0].tree).toBe(data2.treeAxis0);
-    expect(state.series[1].tree).toBe(data2.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([4, 6]);
-    expect(state.series[1].scale.domain()).toEqual([40, 60]);
+    expect(state.axisStates[0].tree).toBe(data2.treeAxis0);
+    expect(state.axisStates[1].tree).toBe(data2.treeAxis1);
+    expect(state.axisStates[0].scale.domain()).toEqual([4, 6]);
+    expect(state.axisStates[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
@@ -221,7 +222,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
@@ -237,7 +238,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
-    expect(state.series[1].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[1].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
@@ -74,6 +74,7 @@ function createSvg() {
   const dom = new JSDOM(`<div id="c"><svg></svg></div>`, {
     pretendToBeVisual: true,
     contentType: "text/html",
+    url: "http://localhost",
   });
   const div = dom.window.document.getElementById("c") as any;
   Object.defineProperty(div, "clientWidth", { value: 100 });
@@ -94,21 +95,12 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(1);
     expect(series[0]).toMatchObject({
-      tree: data.treeAxis0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
+      axisIdx: 0,
     });
   });
 
@@ -125,29 +117,17 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeAxis0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
+      axisIdx: 0,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeAxis1,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[1],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[1],
+      axisIdx: 1,
     });
   });
 
@@ -164,29 +144,17 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
-      tree: data.treeAxis0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
+      axisIdx: 0,
     });
     expect(series[1]).toMatchObject({
-      tree: data.treeAxis1,
-      transform: state.transforms[1]!,
-      scale: state.scales.y[1],
       view: state.paths.nodes[1],
-      axis: state.axes.y[1].axis,
-      gAxis: state.axes.y[1].g,
+      path: state.paths.path.nodes()[1],
+      axisIdx: 1,
     });
   });
 
@@ -202,18 +170,12 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    setupRender(svg as any, data, false);
     const svg2 = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
     const singlePaths = initPaths(svg2, 1);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      singlePaths,
-      state.axes,
-    );
+    const series = buildSeries(data, singlePaths);
     expect(series.length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- introduce AxisState to hold axis resources and transforms
- trim Series to rendering details and axis index
- build per-axis state in setupRender and reference via axisIdx

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897316a1608832b9739b84d73cdd7d0