### PR TITLE
refactor: add legend context and update chart API

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -103,7 +103,15 @@ describe("LegendController", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     select(state.paths.nodes[0]).select("path").attr("stroke", "green");
-    const lc = new LegendController(legendDiv as any, state, data);
+    const lc = new LegendController(legendDiv as any);
+    lc.init({
+      getPoint: data.getPoint.bind(data),
+      length: data.length,
+      series: state.series.map((s) => ({
+        path: s.path as SVGPathElement,
+        transform: s.transform,
+      })),
+    });
 
     const updateSpy = vi
       .spyOn(domNode, "updateNode")
@@ -146,7 +154,15 @@ describe("LegendController", () => {
     }) as any;
     const state = setupRender(svg as any, data, false);
     select(state.paths.nodes[0]).select("path").attr("stroke", "green");
-    const lc = new LegendController(legendDiv as any, state, data);
+    const lc = new LegendController(legendDiv as any);
+    lc.init({
+      getPoint: data.getPoint.bind(data),
+      length: data.length,
+      series: state.series.map((s) => ({
+        path: s.path as SVGPathElement,
+        transform: s.transform,
+      })),
+    });
 
     const updateSpy = vi
       .spyOn(domNode, "updateNode")
@@ -178,7 +194,15 @@ describe("LegendController", () => {
     }) as any;
     const state = setupRender(svg as any, data, false);
     select(state.paths.nodes[0]).select("path").attr("stroke", "green");
-    const lc = new LegendController(legendDiv as any, state, data);
+    const lc = new LegendController(legendDiv as any);
+    lc.init({
+      getPoint: data.getPoint.bind(data),
+      length: data.length,
+      series: state.series.map((s) => ({
+        path: s.path as SVGPathElement,
+        transform: s.transform,
+      })),
+    });
 
     expect(() => {
       lc.highlightIndex(1);

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -26,11 +26,8 @@ onCsv((data: [number, number][]) => {
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
-  const chart = new TimeSeriesChart(
-    svg,
-    source,
-    (state, chartData) => new LegendController(legend, state, chartData),
-  );
+  const legendController = new LegendController(legend);
+  const chart = new TimeSeriesChart(svg, source, legendController);
   const renderMs = performance.now() - start;
   const renderTimeEl = document.getElementById("render-time");
   if (renderTimeEl) {

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -30,10 +30,11 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) => data[i][seriesIdx],
     };
+    const legendController = new LegendController(legend);
     const chart = new TimeSeriesChart(
       svg,
       source,
-      (state, chartData) => new LegendController(legend, state, chartData),
+      legendController,
       dualYAxis,
       onZoom,
       onMouseMove,

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
-import type { ILegendController } from "./legend.ts";
+import type { ILegendController, LegendContext } from "./legend.ts";
 
 class Matrix {
   constructor(
@@ -65,6 +65,7 @@ vi.mock("d3-zoom", () => ({
 }));
 
 class StubLegendController implements ILegendController {
+  init = vi.fn((_: LegendContext) => {});
   highlightIndex = vi.fn();
   refresh = vi.fn();
   clearHighlight = vi.fn();
@@ -98,7 +99,7 @@ function createChart(data: Array<[number]>) {
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
-    () => legendController,
+    legendController,
     false,
     () => {},
     () => {},

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -70,6 +70,7 @@ vi.mock("../../../samples/LegendController.ts", () => ({
     highlightIndex = vi.fn();
     clearHighlight = vi.fn();
     destroy = vi.fn();
+    init = vi.fn();
     constructor() {
       legendRefresh = this.refresh;
     }
@@ -134,11 +135,11 @@ function createChart(data: Array<[number, number]>, options?: any) {
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
+  const legendController = new LegendController(select(legend) as any);
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
-    (state, chartData) =>
-      new LegendController(select(legend) as any, state, chartData),
+    legendController,
     true,
     () => {},
     () => {},

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -121,11 +121,11 @@ function createChart(data: Array<[number]>) {
     seriesAxes: [0],
     getSeries: (i) => data[i][0],
   };
+  const legendController = new LegendController(select(legend) as any);
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
-    (state, chartData) =>
-      new LegendController(select(legend) as any, state, chartData),
+    legendController,
     false,
     () => {},
     () => {},

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -125,11 +125,14 @@ function createChart(
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
+  const legendController = new LegendController(
+    select(legend) as any,
+    formatTime,
+  );
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
-    (state, chartData) =>
-      new LegendController(select(legend) as any, state, chartData, formatTime),
+    legendController,
     true,
     () => {},
     () => {},
@@ -357,10 +360,11 @@ describe("chart interaction", () => {
       seriesAxes: [0, 1],
       getSeries: (i) => [0, 1][i],
     };
+    const legendController = new LegendController(select(legend) as any);
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       source,
-      (state, data) => new LegendController(select(legend) as any, state, data),
+      legendController,
       true,
       () => {},
       mouseMoveHandler,

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -1,4 +1,18 @@
+import type { ViewportTransform } from "../ViewportTransform.ts";
+
+export interface LegendSeriesInfo {
+  path: SVGPathElement;
+  transform: ViewportTransform;
+}
+
+export interface LegendContext {
+  getPoint(idx: number): { values: number[]; timestamp: number };
+  length: number;
+  series: readonly LegendSeriesInfo[];
+}
+
 export interface ILegendController {
+  init(context: LegendContext): void;
   highlightIndex(idx: number): void;
   refresh(): void;
   clearHighlight(): void;

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -103,6 +103,7 @@ describe("TimeSeriesChart.resize", () => {
     };
 
     const legend = {
+      init: () => {},
       highlightIndex: () => {},
       refresh: vi.fn(),
       clearHighlight: () => {},
@@ -112,7 +113,7 @@ describe("TimeSeriesChart.resize", () => {
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       source,
-      () => legend as any,
+      legend as any,
     );
 
     renderSpy.mockClear();

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -5,7 +5,7 @@ import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
-import type { ILegendController } from "./chart/legend.ts";
+import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
 
 export type { IMinMax, IDataSource } from "./chart/data.ts";
@@ -28,10 +28,7 @@ export class TimeSeriesChart {
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
     data: IDataSource,
-    legendControllerFactory: (
-      state: RenderState,
-      data: ChartData,
-    ) => ILegendController,
+    legendController: ILegendController,
     dualYAxis = false,
     zoomHandler: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
@@ -49,7 +46,17 @@ export class TimeSeriesChart {
       .attr("width", this.state.dimensions.width)
       .attr("height", this.state.dimensions.height);
 
-    this.legendController = legendControllerFactory(this.state, this.data);
+    this.legendController = legendController;
+
+    const context: LegendContext = {
+      getPoint: (idx) => this.data.getPoint(idx),
+      length: this.data.length,
+      series: this.state.series.map((s) => ({
+        path: s.path as SVGPathElement,
+        transform: s.transform,
+      })),
+    };
+    this.legendController.init(context);
 
     this.zoomArea
       .on("mousemove", mouseMoveHandler)


### PR DESCRIPTION
## Summary
- introduce LegendContext with series metadata for legend controllers
- wire TimeSeriesChart to pass LegendContext to legend controllers
- update legend implementation, samples, and tests to new init contract

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897334b4b34832b86b534d073c83b93