### PR TITLE
Refactor axis handling and series rendering

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -115,7 +115,7 @@ describe("LegendController", () => {
     const matrix = lastCall[1] as Matrix;
     const modelPoint = new Point(1, data.getPoint(1).values[0]);
     const expected = modelPoint.matrixTransform(
-      state.transforms[0].matrix as any,
+      state.axisStates[0].transform.matrix as any,
     );
     expect(matrix.e).toBeCloseTo(expected.x);
     expect(matrix.f).toBeCloseTo(expected.y);

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -124,10 +124,12 @@ export class LegendController implements ILegendController {
       greenData,
       this.legendGreen,
       this.highlightedGreenDot,
-      this.state.transforms[0].matrix,
+      this.state.axisStates[0].transform.matrix,
     );
     if (this.highlightedBlueDot) {
-      const tf = this.state.transforms[1] ?? this.state.transforms[0];
+      const tf =
+        this.state.axisStates[1]?.transform ??
+        this.state.axisStates[0].transform;
       updateDot(
         blueData as number,
         this.legendBlue,

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -82,7 +82,9 @@ vi.mock("./zoomState.ts", () => ({
     private zoomCallback: (e: any) => void;
     reset = vi.fn(() => {
       const identity = { x: 0, k: 1 };
-      this.state.transforms.forEach((t: any) => t.onZoomPan(identity));
+      this.state.axisStates.forEach((a: any) =>
+        a.transform.onZoomPan(identity),
+      );
       this.refreshChart();
       this.zoomCallback({ transform: identity, sourceEvent: null });
     });

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -114,9 +114,9 @@ describe("RenderState.refresh integration", () => {
     expect(yNyAfter).not.toEqual(yNyBefore);
     expect(ySfAfter).not.toEqual(ySfBefore);
 
-    expect((state.axes.x.axis as any).scale1.domain()).toEqual(xAfter);
-    expect((state.axes.y[0].axis as any).scale1.domain()).toEqual(yNyAfter);
-    expect((state.axes.y[1].axis as any).scale1.domain()).toEqual(ySfAfter);
+    expect((state.axisX.axis as any).scale1.domain()).toEqual(xAfter);
+    expect((state.axisStates[0].axis as any).scale1.domain()).toEqual(yNyAfter);
+    expect((state.axisStates[1].axis as any).scale1.domain()).toEqual(ySfAfter);
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);
     for (const s of state.series) {

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -112,13 +112,13 @@ describe("RenderState.refresh", () => {
 
     expect(state.series.length).toBe(1);
     expect(state.axisStates[0].tree).toBe(data.treeAxis0);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 3]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
       expect(updateNodeMock).toHaveBeenNthCalledWith(
         i + 1,
         s.view,
-        s.transform.matrix,
+        state.axisStates[s.axisIdx].transform.matrix,
       );
     });
   });
@@ -142,14 +142,14 @@ describe("RenderState.refresh", () => {
 
     expect(state.axisStates[0].tree).toBe(data.treeAxis0);
     expect(state.axisStates[1].tree).toBe(data.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
-    expect(state.series[1].scale.domain()).toEqual([10, 30]);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[1].scale.domain()).toEqual([10, 30]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
       expect(updateNodeMock).toHaveBeenNthCalledWith(
         i + 1,
         s.view,
-        s.transform.matrix,
+        state.axisStates[s.axisIdx].transform.matrix,
       );
     });
   });
@@ -169,9 +169,9 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].scale).toBe(state.series[1].scale);
-    expect(state.series[0].scale.domain()).toEqual([1, 30]);
-    expect(state.series[1].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates[0].scale).toBe(state.axisStates[1].scale);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates[1].scale.domain()).toEqual([1, 30]);
   });
 
   it("refreshes after data changes", () => {
@@ -203,8 +203,8 @@ describe("RenderState.refresh", () => {
 
     expect(state.axisStates[0].tree).toBe(data2.treeAxis0);
     expect(state.axisStates[1].tree).toBe(data2.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([4, 6]);
-    expect(state.series[1].scale.domain()).toEqual([40, 60]);
+    expect(state.axisStates[0].scale.domain()).toEqual([4, 6]);
+    expect(state.axisStates[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
@@ -221,7 +221,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
@@ -237,7 +237,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
-    expect(state.series[1].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[1].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
@@ -94,21 +94,12 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(1);
     expect(series[0]).toMatchObject({
       axisIdx: 0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
     });
   });
 
@@ -125,29 +116,17 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
       axisIdx: 0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
     });
     expect(series[1]).toMatchObject({
       axisIdx: 1,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[1],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[1],
     });
   });
 
@@ -164,29 +143,17 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
       axisIdx: 0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
     });
     expect(series[1]).toMatchObject({
       axisIdx: 1,
-      transform: state.transforms[1]!,
-      scale: state.scales.y[1],
       view: state.paths.nodes[1],
-      axis: state.axes.y[1].axis,
-      gAxis: state.axes.y[1].g,
+      path: state.paths.path.nodes()[1],
     });
   });
 
@@ -202,18 +169,12 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    setupRender(svg as any, data, false);
     const svg2 = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
     const singlePaths = initPaths(svg2, 1);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      singlePaths,
-      state.axes,
-    );
+    const series = buildSeries(data, singlePaths);
     expect(series.length).toBe(1);
   });
 });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -69,6 +69,11 @@ function setupAxes(
   return { x: { axis: xAxis, g: gX }, y: yAxes };
 }
 
+interface Dimensions {
+  width: number;
+  height: number;
+}
+
 interface AxisData {
   axis: MyAxis;
   g: Selection<SVGGElement, unknown, HTMLElement, unknown>;
@@ -79,35 +84,22 @@ interface AxisSet {
   y: AxisData[];
 }
 
-interface Dimensions {
-  width: number;
-  height: number;
-}
-
-interface AxisState {
+export interface AxisState {
   tree?: SegmentTree<IMinMax>;
-  transform: ViewportTransform;
   scale: ScaleLinear<number, number>;
+  axis?: MyAxis;
+  gAxis?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+  transform: ViewportTransform;
 }
 
 export interface Series {
   axisIdx: number;
-  transform: ViewportTransform;
-  scale: ScaleLinear<number, number>;
   view?: SVGGElement;
   path?: SVGPathElement;
-  axis?: MyAxis;
-  gAxis?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
   line: Line<number[]>;
 }
 
-export function buildSeries(
-  data: ChartData,
-  transforms: ViewportTransform[],
-  scales: ScaleSet,
-  paths: PathSet,
-  axes?: AxisSet,
-): Series[] {
+export function buildSeries(data: ChartData, paths: PathSet): Series[] {
   const pathNodes = paths.path.nodes() as SVGPathElement[];
   const views = paths.nodes;
   const series: Series[] = [];
@@ -118,23 +110,7 @@ export function buildSeries(
     if (!path || !view) continue;
 
     const axisIdx = data.seriesAxes[i] ?? 0;
-    const tree = data.getTree(axisIdx);
-    if (!tree) continue;
-
-    const transform = transforms[axisIdx] ?? transforms[0];
-    const scale = scales.y[axisIdx] ?? scales.y[0];
-    const axisData = axes?.y?.[axisIdx] ?? axes?.y?.[0];
-
-    series.push({
-      axisIdx,
-      transform,
-      scale,
-      view,
-      path,
-      axis: axisData?.axis,
-      gAxis: axisData?.g,
-      line: createLine(i),
-    });
+    series.push({ axisIdx, view, path, line: createLine(i) });
   }
 
   return series;
@@ -142,9 +118,8 @@ export function buildSeries(
 
 export interface RenderState {
   scales: ScaleSet;
-  axes: AxisSet;
+  axisX: AxisData;
   paths: PathSet;
-  transforms: ViewportTransform[];
   axisStates: AxisState[];
   bScreenXVisible: AR1Basis;
   dimensions: Dimensions;
@@ -203,7 +178,7 @@ export function setupRender(
   );
 
   updateScaleX(scales.x, data.bIndexFull, data);
-  const series = buildSeries(data, transformsInner, scales, paths);
+  const series = buildSeries(data, paths);
 
   const axisStates: AxisState[] = data.trees.map((tree, i) => ({
     transform: transformsInner[Math.min(i, axisCount - 1)],
@@ -215,11 +190,10 @@ export function setupRender(
 
   const axes = setupAxes(svg, scales, width, height, hasSf, dualYAxis);
 
-  // Attach axes to series after scales have been initialized
-  series.forEach((s) => {
-    const axisData = axes.y[s.axisIdx] ?? axes.y[0];
-    s.axis = axisData.axis;
-    s.gAxis = axisData.g;
+  axisStates.forEach((a, i) => {
+    const axisData = axes.y[i] ?? axes.y[0];
+    a.axis = axisData.axis;
+    a.gAxis = axisData.g;
   });
 
   const refDp = DirectProductBasis.fromProjections(
@@ -235,18 +209,18 @@ export function setupRender(
 
   const state: RenderState = {
     scales,
-    axes,
+    axisX: axes.x,
     paths,
-    transforms: transformsInner,
     axisStates,
     bScreenXVisible,
     dimensions,
     dualYAxis,
     series,
     refresh(this: RenderState, data: ChartData) {
-      const bIndexVisible = this.transforms[0].fromScreenToModelBasisX(
-        this.bScreenXVisible,
-      );
+      const bIndexVisible =
+        this.axisStates[0].transform.fromScreenToModelBasisX(
+          this.bScreenXVisible,
+        );
       updateScaleX(this.scales.x, bIndexVisible, data);
       this.axisStates.forEach((a, i) => {
         a.tree = data.getTree(i);
@@ -256,13 +230,16 @@ export function setupRender(
 
       for (const s of this.series) {
         if (s.view) {
-          updateNode(s.view, s.transform.matrix);
+          const tf = this.axisStates[s.axisIdx].transform;
+          updateNode(s.view, tf.matrix);
         }
       }
-      for (const a of this.axes.y) {
-        a.axis.axisUp(a.g);
+      for (const a of this.axisStates) {
+        if (a.axis && a.gAxis) {
+          a.axis.axisUp(a.gAxis);
+        }
       }
-      this.axes.x.axis.axisUp(this.axes.x.g);
+      this.axisX.axis.axisUp(this.axisX.g);
     },
   };
 

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -61,7 +61,7 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [{ onZoomPan: vi.fn<(t: unknown) => void>() }],
+      axisStates: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -96,7 +96,7 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [{ onZoomPan: vi.fn<(t: unknown) => void>() }],
+      axisStates: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -51,11 +51,11 @@ describe("ZoomState", () => {
   it("updates transforms and triggers refresh on zoom", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const y2 = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
+    const y2 = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y, y2],
+      axisStates: [y, y2],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -73,8 +73,8 @@ describe("ZoomState", () => {
     zs.zoom(event);
     vi.runAllTimers();
 
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
-    expect(y2.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(y.transform.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(y2.transform.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
@@ -86,10 +86,10 @@ describe("ZoomState", () => {
   it("does not reschedule for programmatic transform", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axisStates: [y],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -117,10 +117,10 @@ describe("ZoomState", () => {
   it("refresh re-applies transform and triggers refresh callback", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axisStates: [y],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -148,10 +148,10 @@ describe("ZoomState", () => {
   it("reset sets transform to identity and triggers zoom event", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axisStates: [y],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -162,7 +162,7 @@ describe("ZoomState", () => {
 
     const transformSpy = zs.zoomBehavior.transform as unknown as vi.Mock;
     transformSpy.mockClear();
-    y.onZoomPan.mockClear();
+    y.transform.onZoomPan.mockClear();
     refresh.mockClear();
 
     zs.reset();
@@ -172,7 +172,7 @@ describe("ZoomState", () => {
       rect,
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
-    expect(y.onZoomPan).toHaveBeenCalledWith(
+    expect(y.transform.onZoomPan).toHaveBeenCalledWith(
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
     expect(
@@ -185,10 +185,10 @@ describe("ZoomState", () => {
   it("updates zoom extents on resize", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axisStates: [y],
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -217,10 +217,10 @@ describe("ZoomState", () => {
   it("uses provided scale extents", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axisStates: [y],
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -246,10 +246,10 @@ describe("ZoomState", () => {
   it("updates scale extent at runtime", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const y = { transform: { onZoomPan: vi.fn<(t: unknown) => void>() } };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axisStates: [y],
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -58,7 +58,9 @@ export class ZoomState {
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.currentPanZoomTransformState = event.transform;
-    this.state.transforms.forEach((t) => t.onZoomPan(event.transform));
+    this.state.axisStates.forEach((a) =>
+      a.transform.onZoomPan(event.transform),
+    );
     if (event.sourceEvent) {
       this.scheduleRefresh();
     }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -111,7 +111,7 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    let idx = this.state.transforms[0].fromScreenToModelX(x);
+    let idx = this.state.axisStates[0].transform.fromScreenToModelX(x);
     idx = Math.min(Math.max(idx, 0), this.data.length - 1);
     this.legendController.highlightIndex(idx);
   };


### PR DESCRIPTION
## Summary
- add AxisState to track transform, scale, axis and tree per dataset
- simplify Series to rendering details and build from `data.seriesAxes`
- update render, hover, and zoom logic to use centralized axis state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897376d8494832b85272124659c6992