### PR TITLE
refactor: separate axis state from series

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -109,7 +109,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: s.transform,
+        transform: state.axisStates[s.axisIdx].transform,
       })),
     });
 
@@ -160,7 +160,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: s.transform,
+        transform: state.axisStates[s.axisIdx].transform,
       })),
     });
 
@@ -200,7 +200,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: s.transform,
+        transform: state.axisStates[s.axisIdx].transform,
       })),
     });
 

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -115,8 +115,8 @@ describe("RenderState.refresh integration", () => {
     expect(ySfAfter).not.toEqual(ySfBefore);
 
     expect((state.axes.x.axis as any).scale1.domain()).toEqual(xAfter);
-    expect((state.axes.y[0].axis as any).scale1.domain()).toEqual(yNyAfter);
-    expect((state.axes.y[1].axis as any).scale1.domain()).toEqual(ySfAfter);
+    expect((state.axisStates[0].axis as any).scale1.domain()).toEqual(yNyAfter);
+    expect((state.axisStates[1].axis as any).scale1.domain()).toEqual(ySfAfter);
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);
     for (const s of state.series) {

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -112,14 +112,13 @@ describe("RenderState.refresh", () => {
 
     expect(state.series.length).toBe(1);
     expect(state.axisStates[0].tree).toBe(data.treeAxis0);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axisStates[state.series[0].axisIdx].scale.domain()).toEqual([
+      1, 3,
+    ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      expect(updateNodeMock).toHaveBeenNthCalledWith(
-        i + 1,
-        s.view,
-        s.transform.matrix,
-      );
+      const t = state.axisStates[s.axisIdx].transform;
+      expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });
 
@@ -142,15 +141,16 @@ describe("RenderState.refresh", () => {
 
     expect(state.axisStates[0].tree).toBe(data.treeAxis0);
     expect(state.axisStates[1].tree).toBe(data.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([1, 3]);
-    expect(state.series[1].scale.domain()).toEqual([10, 30]);
+    expect(state.axisStates[state.series[0].axisIdx].scale.domain()).toEqual([
+      1, 3,
+    ]);
+    expect(state.axisStates[state.series[1].axisIdx].scale.domain()).toEqual([
+      10, 30,
+    ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      expect(updateNodeMock).toHaveBeenNthCalledWith(
-        i + 1,
-        s.view,
-        s.transform.matrix,
-      );
+      const t = state.axisStates[s.axisIdx].transform;
+      expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });
 
@@ -169,9 +169,9 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.series[0].scale).toBe(state.series[1].scale);
-    expect(state.series[0].scale.domain()).toEqual([1, 30]);
-    expect(state.series[1].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates[0].scale).toBe(state.axisStates[1].scale);
+    expect(state.axisStates[0].scale.domain()).toEqual([1, 30]);
+    expect(state.axisStates[1].scale.domain()).toEqual([1, 30]);
   });
 
   it("refreshes after data changes", () => {
@@ -203,8 +203,8 @@ describe("RenderState.refresh", () => {
 
     expect(state.axisStates[0].tree).toBe(data2.treeAxis0);
     expect(state.axisStates[1].tree).toBe(data2.treeAxis1);
-    expect(state.series[0].scale.domain()).toEqual([4, 6]);
-    expect(state.series[1].scale.domain()).toEqual([40, 60]);
+    expect(state.axisStates[0].scale.domain()).toEqual([4, 6]);
+    expect(state.axisStates[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
@@ -221,7 +221,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
@@ -237,7 +237,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     state.refresh(data);
-    expect(state.series[0].scale.domain()).toEqual([Infinity, -Infinity]);
-    expect(state.series[1].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axisStates[1].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
@@ -94,21 +94,12 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(1);
     expect(series[0]).toMatchObject({
       axisIdx: 0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
     });
   });
 
@@ -125,29 +116,17 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
       axisIdx: 0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
     });
     expect(series[1]).toMatchObject({
       axisIdx: 1,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[1],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[1],
     });
   });
 
@@ -164,29 +143,17 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      state.paths,
-      state.axes,
-    );
+    const series = buildSeries(data, state.paths);
     expect(series.length).toBe(2);
     expect(series[0]).toMatchObject({
       axisIdx: 0,
-      transform: state.transforms[0],
-      scale: state.scales.y[0],
       view: state.paths.nodes[0],
-      axis: state.axes.y[0].axis,
-      gAxis: state.axes.y[0].g,
+      path: state.paths.path.nodes()[0],
     });
     expect(series[1]).toMatchObject({
       axisIdx: 1,
-      transform: state.transforms[1]!,
-      scale: state.scales.y[1],
       view: state.paths.nodes[1],
-      axis: state.axes.y[1].axis,
-      gAxis: state.axes.y[1].g,
+      path: state.paths.path.nodes()[1],
     });
   });
 
@@ -202,18 +169,12 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    setupRender(svg as any, data, false);
     const svg2 = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
     const singlePaths = initPaths(svg2, 1);
-    const series = buildSeries(
-      data,
-      state.transforms,
-      state.scales,
-      singlePaths,
-      state.axes,
-    );
+    const series = buildSeries(data, singlePaths);
     expect(series.length).toBe(1);
   });
 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -53,7 +53,9 @@ export class TimeSeriesChart {
       length: this.data.length,
       series: this.state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: s.transform,
+        transform:
+          this.state.axisStates[s.axisIdx]?.transform ??
+          this.state.axisStates[0].transform,
       })),
     };
     this.legendController.init(context);


### PR DESCRIPTION
## Summary
- add axis and DOM group references to `AxisState` and slim `Series` to rendering details
- build series per dataset and link axis information through `axisIdx`
- update render setup and legend mapping to use new axis state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68973c7ec9c4832bb243cb8cc0870671