### PR TITLE
refactor: centralize axis and series data

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -102,14 +102,14 @@ describe("LegendController", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    select(state.paths.nodes[0]).select("path").attr("stroke", "green");
+    select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
       getPoint: data.getPoint.bind(data),
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: state.axisStates[s.axisIdx].transform,
+        transform: state.axes.y[s.axisIdx].transform,
       })),
     });
 
@@ -123,7 +123,7 @@ describe("LegendController", () => {
     const matrix = lastCall[1] as Matrix;
     const modelPoint = new Point(1, data.getPoint(1).values[0]);
     const expected = modelPoint.matrixTransform(
-      state.transforms[0].matrix as any,
+      state.axes.y[0].transform.matrix as any,
     );
     expect(matrix.e).toBeCloseTo(expected.x);
     expect(matrix.f).toBeCloseTo(expected.y);
@@ -153,14 +153,14 @@ describe("LegendController", () => {
       return [timestamp, ...values] as any;
     }) as any;
     const state = setupRender(svg as any, data, false);
-    select(state.paths.nodes[0]).select("path").attr("stroke", "green");
+    select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
       getPoint: data.getPoint.bind(data),
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: state.axisStates[s.axisIdx].transform,
+        transform: state.axes.y[s.axisIdx].transform,
       })),
     });
 
@@ -193,14 +193,14 @@ describe("LegendController", () => {
       return { timestamp } as any;
     }) as any;
     const state = setupRender(svg as any, data, false);
-    select(state.paths.nodes[0]).select("path").attr("stroke", "green");
+    select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
       getPoint: data.getPoint.bind(data),
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: state.axisStates[s.axisIdx].transform,
+        transform: state.axes.y[s.axisIdx].transform,
       })),
     });
 

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -83,7 +83,7 @@ vi.mock("./zoomState.ts", () => ({
     private zoomCallback: (e: any) => void;
     reset = vi.fn(() => {
       const identity = { x: 0, k: 1 };
-      this.state.transforms.forEach((t: any) => t.onZoomPan(identity));
+      this.state.axes.y.forEach((a: any) => a.transform.onZoomPan(identity));
       this.refreshChart();
       this.zoomCallback({ transform: identity, sourceEvent: null });
     });

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -99,24 +99,24 @@ describe("RenderState.refresh integration", () => {
       .spyOn(domNode, "updateNode")
       .mockImplementation(() => {});
 
-    const xBefore = state.scales.x.domain().slice();
-    const yNyBefore = state.scales.y[0].domain().slice();
-    const ySfBefore = state.scales.y[1].domain().slice();
+    const xBefore = state.axes.x.scale.domain().slice();
+    const yNyBefore = state.axes.y[0].scale.domain().slice();
+    const ySfBefore = state.axes.y[1].scale.domain().slice();
 
     data.append(100, 200);
     state.refresh(data);
 
-    const xAfter = state.scales.x.domain();
-    const yNyAfter = state.scales.y[0].domain();
-    const ySfAfter = state.scales.y[1].domain();
+    const xAfter = state.axes.x.scale.domain();
+    const yNyAfter = state.axes.y[0].scale.domain();
+    const ySfAfter = state.axes.y[1].scale.domain();
 
     expect(xAfter).not.toEqual(xBefore);
     expect(yNyAfter).not.toEqual(yNyBefore);
     expect(ySfAfter).not.toEqual(ySfBefore);
 
     expect((state.axes.x.axis as any).scale1.domain()).toEqual(xAfter);
-    expect((state.axisStates[0].axis as any).scale1.domain()).toEqual(yNyAfter);
-    expect((state.axisStates[1].axis as any).scale1.domain()).toEqual(ySfAfter);
+    expect((state.axes.y[0].axis as any).scale1.domain()).toEqual(yNyAfter);
+    expect((state.axes.y[1].axis as any).scale1.domain()).toEqual(ySfAfter);
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);
     for (const s of state.series) {

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -111,13 +111,12 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.series.length).toBe(1);
-    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
-    expect(state.axisStates[state.series[0].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[0].axisIdx].scale.domain()).toEqual([
       1, 3,
     ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      const t = state.axisStates[s.axisIdx].transform;
+      const t = state.axes.y[s.axisIdx].transform;
       expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });
@@ -139,17 +138,15 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.axisStates[0].tree).toBe(data.treeAxis0);
-    expect(state.axisStates[1].tree).toBe(data.treeAxis1);
-    expect(state.axisStates[state.series[0].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[0].axisIdx].scale.domain()).toEqual([
       1, 3,
     ]);
-    expect(state.axisStates[state.series[1].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[1].axisIdx].scale.domain()).toEqual([
       10, 30,
     ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      const t = state.axisStates[s.axisIdx].transform;
+      const t = state.axes.y[s.axisIdx].transform;
       expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });
@@ -169,9 +166,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.axisStates[0].scale).toBe(state.axisStates[1].scale);
-    expect(state.axisStates[0].scale.domain()).toEqual([1, 30]);
-    expect(state.axisStates[1].scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y).toHaveLength(1);
+    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
   });
 
   it("refreshes after data changes", () => {
@@ -201,10 +197,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data2);
 
-    expect(state.axisStates[0].tree).toBe(data2.treeAxis0);
-    expect(state.axisStates[1].tree).toBe(data2.treeAxis1);
-    expect(state.axisStates[0].scale.domain()).toEqual([4, 6]);
-    expect(state.axisStates[1].scale.domain()).toEqual([40, 60]);
+    expect(state.axes.y[0].scale.domain()).toEqual([4, 6]);
+    expect(state.axes.y[1].scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
@@ -221,7 +215,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     state.refresh(data);
-    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axes.y[0].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
@@ -237,7 +231,7 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     state.refresh(data);
-    expect(state.axisStates[0].scale.domain()).toEqual([Infinity, -Infinity]);
-    expect(state.axisStates[1].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axes.y[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    expect(state.axes.y[1].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -4,10 +4,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
-import { select, type Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
-import { setupRender, buildSeries } from "./render.ts";
-import { initPaths } from "./render/utils.ts";
+import { setupRender } from "./render.ts";
 
 class Matrix {
   constructor(
@@ -94,13 +93,8 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(data, state.paths);
-    expect(series.length).toBe(1);
-    expect(series[0]).toMatchObject({
-      axisIdx: 0,
-      view: state.paths.nodes[0],
-      path: state.paths.path.nodes()[0],
-    });
+    expect(state.series.length).toBe(1);
+    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
   });
 
   it("returns two series for combined axis", () => {
@@ -116,18 +110,9 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    const series = buildSeries(data, state.paths);
-    expect(series.length).toBe(2);
-    expect(series[0]).toMatchObject({
-      axisIdx: 0,
-      view: state.paths.nodes[0],
-      path: state.paths.path.nodes()[0],
-    });
-    expect(series[1]).toMatchObject({
-      axisIdx: 1,
-      view: state.paths.nodes[1],
-      path: state.paths.path.nodes()[1],
-    });
+    expect(state.series.length).toBe(2);
+    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
+    expect(state.series[1]).toMatchObject({ axisIdx: 1 });
   });
 
   it("returns two series for dualYAxis", () => {
@@ -143,38 +128,8 @@ describe("buildSeries", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    const series = buildSeries(data, state.paths);
-    expect(series.length).toBe(2);
-    expect(series[0]).toMatchObject({
-      axisIdx: 0,
-      view: state.paths.nodes[0],
-      path: state.paths.path.nodes()[0],
-    });
-    expect(series[1]).toMatchObject({
-      axisIdx: 1,
-      view: state.paths.nodes[1],
-      path: state.paths.path.nodes()[1],
-    });
-  });
-
-  it("omits secondary series when path is missing", () => {
-    const svg = createSvg();
-    const source: IDataSource = {
-      startTime: 0,
-      timeStep: 1,
-      length: 3,
-      seriesCount: 2,
-      seriesAxes: [0, 1],
-      getSeries: (i, seriesIdx) =>
-        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
-    };
-    const data = new ChartData(source);
-    setupRender(svg as any, data, false);
-    const svg2 = select(document.createElement("div")).append(
-      "svg",
-    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const singlePaths = initPaths(svg2, 1);
-    const series = buildSeries(data, singlePaths);
-    expect(series.length).toBe(1);
+    expect(state.series.length).toBe(2);
+    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
+    expect(state.series[1]).toMatchObject({ axisIdx: 1 });
   });
 });

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
-import { initPaths, renderPaths, createLine } from "./render/utils.ts";
+import { initSeriesNode, renderPaths, createLine } from "./render/utils.ts";
 import type { RenderState } from "./render.ts";
 
 describe("renderPaths", () => {
@@ -39,34 +39,31 @@ describe("renderPaths", () => {
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
     const svg = svgSelection.node() as SVGSVGElement;
-    const { path } = initPaths(svgSelection, 1);
-    const nodes = path.nodes() as SVGPathElement[];
+    const { path } = initSeriesNode(svgSelection);
     const state = {
-      series: [{ path: nodes[0], line: createLine(0) }],
+      series: [{ path, line: createLine(0) }],
     } as unknown as RenderState;
-    const pathNode = nodes[0];
+    const pathNode = path;
     const spy = vi.spyOn(pathNode, "setAttribute");
 
     renderPaths(state, [[0], [1]]);
 
     expect(spy).toHaveBeenCalledTimes(state.series.length);
-    expect(path.attr("d")).not.toBe("");
+    expect(path.getAttribute("d")).not.toBe("");
     expect(svg.querySelectorAll("path").length).toBe(1);
 
     spy.mockRestore();
   });
 });
 
-describe("initPaths", () => {
-  it("creates only primary path when hasSf is false", () => {
+describe("initSeriesNode", () => {
+  it("creates a view and path", () => {
     const svgSelection = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const { path, nodes } = initPaths(svgSelection, 1);
+    const { view, path } = initSeriesNode(svgSelection);
 
-    expect(path.size()).toBe(1);
-    expect(nodes).toHaveLength(1);
-    expect(nodes[0].tagName).toBe("g");
-    expect(nodes[1]).toBeUndefined();
+    expect(view.tagName).toBe("g");
+    expect(path.tagName).toBe("path");
   });
 });

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -4,15 +4,14 @@
 import { describe, it, expect } from "vitest";
 import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
-import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
 import type { ViewportTransform } from "../ViewportTransform.ts";
 import { vi } from "vitest";
 import {
   createDimensions,
-  createScales,
   updateScaleX,
-  initPaths,
+  initSeriesNode,
 } from "./render/utils.ts";
 
 describe("createDimensions", () => {
@@ -36,25 +35,6 @@ describe("createDimensions", () => {
     expect(svg.getAttribute("height")).toBe(String(height));
     expect(dp.x().toArr()).toEqual([0, width]);
     expect(dp.y().toArr()).toEqual([height, 0]);
-  });
-});
-
-describe("createScales", () => {
-  const bX = new AR1Basis(0, 100);
-  const bY = new AR1Basis(100, 0);
-  const b = DirectProductBasis.fromProjections(bX, bY);
-
-  it("creates single y scale when count is 1", () => {
-    const scales = createScales(b, 1);
-    expect(scales.y).toHaveLength(1);
-    expect(scales.x.range()).toEqual([0, 100]);
-    expect(scales.y[0].range()).toEqual([100, 0]);
-  });
-
-  it("creates multiple y scales when count > 1", () => {
-    const scales = createScales(b, 2);
-    expect(scales.y).toHaveLength(2);
-    expect(scales.y[1].range()).toEqual([100, 0]);
   });
 });
 
@@ -102,8 +82,8 @@ describe("updateScaleY", () => {
   });
 });
 
-describe("initPaths", () => {
-  it("creates single series elements", () => {
+describe("initSeriesNode", () => {
+  it("creates a view and path", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const selection = select(svg) as unknown as Selection<
       SVGSVGElement,
@@ -111,29 +91,10 @@ describe("initPaths", () => {
       HTMLElement,
       unknown
     >;
-    const { path, nodes } = initPaths(selection, 1);
-    expect(path.nodes()).toHaveLength(1);
-    expect(nodes).toHaveLength(1);
-    expect(nodes[0].tagName).toBe("g");
-    expect(nodes[1]).toBeUndefined();
+    const { view, path } = initSeriesNode(selection);
+    expect(view.tagName).toBe("g");
+    expect(path.tagName).toBe("path");
     expect(svg.querySelectorAll("g.view")).toHaveLength(1);
     expect(svg.querySelectorAll("path")).toHaveLength(1);
-  });
-
-  it("creates dual series elements", () => {
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    const selection = select(svg) as unknown as Selection<
-      SVGSVGElement,
-      unknown,
-      HTMLElement,
-      unknown
-    >;
-    const { path, nodes } = initPaths(selection, 2);
-    expect(path.nodes()).toHaveLength(2);
-    expect(nodes).toHaveLength(2);
-    expect(nodes[0].tagName).toBe("g");
-    expect(nodes[1].tagName).toBe("g");
-    expect(svg.querySelectorAll("g.view")).toHaveLength(2);
-    expect(svg.querySelectorAll("path")).toHaveLength(2);
   });
 });

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -91,8 +91,8 @@ describe("setupRender Y-axis modes", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    expect(state.scales.y[0].domain()).toEqual([1, 30]);
-    expect(state.scales.y[1]).toBeUndefined();
+    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y[1]).toBeUndefined();
   });
 
   it("separates scales when dualYAxis is true", () => {
@@ -108,7 +108,7 @@ describe("setupRender Y-axis modes", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    expect(state.scales.y[0].domain()).toEqual([1, 3]);
-    expect(state.scales.y[1].domain()).toEqual([10, 30]);
+    expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
+    expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
   });
 });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,6 +1,6 @@
 import { Selection } from "d3-selection";
 import { line, type Line } from "d3-shape";
-import { ScaleLinear, ScaleTime, scaleLinear, scaleTime } from "d3-scale";
+import type { ScaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";
 import type { RenderState } from "../render.ts";
@@ -30,23 +30,6 @@ export function createDimensions(
   return DirectProductBasis.fromProjections(bScreenXVisible, bScreenYVisible);
 }
 
-export interface ScaleSet {
-  x: ScaleTime<number, number>;
-  y: ScaleLinear<number, number>[];
-}
-
-export function createScales(
-  bScreenVisible: DirectProductBasis,
-  yScaleCount: number,
-): ScaleSet {
-  const [xRange, yRange] = bScreenVisible.toArr();
-  const x: ScaleTime<number, number> = scaleTime().range(xRange);
-  const y = Array.from({ length: yScaleCount }, () =>
-    scaleLinear<number, number>().range(yRange),
-  );
-  return { x, y };
-}
-
 export function updateScaleX(
   x: ScaleTime<number, number>,
   bIndexVisible: AR1Basis,
@@ -57,24 +40,17 @@ export function updateScaleX(
   x.domain(bTimeVisible.toArr());
 }
 
-export interface PathSet {
-  path: Selection<SVGPathElement, number, SVGGElement, unknown>;
-  nodes: SVGGElement[];
+export interface SeriesNode {
+  view: SVGGElement;
+  path: SVGPathElement;
 }
 
-export function initPaths(
+export function initSeriesNode(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-  seriesCount: number,
-): PathSet {
-  const views = svg
-    .selectAll<SVGGElement, number>("g")
-    .data(Array.from({ length: seriesCount }, (_, i) => i))
-    .enter()
-    .append("g")
-    .attr("class", "view");
-  const nodes = views.nodes() as SVGGElement[];
-  const path = views.append<SVGPathElement>("path");
-  return { path, nodes };
+): SeriesNode {
+  const view = svg.append("g").attr("class", "view");
+  const path = view.append<SVGPathElement>("path").node() as SVGPathElement;
+  return { view: view.node() as SVGGElement, path };
 }
 
 export function renderPaths(state: RenderState, dataArr: number[][]) {

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { select, Selection } from "d3-selection";
 import type { RenderState } from "./render.ts";
@@ -61,7 +62,10 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [{ onZoomPan: vi.fn<(t: unknown) => void>() }],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } as any }],
+      },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -96,7 +100,10 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [{ onZoomPan: vi.fn<(t: unknown) => void>() }],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } as any }],
+      },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -1,6 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { select, Selection } from "d3-selection";
 import type { RenderState } from "./render.ts";
@@ -55,7 +56,10 @@ describe("ZoomState", () => {
     const y2 = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y, y2],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: y } as any, { transform: y2 } as any],
+      },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -89,7 +93,10 @@ describe("ZoomState", () => {
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: y } as any],
+      },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -120,7 +127,10 @@ describe("ZoomState", () => {
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: y } as any],
+      },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -151,7 +161,10 @@ describe("ZoomState", () => {
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: y } as any],
+      },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -188,7 +201,10 @@ describe("ZoomState", () => {
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: y } as any],
+      },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -220,7 +236,10 @@ describe("ZoomState", () => {
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axes: {
+        x: { axis: {} as any, g: {} as any, scale: {} as any },
+        y: [{ transform: y } as any],
+      },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -58,7 +58,7 @@ export class ZoomState {
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.currentPanZoomTransformState = event.transform;
-    this.state.transforms.forEach((t) => t.onZoomPan(event.transform));
+    this.state.axes.y.forEach((a) => a.transform.onZoomPan(event.transform));
     if (event.sourceEvent) {
       this.scheduleRefresh();
     }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -54,8 +54,8 @@ export class TimeSeriesChart {
       series: this.state.series.map((s) => ({
         path: s.path as SVGPathElement,
         transform:
-          this.state.axisStates[s.axisIdx]?.transform ??
-          this.state.axisStates[0].transform,
+          this.state.axes.y[s.axisIdx]?.transform ??
+          this.state.axes.y[0].transform,
       })),
     };
     this.legendController.init(context);
@@ -120,7 +120,7 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    let idx = this.state.transforms[0].fromScreenToModelX(x);
+    let idx = this.state.axes.y[0].transform.fromScreenToModelX(x);
     idx = Math.min(Math.max(idx, 0), this.data.length - 1);
     this.legendController.highlightIndex(idx);
   };


### PR DESCRIPTION
## Summary
- unify per-axis state into objects holding scale, transform and axis refs
- build series from view/path pairs and drop parallel path arrays
- update tests and utilities for new axis/series structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689741bb3fc4832bb5ef64c382aaed16