### PR TITLE
refactor: move segment trees to axis state

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -147,8 +147,10 @@ describe("ChartData", () => {
     ]);
     expect(cd.getPoint(0).timestamp).toBe(3);
     expect(cd.getPoint(1).timestamp).toBe(4);
-    expect(cd.treeAxis0.query(0, 1)).toEqual({ min: 3, max: 4 });
-    expect(cd.treeAxis1!.query(0, 1)).toEqual({ min: 3, max: 4 });
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
+    expect(tree0.query(0, 1)).toEqual({ min: 3, max: 4 });
+    expect(tree1.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
 
   it("throws when ny is invalid", () => {
@@ -191,8 +193,10 @@ describe("ChartData", () => {
       ),
     );
     const range = new AR1Basis(0, 2);
-    expect(cd.bAxisVisible(range, 0).toArr()).toEqual([10, 50]);
-    expect(cd.bAxisVisible(range, 1).toArr()).toEqual([20, 60]);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
+    expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([10, 50]);
+    expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([20, 60]);
   });
 
   it("floors and ceils fractional bounds when computing temperature visibility", () => {
@@ -206,10 +210,12 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const fractionalRange = new AR1Basis(0.49, 1.49);
-    expect(cd.bAxisVisible(fractionalRange, 0).toArr()).toEqual([10, 50]);
-    expect(cd.bAxisVisible(fractionalRange, 1).toArr()).toEqual([20, 60]);
+    expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([10, 50]);
+    expect(cd.bAxisVisible(fractionalRange, tree1).toArr()).toEqual([20, 60]);
   });
 
   it("handles fractional bounds in the middle of the dataset", () => {
@@ -223,10 +229,12 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const fractionalRange = new AR1Basis(1.1, 1.7);
-    expect(cd.bAxisVisible(fractionalRange, 0).toArr()).toEqual([30, 50]);
-    expect(cd.bAxisVisible(fractionalRange, 1).toArr()).toEqual([40, 60]);
+    expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([30, 50]);
+    expect(cd.bAxisVisible(fractionalRange, tree1).toArr()).toEqual([40, 60]);
   });
 
   it("clamps bounds that extend past the data range", () => {
@@ -240,12 +248,14 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const outOfRange = new AR1Basis(-0.5, 3.5);
-    expect(() => cd.bAxisVisible(outOfRange, 0)).not.toThrow();
-    expect(() => cd.bAxisVisible(outOfRange, 1)).not.toThrow();
-    expect(cd.bAxisVisible(outOfRange, 0).toArr()).toEqual([10, 50]);
-    expect(cd.bAxisVisible(outOfRange, 1).toArr()).toEqual([20, 60]);
+    expect(() => cd.bAxisVisible(outOfRange, tree0)).not.toThrow();
+    expect(() => cd.bAxisVisible(outOfRange, tree1)).not.toThrow();
+    expect(cd.bAxisVisible(outOfRange, tree0).toArr()).toEqual([10, 50]);
+    expect(cd.bAxisVisible(outOfRange, tree1).toArr()).toEqual([20, 60]);
   });
 
   it("clamps bounds completely to the left of the data range", () => {
@@ -259,12 +269,14 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const leftRange = new AR1Basis(-5, -1);
-    expect(() => cd.bAxisVisible(leftRange, 0)).not.toThrow();
-    expect(() => cd.bAxisVisible(leftRange, 1)).not.toThrow();
-    expect(cd.bAxisVisible(leftRange, 0).toArr()).toEqual([10, 10]);
-    expect(cd.bAxisVisible(leftRange, 1).toArr()).toEqual([20, 20]);
+    expect(() => cd.bAxisVisible(leftRange, tree0)).not.toThrow();
+    expect(() => cd.bAxisVisible(leftRange, tree1)).not.toThrow();
+    expect(cd.bAxisVisible(leftRange, tree0).toArr()).toEqual([10, 10]);
+    expect(cd.bAxisVisible(leftRange, tree1).toArr()).toEqual([20, 20]);
   });
 
   it("clamps bounds completely to the right of the data range", () => {
@@ -278,12 +290,14 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const rightRange = new AR1Basis(5, 10);
-    expect(() => cd.bAxisVisible(rightRange, 0)).not.toThrow();
-    expect(() => cd.bAxisVisible(rightRange, 1)).not.toThrow();
-    expect(cd.bAxisVisible(rightRange, 0).toArr()).toEqual([50, 50]);
-    expect(cd.bAxisVisible(rightRange, 1).toArr()).toEqual([60, 60]);
+    expect(() => cd.bAxisVisible(rightRange, tree0)).not.toThrow();
+    expect(() => cd.bAxisVisible(rightRange, tree1)).not.toThrow();
+    expect(cd.bAxisVisible(rightRange, tree0).toArr()).toEqual([50, 50]);
+    expect(cd.bAxisVisible(rightRange, tree1).toArr()).toEqual([60, 60]);
   });
 
   it("computes combined temperature basis and direct product", () => {
@@ -297,7 +311,9 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
+    const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
     expect(combined.toArr()).toEqual([-3, 10]);
     expect(dp.x().toArr()).toEqual([0, 2]);
     expect(dp.y().toArr()).toEqual([-3, 10]);
@@ -313,14 +329,22 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
     const range = new AR1Basis(0, 1);
-    expect(cd.treeAxis0.query(0, 1)).toEqual({ min: Infinity, max: -Infinity });
-    expect(cd.treeAxis1!.query(0, 1)).toEqual({
+    expect(tree0.query(0, 1)).toEqual({ min: Infinity, max: -Infinity });
+    expect(tree1.query(0, 1)).toEqual({
       min: Infinity,
       max: -Infinity,
     });
-    expect(cd.bAxisVisible(range, 0).toArr()).toEqual([Infinity, -Infinity]);
-    expect(cd.bAxisVisible(range, 1).toArr()).toEqual([Infinity, -Infinity]);
+    expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([
+      Infinity,
+      -Infinity,
+    ]);
+    expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([
+      Infinity,
+      -Infinity,
+    ]);
   });
 
   it("ignores NaN values when computing min/max", () => {
@@ -333,11 +357,13 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
     const range = new AR1Basis(0, 1);
-    expect(cd.treeAxis0.query(0, 1)).toEqual({ min: 5, max: 5 });
-    expect(cd.treeAxis1!.query(0, 1)).toEqual({ min: 3, max: 3 });
-    expect(cd.bAxisVisible(range, 0).toArr()).toEqual([5, 5]);
-    expect(cd.bAxisVisible(range, 1).toArr()).toEqual([3, 3]);
+    expect(tree0.query(0, 1)).toEqual({ min: 5, max: 5 });
+    expect(tree1.query(0, 1)).toEqual({ min: 3, max: 3 });
+    expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([5, 5]);
+    expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([3, 3]);
   });
 
   describe("single-axis", () => {
@@ -351,11 +377,11 @@ describe("ChartData", () => {
         seriesAxes: [0],
       };
       const cd = new ChartData(source);
-      expect(cd.treeAxis1).toBeUndefined();
       expect(cd.data).toEqual([[0], [1]]);
       cd.append(2);
       expect(cd.data).toEqual([[1], [2]]);
-      expect(cd.treeAxis0.query(0, 1)).toEqual({ min: 1, max: 2 });
+      const tree0 = cd.buildAxisTree(0);
+      expect(tree0.query(0, 1)).toEqual({ min: 1, max: 2 });
     });
 
     it("ignores provided sf when single-axis", () => {
@@ -374,12 +400,16 @@ describe("ChartData", () => {
 
     it("returns Infinity/-Infinity min/max when data is all NaN", () => {
       const cd = new ChartData(makeSource([[NaN], [NaN]], [0]));
+      const tree0 = cd.buildAxisTree(0);
       const range = new AR1Basis(0, 1);
-      expect(cd.treeAxis0.query(0, 1)).toEqual({
+      expect(tree0.query(0, 1)).toEqual({
         min: Infinity,
         max: -Infinity,
       });
-      expect(cd.bAxisVisible(range, 0).toArr()).toEqual([Infinity, -Infinity]);
+      expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([
+        Infinity,
+        -Infinity,
+      ]);
     });
   });
 
@@ -393,17 +423,20 @@ describe("ChartData", () => {
         [0, 0, 0, 1, 1],
       ),
     );
-    expect(cd.trees).toHaveLength(2);
-    expect(cd.treeAxis0.query(0, 1)).toEqual({ min: 0, max: 20 });
-    expect(cd.treeAxis1!.query(0, 1)).toEqual({ min: 100, max: 220 });
+    let tree0 = cd.buildAxisTree(0);
+    let tree1 = cd.buildAxisTree(1);
+    expect(tree0.query(0, 1)).toEqual({ min: 0, max: 20 });
+    expect(tree1.query(0, 1)).toEqual({ min: 100, max: 220 });
 
     cd.append(2, 30, 25, 130, 230);
     expect(cd.data).toEqual([
       [1, 20, 15, 110, 220],
       [2, 30, 25, 130, 230],
     ]);
-    expect(cd.treeAxis0.query(0, 1)).toEqual({ min: 1, max: 30 });
-    expect(cd.treeAxis1!.query(0, 1)).toEqual({ min: 110, max: 230 });
+    tree0 = cd.buildAxisTree(0);
+    tree1 = cd.buildAxisTree(1);
+    expect(tree0.query(0, 1)).toEqual({ min: 1, max: 30 });
+    expect(tree1.query(0, 1)).toEqual({ min: 110, max: 230 });
     expect(cd.getPoint(1)).toEqual({
       values: [2, 30, 25, 130, 230],
       timestamp: 2,

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -202,6 +202,27 @@ describe("RenderState.refresh", () => {
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
+  it("rebuilds axis trees after data append", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      seriesCount: 1,
+      seriesAxes: [0],
+      getSeries: (i) => [1, 2, 3][i],
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+
+    expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 1, max: 3 });
+
+    data.append(4);
+    state.refresh(data);
+
+    expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 2, max: 4 });
+  });
+
   it("produces finite domain when series is all NaN", () => {
     const svg = createSvg();
     const source: IDataSource = {

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -74,7 +74,8 @@ describe("updateScaleY", () => {
     const vt = {
       onReferenceViewWindowResize: vi.fn(),
     } as unknown as ViewportTransform;
-    const dp = cd.updateScaleY(new AR1Basis(0, 2), cd.treeAxis0);
+    const tree = cd.buildAxisTree(0);
+    const dp = cd.updateScaleY(new AR1Basis(0, 2), tree);
     vt.onReferenceViewWindowResize(dp);
     y.domain(dp.y().toArr());
     expect(y.domain()).toEqual([10, 40]);


### PR DESCRIPTION
## Summary
- move segment trees out of `ChartData` and into per-axis state
- rebuild axis trees during render updates and support combined axes
- adjust tests for new API
- add regression test ensuring axis trees rebuild after appending data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68974fbe6c48832b9edbe25a6a98c329