### PR TITLE
refactor: apply chaining in render

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -29,19 +29,22 @@ export class ViewportTransform {
     this.composedMatrix = this.zoomTransform.multiply(this.referenceTransform);
   }
 
-  public onViewPortResize(bScreenVisible: DirectProductBasis): void {
+  public onViewPortResize(bScreenVisible: DirectProductBasis): this {
     this.viewPortPoints = bScreenVisible;
     this.updateReferenceTransform();
+    return this;
   }
 
-  public onReferenceViewWindowResize(newPoints: DirectProductBasis) {
+  public onReferenceViewWindowResize(newPoints: DirectProductBasis): this {
     this.referenceViewWindowPoints = newPoints;
     this.updateReferenceTransform();
+    return this;
   }
 
-  public onZoomPan(t: ZoomTransform): void {
+  public onZoomPan(t: ZoomTransform): this {
     this.zoomTransform = new DOMMatrix().scale(t.k, 1).translate(t.x, 0);
     this.updateComposedMatrix();
+    return this;
   }
 
   private toModelPoint(x: number, y: number) {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -51,22 +51,28 @@ function setupAxes(
   xAxis.setScale(xScale);
   const gX = svg.append("g").attr("class", "axis").call(xAxis.axis.bind(xAxis));
 
-  const yRight = createYAxis(Orientation.Right, axes[0].scale, width);
-  const gYRight = svg
+  axes[0].g = svg
     .append("g")
     .attr("class", "axis")
-    .call(yRight.axis.bind(yRight));
-  axes[0].axis = yRight;
-  axes[0].g = gYRight;
+    .call(
+      (axes[0].axis = createYAxis(
+        Orientation.Right,
+        axes[0].scale,
+        width,
+      )).axis.bind(axes[0].axis),
+    );
 
   if (hasSf && dualYAxis && axes[1]) {
-    const yLeft = createYAxis(Orientation.Left, axes[1].scale, width);
-    const gYLeft = svg
+    axes[1].g = svg
       .append("g")
       .attr("class", "axis")
-      .call(yLeft.axis.bind(yLeft));
-    axes[1].axis = yLeft;
-    axes[1].g = gYLeft;
+      .call(
+        (axes[1].axis = createYAxis(
+          Orientation.Left,
+          axes[1].scale,
+          width,
+        )).axis.bind(axes[1].axis),
+      );
   }
 
   return { axis: xAxis, g: gX, scale: xScale };
@@ -158,9 +164,8 @@ export function setupRender(
 
   const bScreenVisibleDp = createDimensions(svg);
   const bScreenXVisible = bScreenVisibleDp.x();
-  const bScreenYVisible = bScreenVisibleDp.y();
   const width = bScreenXVisible.getRange();
-  const height = bScreenYVisible.getRange();
+  const height = bScreenVisibleDp.y().getRange();
   const axisCount = hasSf && dualYAxis ? 2 : 1;
 
   const [xRange, yRange] = bScreenVisibleDp.toArr();


### PR DESCRIPTION
## Summary
- use chained D3 calls to create and assign axes in render setup
- simplify dimension handling with chained basis calls
- expose chainable ViewportTransform methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689757bb6fec832b8083d235bd25e5da