### PR TITLE
feat(chart): validate time inputs

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -25,6 +25,52 @@ describe("ChartData", () => {
     expect(() => new ChartData(source)).toThrow(/non-empty data array/);
   });
 
+  it("throws when startTime is not finite", () => {
+    const source: IDataSource = {
+      startTime: NaN,
+      timeStep: 1,
+      length: 1,
+      seriesCount: 1,
+      getSeries: () => 0,
+      seriesAxes: [0],
+    };
+    expect(() => new ChartData(source)).toThrow(/startTime/);
+  });
+
+  it("throws when timeStep is not finite", () => {
+    const base = {
+      startTime: 0,
+      length: 1,
+      seriesCount: 1,
+      getSeries: () => 0,
+      seriesAxes: [0],
+    };
+    expect(() => new ChartData({ ...base, timeStep: NaN })).toThrow(/timeStep/);
+    expect(() => new ChartData({ ...base, timeStep: Infinity })).toThrow(
+      /timeStep/,
+    );
+    expect(() => new ChartData({ ...base, timeStep: -Infinity })).toThrow(
+      /timeStep/,
+    );
+  });
+
+  it("throws when timeStep is not greater than 0", () => {
+    const base: IDataSource = {
+      startTime: 0,
+      length: 1,
+      seriesCount: 1,
+      getSeries: () => 0,
+      seriesAxes: [0],
+      timeStep: 0,
+    };
+    expect(() => new ChartData({ ...base, timeStep: 0 })).toThrow(
+      /greater than 0/,
+    );
+    expect(() => new ChartData({ ...base, timeStep: -1 })).toThrow(
+      /greater than 0/,
+    );
+  });
+
   it("throws when seriesAxes length does not match seriesCount", () => {
     const source = makeSource(
       [

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -58,6 +58,15 @@ export class ChartData {
     if (source.seriesCount < 1) {
       throw new Error("ChartData requires at least one series");
     }
+    if (!Number.isFinite(source.startTime)) {
+      throw new Error("ChartData requires startTime to be a finite number");
+    }
+    if (!Number.isFinite(source.timeStep)) {
+      throw new Error("ChartData requires timeStep to be a finite number");
+    }
+    if (source.timeStep <= 0) {
+      throw new Error("ChartData requires timeStep to be greater than 0");
+    }
     this.seriesCount = source.seriesCount;
     if (source.seriesAxes == null) {
       throw new Error("ChartData requires seriesAxes mapping");


### PR DESCRIPTION
## Summary
- validate `ChartData` constructor startTime is finite and timeStep is finite and positive
- test constructor guardrails for invalid time inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689774b3ca60832bab1a94fad3be93e6