### PR TITLE
feat: clean up DOM on chart dispose

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -97,6 +97,23 @@ export class TimeSeriesChart {
     this.zoomArea.on("mousemove", null).on("mouseleave", null);
     this.zoomArea.remove();
     this.legendController.destroy();
+
+    for (const s of this.state.series) {
+      s.path?.remove();
+      s.view?.remove();
+      s.path = undefined;
+      s.view = undefined;
+    }
+    this.state.series.length = 0;
+    const axisX = this.state.axes.x;
+    axisX.g.remove();
+    (axisX as unknown as { g?: typeof axisX.g }).g = undefined;
+
+    for (const axis of this.state.axes.y) {
+      axis.g?.remove();
+      axis.g = undefined;
+    }
+    this.state.axes.y.length = 0;
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {


### PR DESCRIPTION
## Summary
- ensure TimeSeriesChart.dispose removes series paths and axis groups
- clear SVG references after disposal to aid GC

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689774a78728832baeb792db6319bb5f