### PR TITLE
Refactor axes to use AxisId enum

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -8,6 +8,7 @@ import { select } from "d3-selection";
 
 import { LegendController } from "./LegendController.ts";
 import { ChartData, IDataSource } from "../svg-time-series/src/chart/data.ts";
+import { AxisId } from "../svg-time-series/src/chart/types.ts";
 import { setupRender } from "../svg-time-series/src/chart/render.ts";
 import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
 
@@ -98,7 +99,7 @@ describe("LegendController", () => {
       length: 2,
       seriesCount: 1,
       getSeries: (i) => [10, 20][i],
-      seriesAxes: [0],
+      seriesAxes: [AxisId.Primary],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
@@ -109,7 +110,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: state.axes.y[s.axisIdx].transform,
+        transform: state.axes.y[s.axis].transform,
       })),
     });
 
@@ -123,7 +124,7 @@ describe("LegendController", () => {
     const matrix = lastCall[1] as Matrix;
     const modelPoint = new Point(1, data.getPoint(1).values[0]);
     const expected = modelPoint.matrixTransform(
-      state.axes.y[0].transform.matrix as any,
+      state.axes.y[AxisId.Primary].transform.matrix as any,
     );
     expect(matrix.e).toBeCloseTo(expected.x);
     expect(matrix.f).toBeCloseTo(expected.y);
@@ -143,7 +144,7 @@ describe("LegendController", () => {
       length: 2,
       seriesCount: 1,
       getSeries: (i) => [10, 20][i],
-      seriesAxes: [0],
+      seriesAxes: [AxisId.Primary],
     };
     const data = new ChartData(source);
     const originalGetPoint = data.getPoint.bind(data);
@@ -160,7 +161,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: state.axes.y[s.axisIdx].transform,
+        transform: state.axes.y[s.axis].transform,
       })),
     });
 
@@ -183,7 +184,7 @@ describe("LegendController", () => {
       length: 2,
       seriesCount: 1,
       getSeries: (i) => [10, 20][i],
-      seriesAxes: [0],
+      seriesAxes: [AxisId.Primary],
     };
     const data = new ChartData(source);
     const originalGetPoint = data.getPoint.bind(data);
@@ -200,7 +201,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path as SVGPathElement,
-        transform: state.axes.y[s.axisIdx].transform,
+        transform: state.axes.y[s.axis].transform,
       })),
     });
 

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from "vitest";
 import { ChartData, IDataSource } from "./data.ts";
+import { AxisId } from "./types.ts";
 import { AR1Basis } from "../math/affine.ts";
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 describe("ChartData", () => {
-  const makeSource = (data: number[][], seriesAxes: number[]): IDataSource => ({
+  const makeSource = (data: number[][], seriesAxes: AxisId[]): IDataSource => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -20,7 +21,7 @@ describe("ChartData", () => {
       length: 0,
       seriesCount: 1,
       getSeries: () => 0,
-      seriesAxes: [0],
+      seriesAxes: [AxisId.Primary],
     };
     expect(() => new ChartData(source)).toThrow(/non-empty data array/);
   });
@@ -31,7 +32,7 @@ describe("ChartData", () => {
         [0, 0],
         [1, 1],
       ],
-      [0],
+      [AxisId.Primary],
     );
     expect(() => new ChartData(source)).toThrow(/seriesAxes length/);
   });
@@ -42,7 +43,7 @@ describe("ChartData", () => {
         [0, 0],
         [1, 1],
       ],
-      [0, 2],
+      [AxisId.Primary, 2 as AxisId],
     );
     expect(() => new ChartData(source)).toThrow(/0 or 1/);
   });
@@ -53,7 +54,7 @@ describe("ChartData", () => {
         [0, 0],
         [1, 1],
       ],
-      [0, 1],
+      [AxisId.Primary, AxisId.Secondary],
     );
     const cd = new ChartData(source);
     expect(cd.data).toEqual([
@@ -81,7 +82,7 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
     expect(cd.getPoint(1)).toEqual({ values: [30, 40], timestamp: 1 });
@@ -97,7 +98,7 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
     expect(() => cd.getPoint(NaN)).toThrow(/idx/);
@@ -113,7 +114,7 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
     expect(cd.getPoint(1_000_000)).toEqual({
@@ -133,7 +134,7 @@ describe("ChartData", () => {
           [0, 0],
           [1, 1],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
 
@@ -147,8 +148,8 @@ describe("ChartData", () => {
     ]);
     expect(cd.getPoint(0).timestamp).toBe(3);
     expect(cd.getPoint(1).timestamp).toBe(4);
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
     expect(tree0.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
@@ -159,7 +160,7 @@ describe("ChartData", () => {
         [0, 0],
         [1, 1],
       ],
-      [0, 1],
+      [AxisId.Primary, AxisId.Secondary],
     );
     const cd = new ChartData(source);
     expect(() => cd.append(undefined as unknown as number, 2)).toThrow(
@@ -173,7 +174,7 @@ describe("ChartData", () => {
         [0, 0],
         [1, 1],
       ],
-      [0, 1],
+      [AxisId.Primary, AxisId.Secondary],
     );
     const cd = new ChartData(source);
     expect(() => cd.append(2, undefined as unknown as number)).toThrow(
@@ -189,12 +190,12 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
     const range = new AR1Basis(0, 2);
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
     expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([10, 50]);
     expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([20, 60]);
   });
@@ -207,11 +208,11 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
 
     const fractionalRange = new AR1Basis(0.49, 1.49);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([10, 50]);
@@ -226,11 +227,11 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
 
     const fractionalRange = new AR1Basis(1.1, 1.7);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([30, 50]);
@@ -245,11 +246,11 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
 
     const outOfRange = new AR1Basis(-0.5, 3.5);
     expect(() => cd.bAxisVisible(outOfRange, tree0)).not.toThrow();
@@ -266,11 +267,11 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
 
     const leftRange = new AR1Basis(-5, -1);
     expect(() => cd.bAxisVisible(leftRange, tree0)).not.toThrow();
@@ -287,11 +288,11 @@ describe("ChartData", () => {
           [30, 40],
           [50, 60],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
 
     const rightRange = new AR1Basis(5, 10);
     expect(() => cd.bAxisVisible(rightRange, tree0)).not.toThrow();
@@ -308,11 +309,11 @@ describe("ChartData", () => {
           [5, 2],
           [-3, 7],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
     const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
     expect(combined.toArr()).toEqual([-3, 10]);
     expect(dp.x().toArr()).toEqual([0, 2]);
@@ -326,11 +327,11 @@ describe("ChartData", () => {
           [NaN, NaN],
           [NaN, NaN],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
     const range = new AR1Basis(0, 1);
     expect(tree0.query(0, 1)).toEqual({ min: Infinity, max: -Infinity });
     expect(tree1.query(0, 1)).toEqual({
@@ -354,11 +355,11 @@ describe("ChartData", () => {
           [NaN, NaN],
           [5, 3],
         ],
-        [0, 1],
+        [AxisId.Primary, AxisId.Secondary],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = cd.buildAxisTree(AxisId.Primary);
+    const tree1 = cd.buildAxisTree(AxisId.Secondary);
     const range = new AR1Basis(0, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 5, max: 5 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 3 });
@@ -374,13 +375,13 @@ describe("ChartData", () => {
         length: 2,
         seriesCount: 1,
         getSeries: (i) => [0, 1][i],
-        seriesAxes: [0],
+        seriesAxes: [AxisId.Primary],
       };
       const cd = new ChartData(source);
       expect(cd.data).toEqual([[0], [1]]);
       cd.append(2);
       expect(cd.data).toEqual([[1], [2]]);
-      const tree0 = cd.buildAxisTree(0);
+      const tree0 = cd.buildAxisTree(AxisId.Primary);
       expect(tree0.query(0, 1)).toEqual({ min: 1, max: 2 });
     });
 
@@ -391,7 +392,7 @@ describe("ChartData", () => {
         length: 1,
         seriesCount: 1,
         getSeries: (i) => [0][i],
-        seriesAxes: [0],
+        seriesAxes: [AxisId.Primary],
       };
       const cd = new ChartData(source);
       expect(() => cd.append(1)).not.toThrow();
@@ -399,8 +400,8 @@ describe("ChartData", () => {
     });
 
     it("returns Infinity/-Infinity min/max when data is all NaN", () => {
-      const cd = new ChartData(makeSource([[NaN], [NaN]], [0]));
-      const tree0 = cd.buildAxisTree(0);
+      const cd = new ChartData(makeSource([[NaN], [NaN]], [AxisId.Primary]));
+      const tree0 = cd.buildAxisTree(AxisId.Primary);
       const range = new AR1Basis(0, 1);
       expect(tree0.query(0, 1)).toEqual({
         min: Infinity,
@@ -420,11 +421,17 @@ describe("ChartData", () => {
           [0, 10, 5, 100, 200],
           [1, 20, 15, 110, 220],
         ],
-        [0, 0, 0, 1, 1],
+        [
+          AxisId.Primary,
+          AxisId.Primary,
+          AxisId.Primary,
+          AxisId.Secondary,
+          AxisId.Secondary,
+        ],
       ),
     );
-    let tree0 = cd.buildAxisTree(0);
-    let tree1 = cd.buildAxisTree(1);
+    let tree0 = cd.buildAxisTree(AxisId.Primary);
+    let tree1 = cd.buildAxisTree(AxisId.Secondary);
     expect(tree0.query(0, 1)).toEqual({ min: 0, max: 20 });
     expect(tree1.query(0, 1)).toEqual({ min: 100, max: 220 });
 
@@ -433,8 +440,8 @@ describe("ChartData", () => {
       [1, 20, 15, 110, 220],
       [2, 30, 25, 130, 230],
     ]);
-    tree0 = cd.buildAxisTree(0);
-    tree1 = cd.buildAxisTree(1);
+    tree0 = cd.buildAxisTree(AxisId.Primary);
+    tree1 = cd.buildAxisTree(AxisId.Secondary);
     expect(tree0.query(0, 1)).toEqual({ min: 1, max: 30 });
     expect(tree1.query(0, 1)).toEqual({ min: 110, max: 230 });
     expect(cd.getPoint(1)).toEqual({

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { AxisId } from "./types.ts";
 import type { ILegendController, LegendContext } from "./legend.ts";
 
 class Matrix {
@@ -92,7 +93,7 @@ function createChart(data: Array<[number]>) {
     timeStep: 1,
     length: data.length,
     seriesCount: 1,
-    seriesAxes: [0],
+    seriesAxes: [AxisId.Primary],
     getSeries: (i) => data[i][0],
   };
   const legendController = new StubLegendController();

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { AxisId } from "./types.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -132,7 +133,7 @@ function createChart(data: Array<[number, number]>, options?: any) {
     timeStep: 1,
     length: data.length,
     seriesCount: 2,
-    seriesAxes: [0, 1],
+    seriesAxes: [AxisId.Primary, AxisId.Secondary],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(select(legend) as any);

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { AxisId } from "./types.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -118,7 +119,7 @@ function createChart(data: Array<[number]>) {
     timeStep: 1,
     length: data.length,
     seriesCount: 1,
-    seriesAxes: [0],
+    seriesAxes: [AxisId.Primary],
     getSeries: (i) => data[i][0],
   };
   const legendController = new LegendController(select(legend) as any);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { AxisId } from "./types.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -122,7 +123,7 @@ function createChart(
     timeStep: 1,
     length: data.length,
     seriesCount: 2,
-    seriesAxes: [0, 1],
+    seriesAxes: [AxisId.Primary, AxisId.Secondary],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(
@@ -357,7 +358,7 @@ describe("chart interaction", () => {
       timeStep: 1,
       length: 2,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary],
       getSeries: (i) => [0, 1][i],
     };
     const legendController = new LegendController(select(legend) as any);

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
+import { AxisId } from "./types.ts";
 import { setupRender } from "./render.ts";
 import * as domNode from "../utils/domNodeTransform.ts";
 
@@ -89,7 +90,7 @@ describe("RenderState.refresh integration", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
@@ -100,23 +101,27 @@ describe("RenderState.refresh integration", () => {
       .mockImplementation(() => {});
 
     const xBefore = state.axes.x.scale.domain().slice();
-    const yNyBefore = state.axes.y[0].scale.domain().slice();
-    const ySfBefore = state.axes.y[1].scale.domain().slice();
+    const yNyBefore = state.axes.y[AxisId.Primary].scale.domain().slice();
+    const ySfBefore = state.axes.y[AxisId.Secondary].scale.domain().slice();
 
     data.append(100, 200);
     state.refresh(data);
 
     const xAfter = state.axes.x.scale.domain();
-    const yNyAfter = state.axes.y[0].scale.domain();
-    const ySfAfter = state.axes.y[1].scale.domain();
+    const yNyAfter = state.axes.y[AxisId.Primary].scale.domain();
+    const ySfAfter = state.axes.y[AxisId.Secondary].scale.domain();
 
     expect(xAfter).not.toEqual(xBefore);
     expect(yNyAfter).not.toEqual(yNyBefore);
     expect(ySfAfter).not.toEqual(ySfBefore);
 
     expect((state.axes.x.axis as any).scale1.domain()).toEqual(xAfter);
-    expect((state.axes.y[0].axis as any).scale1.domain()).toEqual(yNyAfter);
-    expect((state.axes.y[1].axis as any).scale1.domain()).toEqual(ySfAfter);
+    expect((state.axes.y[AxisId.Primary].axis as any).scale1.domain()).toEqual(
+      yNyAfter,
+    );
+    expect(
+      (state.axes.y[AxisId.Secondary].axis as any).scale1.domain(),
+    ).toEqual(ySfAfter);
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);
     for (const s of state.series) {

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
+import { AxisId } from "./types.ts";
 import { setupRender } from "./render.ts";
 
 class Matrix {
@@ -88,13 +89,13 @@ describe("buildSeries", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 1,
-      seriesAxes: [0],
+      seriesAxes: [AxisId.Primary],
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     expect(state.series.length).toBe(1);
-    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
+    expect(state.series[0]).toMatchObject({ axis: AxisId.Primary });
   });
 
   it("returns two series for combined axis", () => {
@@ -104,15 +105,15 @@ describe("buildSeries", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     expect(state.series.length).toBe(2);
-    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
-    expect(state.series[1]).toMatchObject({ axisIdx: 1 });
+    expect(state.series[0]).toMatchObject({ axis: AxisId.Primary });
+    expect(state.series[1]).toMatchObject({ axis: AxisId.Secondary });
   });
 
   it("returns two series for dualYAxis", () => {
@@ -122,14 +123,14 @@ describe("buildSeries", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     expect(state.series.length).toBe(2);
-    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
-    expect(state.series[1]).toMatchObject({ axisIdx: 1 });
+    expect(state.series[0]).toMatchObject({ axis: AxisId.Primary });
+    expect(state.series[1]).toMatchObject({ axis: AxisId.Secondary });
   });
 });

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -6,6 +6,7 @@ import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
+import { AxisId } from "./types.ts";
 import type { ViewportTransform } from "../ViewportTransform.ts";
 import { vi } from "vitest";
 import {
@@ -44,7 +45,7 @@ describe("updateScaleX", () => {
     timeStep: 1,
     length: data.length,
     seriesCount: 1,
-    seriesAxes: [0],
+    seriesAxes: [AxisId.Primary],
     getSeries: (i) => data[i][0],
   });
 
@@ -64,7 +65,7 @@ describe("updateScaleY", () => {
     timeStep: 1,
     length: data.length,
     seriesCount: 1,
-    seriesAxes: [0],
+    seriesAxes: [AxisId.Primary],
     getSeries: (i) => data[i][0],
   });
 
@@ -74,7 +75,7 @@ describe("updateScaleY", () => {
     const vt = {
       onReferenceViewWindowResize: vi.fn(),
     } as unknown as ViewportTransform;
-    const tree = cd.buildAxisTree(0);
+    const tree = cd.buildAxisTree(AxisId.Primary);
     const dp = cd.updateScaleY(new AR1Basis(0, 2), tree);
     vt.onReferenceViewWindowResize(dp);
     y.domain(dp.y().toArr());

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
+import { AxisId } from "./types.ts";
 import { setupRender } from "./render.ts";
 
 class Matrix {
@@ -85,14 +86,14 @@ describe("setupRender Y-axis modes", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
-    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
-    expect(state.axes.y[1]).toBeUndefined();
+    expect(state.axes.y[AxisId.Primary].scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y[AxisId.Secondary]).toBeUndefined();
   });
 
   it("separates scales when dualYAxis is true", () => {
@@ -102,13 +103,13 @@ describe("setupRender Y-axis modes", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
-    expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
-    expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
+    expect(state.axes.y[AxisId.Primary].scale.domain()).toEqual([1, 3]);
+    expect(state.axes.y[AxisId.Secondary].scale.domain()).toEqual([10, 30]);
   });
 });

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -26,6 +26,7 @@ vi.mock("../axis.ts", () => {
 import { select } from "d3-selection";
 import * as renderUtils from "./render/utils.ts";
 import { TimeSeriesChart, type IDataSource } from "../draw.ts";
+import { AxisId } from "./types.ts";
 
 class Matrix {
   constructor(
@@ -98,7 +99,7 @@ describe("TimeSeriesChart.resize", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 1,
-      seriesAxes: [0],
+      seriesAxes: [AxisId.Primary],
       getSeries: (i) => [1, 2, 3][i],
     };
 

--- a/svg-time-series/src/chart/types.ts
+++ b/svg-time-series/src/chart/types.ts
@@ -1,0 +1,4 @@
+export enum AxisId {
+  Primary = 0,
+  Secondary = 1,
+}

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { scaleLinear } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
+import { AxisId } from "./types.ts";
 import { updateYScales } from "./render.ts";
 
 class Matrix {
@@ -81,7 +82,12 @@ describe("updateYScales", () => {
     };
 
     const data = {
-      seriesAxes: [0, 1, 2, 1],
+      seriesAxes: [
+        AxisId.Primary,
+        AxisId.Secondary,
+        2 as AxisId,
+        AxisId.Secondary,
+      ],
       bIndexFull: new AR1Basis(0, 10),
       buildAxisTree(axis: number) {
         return {
@@ -117,7 +123,7 @@ describe("updateYScales", () => {
     };
 
     const data = {
-      seriesAxes: [0, 1, 2],
+      seriesAxes: [AxisId.Primary, AxisId.Secondary, 2 as AxisId],
       bIndexFull: new AR1Basis(0, 5),
       buildAxisTree(axis: number) {
         return {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -7,6 +7,7 @@ import type { RenderState } from "./chart/render.ts";
 import { renderPaths } from "./chart/render/utils.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
+import { AxisId } from "./chart/types.ts";
 
 export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
@@ -54,8 +55,8 @@ export class TimeSeriesChart {
       series: this.state.series.map((s) => ({
         path: s.path as SVGPathElement,
         transform:
-          this.state.axes.y[s.axisIdx]?.transform ??
-          this.state.axes.y[0].transform,
+          this.state.axes.y[s.axis]?.transform ??
+          this.state.axes.y[AxisId.Primary].transform,
       })),
     };
     this.legendController.init(context);
@@ -120,7 +121,7 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    let idx = this.state.axes.y[0].transform.fromScreenToModelX(x);
+    let idx = this.state.axes.y[AxisId.Primary].transform.fromScreenToModelX(x);
     idx = Math.min(Math.max(idx, 0), this.data.length - 1);
     this.legendController.highlightIndex(idx);
   };


### PR DESCRIPTION
## Summary
- add AxisId enum to chart types
- replace numeric axis references with AxisId in chart data and rendering
- update tests and samples for new AxisId type

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689774f127bc832b87a5bba4cf607413