### PR TITLE
feat: allow runtime zoom extent updates

### DIFF
--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -56,6 +56,17 @@ additional series are ignored.
 The third argument lets you supply a custom legend controller. See
 `samples/LegendController.ts` for a reference implementation.
 
+## Runtime zoom range
+
+You can adjust how far users can zoom in or out without recreating the chart.
+Use the interaction API to set new minimum and maximum zoom scales:
+
+```ts
+chart.interaction.setScaleExtent([1, 80]);
+```
+
+The first value limits zooming out, while the second limits zooming in.
+
 ## Demos
 
 To explore complete examples with zooming and real-time updates, run the demos in [`samples`](../samples).

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -62,6 +62,7 @@ vi.mock("../axis.ts", () => ({
 }));
 
 let zoomReset: any;
+let zoomSetScaleExtent: any;
 let legendRefresh: any;
 let zoomOptions: any;
 vi.mock("../../../samples/LegendController.ts", () => ({
@@ -90,6 +91,7 @@ vi.mock("./zoomState.ts", () => ({
     refresh = vi.fn();
     destroy = vi.fn();
     zoom = vi.fn();
+    setScaleExtent = vi.fn();
     constructor(
       _zoomArea: any,
       state: any,
@@ -101,6 +103,7 @@ vi.mock("./zoomState.ts", () => ({
       this.refreshChart = refreshChart;
       this.zoomCallback = zoomCallback;
       zoomReset = this.reset;
+      zoomSetScaleExtent = this.setScaleExtent;
       zoomOptions = options;
     }
   },
@@ -154,6 +157,7 @@ beforeEach(() => {
   nodeTransforms.clear();
   transformInstances.length = 0;
   zoomOptions = undefined;
+  zoomSetScaleExtent = undefined;
   (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
 });
 
@@ -179,6 +183,17 @@ describe("interaction.resetZoom", () => {
     expect(zoomReset).toHaveBeenCalled();
     expect(transform.onZoomPan).toHaveBeenCalledWith({ x: 0, k: 1 });
     expect(legendRefresh).toHaveBeenCalled();
+  });
+});
+
+describe("interaction.setScaleExtent", () => {
+  it("delegates to ZoomState", () => {
+    const { interaction } = createChart([
+      [10, 20],
+      [30, 40],
+    ]);
+    interaction.setScaleExtent([2, 80]);
+    expect(zoomSetScaleExtent).toHaveBeenCalledWith([2, 80]);
   });
 });
 

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -16,6 +16,7 @@ export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
   onHover: (x: number) => void;
   resetZoom: () => void;
+  setScaleExtent: (extent: [number, number]) => void;
 }
 
 export class TimeSeriesChart {
@@ -84,6 +85,7 @@ export class TimeSeriesChart {
       zoom: this.zoom,
       onHover: this.onHover,
       resetZoom: this.resetZoom,
+      setScaleExtent: this.setScaleExtent,
     };
   }
 
@@ -105,6 +107,10 @@ export class TimeSeriesChart {
 
   public resetZoom = () => {
     this.zoomState.reset();
+  };
+
+  public setScaleExtent = (extent: [number, number]) => {
+    this.zoomState.setScaleExtent(extent);
   };
 
   public resize = (dimensions: { width: number; height: number }) => {


### PR DESCRIPTION
## Summary
- expose `setScaleExtent` on interaction and chart to update zoom range at runtime
- document runtime zoom extent adjustments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689774bd15e8832baf123feba63747e3