### PR TITLE
refactor: extract SeriesRenderer for per-series drawing

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -3,30 +3,18 @@
  */
 import { bench, describe } from "vitest";
 import { select } from "d3-selection";
-import { renderPaths, createLine } from "../src/chart/render/utils.ts";
-import type { RenderState } from "../src/chart/render.ts";
+import { SeriesRenderer } from "../src/chart/seriesRenderer.ts";
 import { sizes, datasets } from "./timeSeriesData.ts";
 
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  const pathSelection = select(svg)
-    .selectAll("path")
-    .data([0, 1])
-    .enter()
-    .append("path");
-  const nodes = pathSelection.nodes() as SVGPathElement[];
-
-  const state = {
-    series: [
-      { path: nodes[0], line: createLine(0) },
-      { path: nodes[1], line: createLine(1) },
-    ],
-  } as unknown as RenderState;
+  const renderer = new SeriesRenderer();
+  renderer.init(select(svg), 2, [0, 1]);
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];
     bench(`size ${size}`, () => {
-      renderPaths(state, data);
+      renderer.draw(data);
     });
   });
 });

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -8,11 +8,8 @@ import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
 import type { ViewportTransform } from "../ViewportTransform.ts";
 import { vi } from "vitest";
-import {
-  createDimensions,
-  updateScaleX,
-  initSeriesNode,
-} from "./render/utils.ts";
+import { createDimensions, updateScaleX } from "./render/utils.ts";
+import { SeriesRenderer } from "./seriesRenderer.ts";
 
 describe("createDimensions", () => {
   it("sets width and height and returns screen basis", () => {
@@ -83,7 +80,7 @@ describe("updateScaleY", () => {
   });
 });
 
-describe("initSeriesNode", () => {
+describe("SeriesRenderer.init", () => {
   it("creates a view and path", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const selection = select(svg) as unknown as Selection<
@@ -92,9 +89,10 @@ describe("initSeriesNode", () => {
       HTMLElement,
       unknown
     >;
-    const { view, path } = initSeriesNode(selection);
-    expect(view.tagName).toBe("g");
-    expect(path.tagName).toBe("path");
+    const renderer = new SeriesRenderer();
+    const [series] = renderer.init(selection, 1, [0]);
+    expect(series.view?.tagName).toBe("g");
+    expect(series.path?.tagName).toBe("path");
     expect(svg.querySelectorAll("g.view")).toHaveLength(1);
     expect(svg.querySelectorAll("path")).toHaveLength(1);
   });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,16 +1,7 @@
 import { Selection } from "d3-selection";
-import { line, type Line } from "d3-shape";
 import type { ScaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";
-import type { RenderState } from "../render.ts";
-
-export function createLine(seriesIdx: number): Line<number[]> {
-  return line<number[]>()
-    .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
-    .x((_, i) => i)
-    .y((d) => d[seriesIdx] as number);
-}
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -38,26 +29,4 @@ export function updateScaleX(
   const transform = data.indexToTime();
   const bTimeVisible = bIndexVisible.transformWith(transform);
   x.domain(bTimeVisible.toArr());
-}
-
-export interface SeriesNode {
-  view: SVGGElement;
-  path: SVGPathElement;
-}
-
-export function initSeriesNode(
-  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-): SeriesNode {
-  const view = svg.append("g").attr("class", "view");
-  const path = view.append<SVGPathElement>("path").node() as SVGPathElement;
-  return { view: view.node() as SVGGElement, path };
-}
-
-export function renderPaths(state: RenderState, dataArr: number[][]) {
-  const series = state.series;
-  for (const s of series) {
-    if (s.path) {
-      s.path.setAttribute("d", s.line(dataArr) ?? "");
-    }
-  }
 }

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -24,7 +24,7 @@ vi.mock("../axis.ts", () => {
 });
 
 import { select } from "d3-selection";
-import * as renderUtils from "./render/utils.ts";
+import { SeriesRenderer } from "./seriesRenderer.ts";
 import { TimeSeriesChart, type IDataSource } from "../draw.ts";
 
 class Matrix {
@@ -85,7 +85,7 @@ beforeAll(() => {
 
 describe("TimeSeriesChart.resize", () => {
   it("updates axes, paths, and legend", () => {
-    const renderSpy = vi.spyOn(renderUtils, "renderPaths");
+    const renderSpy = vi.spyOn(SeriesRenderer.prototype, "draw");
 
     const div = document.createElement("div");
     Object.defineProperty(div, "clientWidth", { value: 100 });

--- a/svg-time-series/src/chart/seriesRenderer.ts
+++ b/svg-time-series/src/chart/seriesRenderer.ts
@@ -1,0 +1,59 @@
+import { Selection } from "d3-selection";
+import { line, type Line } from "d3-shape";
+
+export interface Series {
+  axisIdx: number;
+  view?: SVGGElement;
+  path?: SVGPathElement;
+  line: Line<number[]>;
+}
+
+interface SeriesNode {
+  view: SVGGElement;
+  path: SVGPathElement;
+}
+
+export class SeriesRenderer {
+  private series: Series[] = [];
+
+  public init(
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+    seriesCount: number,
+    seriesAxes: readonly number[],
+  ): Series[] {
+    this.series = [];
+    for (let i = 0; i < seriesCount; i++) {
+      const { view, path } = this.initSeriesNode(svg);
+      const axisIdx = seriesAxes[i] ?? 0;
+      this.series.push({ axisIdx, view, path, line: this.createLine(i) });
+    }
+    return this.series;
+  }
+
+  public draw(dataArr: number[][]) {
+    for (const s of this.series) {
+      if (s.path) {
+        s.path.setAttribute("d", s.line(dataArr) ?? "");
+      }
+    }
+  }
+
+  private createLine(seriesIdx: number): Line<number[]> {
+    return line<number[]>()
+      .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
+      .x((_, i) => i)
+      .y((d) => d[seriesIdx] as number);
+  }
+
+  private initSeriesNode(
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+  ): SeriesNode {
+    const view = svg.append("g").attr("class", "view");
+    const path = view.append<SVGPathElement>("path").node() as SVGPathElement;
+    return { view: view.node() as SVGGElement, path };
+  }
+
+  public getSeries(): Series[] {
+    return this.series;
+  }
+}

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,7 +4,6 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { renderPaths } from "./chart/render/utils.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
 
@@ -115,7 +114,7 @@ export class TimeSeriesChart {
       .attr("height", dimensions.height);
     this.zoomState.updateExtents(dimensions);
     this.state.refresh(this.data);
-    renderPaths(this.state, this.data.data);
+    this.state.seriesRenderer.draw(this.data.data);
     this.legendController.refresh();
   };
 
@@ -126,7 +125,7 @@ export class TimeSeriesChart {
   };
 
   private drawNewData = () => {
-    renderPaths(this.state, this.data.data);
+    this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
     this.legendController.refresh();
   };


### PR DESCRIPTION
## Summary
- add SeriesRenderer class to manage per-series SVG nodes and path updates
- integrate SeriesRenderer into render setup and chart drawing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689774e52bf0832bb37298e9a6d5bd1c