### PR TITLE
feat: allow runtime scale extent updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ const chartSingle = new TimeSeriesChart(
 If you only have one series, set `seriesCount` to 1; the chart
 will render a single path and axis.
 
+### Adjusting zoom extents
+
+You can change the allowed zoom range at runtime by calling
+`setScaleExtent` on the chart's interaction API:
+
+```ts
+// Allow zoom levels between 1x and 80x
+chart.interaction.setScaleExtent([1, 80]);
+```
+
 ## Secrets of Speed
 
 - No legacy

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -64,6 +64,7 @@ vi.mock("../axis.ts", () => ({
 let zoomReset: any;
 let legendRefresh: any;
 let zoomOptions: any;
+let zoomSetScaleExtent: any;
 vi.mock("../../../samples/LegendController.ts", () => ({
   LegendController: class {
     refresh = vi.fn();
@@ -90,6 +91,7 @@ vi.mock("./zoomState.ts", () => ({
     refresh = vi.fn();
     destroy = vi.fn();
     zoom = vi.fn();
+    setScaleExtent = vi.fn();
     constructor(
       _zoomArea: any,
       state: any,
@@ -102,6 +104,7 @@ vi.mock("./zoomState.ts", () => ({
       this.zoomCallback = zoomCallback;
       zoomReset = this.reset;
       zoomOptions = options;
+      zoomSetScaleExtent = this.setScaleExtent;
     }
   },
 }));
@@ -179,6 +182,18 @@ describe("interaction.resetZoom", () => {
     expect(zoomReset).toHaveBeenCalled();
     expect(transform.onZoomPan).toHaveBeenCalledWith({ x: 0, k: 1 });
     expect(legendRefresh).toHaveBeenCalled();
+  });
+});
+
+describe("interaction.setScaleExtent", () => {
+  it("forwards extent to ZoomState", () => {
+    const { interaction } = createChart([
+      [10, 20],
+      [30, 40],
+    ]);
+    const extent: [number, number] = [1, 100];
+    interaction.setScaleExtent(extent);
+    expect(zoomSetScaleExtent).toHaveBeenCalledWith(extent);
   });
 });
 

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -20,6 +20,7 @@ export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
   onHover: (x: number) => void;
   resetZoom: () => void;
+  setScaleExtent: (extent: [number, number]) => void;
 }
 
 export class TimeSeriesChart {
@@ -90,6 +91,7 @@ export class TimeSeriesChart {
       zoom: this.zoom,
       onHover: this.onHover,
       resetZoom: this.resetZoom,
+      setScaleExtent: this.setScaleExtent,
     };
   }
 
@@ -128,6 +130,10 @@ export class TimeSeriesChart {
 
   public resetZoom = () => {
     this.zoomState.reset();
+  };
+
+  public setScaleExtent = (extent: [number, number]) => {
+    this.zoomState.setScaleExtent(extent);
   };
 
   public resize = (_dimensions: { width: number; height: number }) => {


### PR DESCRIPTION
## Summary
- expose setScaleExtent on chart interaction API
- implement setScaleExtent in TimeSeriesChart to delegate to ZoomState
- document how to adjust zoom range at runtime

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897794887a0832b968c1dd7329d6688