### PR TITLE
fix demo styling for series rendering

### DIFF
--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -133,3 +133,23 @@ describe("buildSeries", () => {
     expect(state.series[1]).toMatchObject({ axisIdx: 1 });
   });
 });
+
+describe("setupRender DOM order", () => {
+  it("renders series views before axes", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      seriesCount: 2,
+      seriesAxes: [0, 1],
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+    };
+    const data = new ChartData(source);
+    setupRender(svg as any, data, true);
+    const groups = svg.selectAll("g").nodes() as SVGGElement[];
+    expect(groups[0].classList.contains("view")).toBe(true);
+    expect(groups[1].classList.contains("view")).toBe(true);
+  });
+});

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -169,8 +169,6 @@ export function setupRender(
 
   updateYScales(axesY, data.bIndexFull, data);
 
-  const xAxisData = setupAxes(svg, xScale, axesY, width, height);
-
   const refDp = DirectProductBasis.fromProjections(
     data.bIndexFull,
     bPlaceholder,
@@ -186,6 +184,8 @@ export function setupRender(
     const axisIdx = data.seriesAxes[i] ?? 0;
     series.push({ axisIdx, view, path, line: createLine(i) });
   }
+
+  const xAxisData = setupAxes(svg, xScale, axesY, width, height);
 
   const axes: Axes = { x: xAxisData, y: axesY };
   const dimensions: Dimensions = { width, height };


### PR DESCRIPTION
## Summary
- append axes after series so existing CSS nth-child selectors work
- revert demo CSS and remove unused series class tagging
- add test ensuring series views render before axis groups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689775757e38832b907c192e8f6ba269