### PR TITLE
refactor: add series renderer class

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -3,30 +3,18 @@
  */
 import { bench, describe } from "vitest";
 import { select } from "d3-selection";
-import { renderPaths, createLine } from "../src/chart/render/utils.ts";
-import type { RenderState } from "../src/chart/render.ts";
+import { SeriesRenderer } from "../src/chart/seriesRenderer.ts";
 import { sizes, datasets } from "./timeSeriesData.ts";
 
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  const pathSelection = select(svg)
-    .selectAll("path")
-    .data([0, 1])
-    .enter()
-    .append("path");
-  const nodes = pathSelection.nodes() as SVGPathElement[];
-
-  const state = {
-    series: [
-      { path: nodes[0], line: createLine(0) },
-      { path: nodes[1], line: createLine(1) },
-    ],
-  } as unknown as RenderState;
+  const renderer = new SeriesRenderer();
+  renderer.init(select(svg), 2, [0, 1]);
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];
     bench(`size ${size}`, () => {
-      renderPaths(state, data);
+      renderer.draw(data);
     });
   });
 });

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -3,67 +3,65 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
-import { initSeriesNode, renderPaths, createLine } from "./render/utils.ts";
-import type { RenderState } from "./render.ts";
+import { SeriesRenderer } from "./seriesRenderer.ts";
 
-describe("renderPaths", () => {
-  it("skips segments for NaN values", () => {
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    const pathSelection = select(svg)
-      .selectAll("path")
-      .data([0, 1])
-      .enter()
-      .append("path");
-    const nodes = pathSelection.nodes() as SVGPathElement[];
-    const state = {
-      series: [
-        { path: nodes[0], line: createLine(0) },
-        { path: nodes[1], line: createLine(1) },
-      ],
-    } as unknown as RenderState;
-    const data: Array<[number, number]> = [
-      [0, 0],
-      [NaN, NaN],
-      [2, 2],
-    ];
+describe("SeriesRenderer", () => {
+  describe("draw", () => {
+    it("skips segments for NaN values", () => {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      const renderer = new SeriesRenderer();
+      renderer.init(
+        select(svg) as unknown as Selection<
+          SVGSVGElement,
+          unknown,
+          HTMLElement,
+          unknown
+        >,
+        2,
+        [0, 1],
+      );
+      const data: Array<[number, number]> = [
+        [0, 0],
+        [NaN, NaN],
+        [2, 2],
+      ];
 
-    renderPaths(state, data);
+      renderer.draw(data);
 
-    const d = pathSelection.attr("d");
-    expect(d).not.toContain("1,");
-    expect(d.match(/M/g)?.length).toBe(2);
+      const d = select(renderer.series[0].path).attr("d");
+      expect(d).not.toContain("1,");
+      expect(d.match(/M/g)?.length).toBe(2);
+    });
+
+    it("only updates primary path when hasSf is false", () => {
+      const svgSelection = select(document.createElement("div")).append(
+        "svg",
+      ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+      const renderer = new SeriesRenderer();
+      const [series] = renderer.init(svgSelection, 1, [0]);
+      const pathNode = series.path;
+      const spy = vi.spyOn(pathNode, "setAttribute");
+
+      renderer.draw([[0], [1]]);
+
+      expect(spy).toHaveBeenCalledTimes(renderer.series.length);
+      expect(pathNode.getAttribute("d")).not.toBe("");
+      expect(svgSelection.selectAll("path").nodes().length).toBe(1);
+
+      spy.mockRestore();
+    });
   });
 
-  it("only updates primary path when hasSf is false", () => {
-    const svgSelection = select(document.createElement("div")).append(
-      "svg",
-    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const svg = svgSelection.node() as SVGSVGElement;
-    const { path } = initSeriesNode(svgSelection);
-    const state = {
-      series: [{ path, line: createLine(0) }],
-    } as unknown as RenderState;
-    const pathNode = path;
-    const spy = vi.spyOn(pathNode, "setAttribute");
+  describe("init", () => {
+    it("creates a view and path", () => {
+      const svgSelection = select(document.createElement("div")).append(
+        "svg",
+      ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+      const renderer = new SeriesRenderer();
+      const [series] = renderer.init(svgSelection, 1, [0]);
 
-    renderPaths(state, [[0], [1]]);
-
-    expect(spy).toHaveBeenCalledTimes(state.series.length);
-    expect(path.getAttribute("d")).not.toBe("");
-    expect(svg.querySelectorAll("path").length).toBe(1);
-
-    spy.mockRestore();
-  });
-});
-
-describe("initSeriesNode", () => {
-  it("creates a view and path", () => {
-    const svgSelection = select(document.createElement("div")).append(
-      "svg",
-    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const { view, path } = initSeriesNode(svgSelection);
-
-    expect(view.tagName).toBe("g");
-    expect(path.tagName).toBe("path");
+      expect(series.view.tagName).toBe("g");
+      expect(series.path.tagName).toBe("path");
+    });
   });
 });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -13,12 +13,8 @@ import { updateNode } from "../utils/domNodeTransform.ts";
 import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData, IMinMax } from "./data.ts";
 import { SegmentTree } from "segment-tree-rmq";
-import {
-  createDimensions,
-  updateScaleX,
-  initSeriesNode,
-  createLine,
-} from "./render/utils.ts";
+import { createDimensions, updateScaleX } from "./render/utils.ts";
+import { SeriesRenderer } from "./seriesRenderer.ts";
 
 function createYAxis(
   orientation: Orientation,
@@ -101,6 +97,7 @@ export interface RenderState {
   bScreenXVisible: AR1Basis;
   dimensions: Dimensions;
   series: Series[];
+  seriesRenderer: SeriesRenderer;
   refresh: (data: ChartData) => void;
 }
 
@@ -180,12 +177,8 @@ export function setupRender(
     a.transform.onReferenceViewWindowResize(refDp);
   }
 
-  const series: Series[] = [];
-  for (let i = 0; i < seriesCount; i++) {
-    const { view, path } = initSeriesNode(svg);
-    const axisIdx = data.seriesAxes[i] ?? 0;
-    series.push({ axisIdx, view, path, line: createLine(i) });
-  }
+  const seriesRenderer = new SeriesRenderer();
+  const series = seriesRenderer.init(svg, seriesCount, data.seriesAxes);
 
   const axes: Axes = { x: xAxisData, y: axesY };
   const dimensions: Dimensions = { width, height };
@@ -195,6 +188,7 @@ export function setupRender(
     bScreenXVisible,
     dimensions,
     series,
+    seriesRenderer,
     refresh(this: RenderState, data: ChartData) {
       const bIndexVisible = this.axes.y[0].transform.fromScreenToModelBasisX(
         this.bScreenXVisible,

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -6,11 +6,7 @@ import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
-import {
-  createDimensions,
-  updateScaleX,
-  initSeriesNode,
-} from "./render/utils.ts";
+import { createDimensions, updateScaleX } from "./render/utils.ts";
 
 describe("createDimensions", () => {
   it("sets width and height and returns screen basis", () => {
@@ -74,22 +70,5 @@ describe("updateScaleY", () => {
     expect(dp.y().toArr()).toEqual([10, 40]);
     y.domain(dp.y().toArr());
     expect(y.domain()).toEqual([10, 40]);
-  });
-});
-
-describe("initSeriesNode", () => {
-  it("creates a view and path", () => {
-    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    const selection = select(svg) as unknown as Selection<
-      SVGSVGElement,
-      unknown,
-      HTMLElement,
-      unknown
-    >;
-    const { view, path } = initSeriesNode(selection);
-    expect(view.tagName).toBe("g");
-    expect(path.tagName).toBe("path");
-    expect(svg.querySelectorAll("g.view")).toHaveLength(1);
-    expect(svg.querySelectorAll("path")).toHaveLength(1);
   });
 });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,16 +1,7 @@
 import { Selection } from "d3-selection";
-import { line, type Line } from "d3-shape";
 import type { ScaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";
-import type { RenderState } from "../render.ts";
-
-export function createLine(seriesIdx: number): Line<number[]> {
-  return line<number[]>()
-    .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
-    .x((_, i) => i)
-    .y((d) => d[seriesIdx] as number);
-}
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -38,26 +29,4 @@ export function updateScaleX(
   const transform = data.indexToTime();
   const bTimeVisible = bIndexVisible.transformWith(transform);
   x.domain(bTimeVisible.toArr());
-}
-
-export interface SeriesNode {
-  view: SVGGElement;
-  path: SVGPathElement;
-}
-
-export function initSeriesNode(
-  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-): SeriesNode {
-  const view = svg.append("g").attr("class", "view");
-  const path = view.append<SVGPathElement>("path").node() as SVGPathElement;
-  return { view: view.node() as SVGGElement, path };
-}
-
-export function renderPaths(state: RenderState, dataArr: number[][]) {
-  const series = state.series;
-  for (const s of series) {
-    if (s.path) {
-      s.path.setAttribute("d", s.line(dataArr) ?? "");
-    }
-  }
 }

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -24,7 +24,7 @@ vi.mock("../axis.ts", () => {
 });
 
 import { select } from "d3-selection";
-import * as renderUtils from "./render/utils.ts";
+import { SeriesRenderer } from "./seriesRenderer.ts";
 import { TimeSeriesChart, type IDataSource } from "../draw.ts";
 
 class Matrix {
@@ -85,7 +85,7 @@ beforeAll(() => {
 
 describe("TimeSeriesChart.resize", () => {
   it("updates axes, paths, and legend", () => {
-    const renderSpy = vi.spyOn(renderUtils, "renderPaths");
+    const renderSpy = vi.spyOn(SeriesRenderer.prototype, "draw");
 
     const div = document.createElement("div");
     Object.defineProperty(div, "clientWidth", { value: 100 });

--- a/svg-time-series/src/chart/seriesRenderer.ts
+++ b/svg-time-series/src/chart/seriesRenderer.ts
@@ -1,0 +1,50 @@
+import { Selection } from "d3-selection";
+import { line, type Line } from "d3-shape";
+import type { Series } from "./render.ts";
+
+interface SeriesNode {
+  view: SVGGElement;
+  path: SVGPathElement;
+}
+
+export class SeriesRenderer {
+  public series: Series[] = [];
+
+  public init(
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+    seriesCount: number,
+    seriesAxes: number[],
+  ): Series[] {
+    const series: Series[] = [];
+    for (let i = 0; i < seriesCount; i++) {
+      const { view, path } = this.initSeriesNode(svg);
+      const axisIdx = seriesAxes[i] ?? 0;
+      series.push({ axisIdx, view, path, line: this.createLine(i) });
+    }
+    this.series = series;
+    return series;
+  }
+
+  public draw(dataArr: number[][]): void {
+    for (const s of this.series) {
+      if (s.path) {
+        s.path.setAttribute("d", s.line(dataArr) ?? "");
+      }
+    }
+  }
+
+  private createLine(seriesIdx: number): Line<number[]> {
+    return line<number[]>()
+      .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
+      .x((_, i) => i)
+      .y((d) => d[seriesIdx] as number);
+  }
+
+  private initSeriesNode(
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+  ): SeriesNode {
+    const view = svg.append("g").attr("class", "view");
+    const path = view.append<SVGPathElement>("path").node() as SVGPathElement;
+    return { view: view.node() as SVGGElement, path };
+  }
+}

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,11 +4,7 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import {
-  createDimensions,
-  renderPaths,
-  updateScaleX,
-} from "./chart/render/utils.ts";
+import { createDimensions, updateScaleX } from "./chart/render/utils.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
 
@@ -155,7 +151,7 @@ export class TimeSeriesChart {
     updateScaleX(this.state.axes.x.scale, bIndexVisible, this.data);
 
     this.state.refresh(this.data);
-    renderPaths(this.state, this.data.data);
+    this.state.seriesRenderer.draw(this.data.data);
     this.legendController.refresh();
   };
 
@@ -166,7 +162,7 @@ export class TimeSeriesChart {
   };
 
   private drawNewData = () => {
-    renderPaths(this.state, this.data.data);
+    this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
     this.legendController.refresh();
   };


### PR DESCRIPTION
## Summary
- add `SeriesRenderer` class to manage series views and path drawing
- rely on `SeriesRenderer` from render pipeline and chart to initialize and update paths
- adjust tests and benchmarks to use the new renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977a4d80f4832bbda09f5d75e7c9ac