### PR TITLE
refactor: unify chart configuration via ChartOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,34 +45,32 @@ work is possible. Keep watching!
 ## Y-axis modes
 
 Charts can display one or two data series. The library supports at most two
-series; additional series are ignored. By default, all series share a single
-Y-axis whose scale is computed from the combined minimum and maximum of every
-series. To draw series with different units, pass `true` for the `dualYAxis`
-parameter of `TimeSeriesChart`, which enables independent left and right Y
-scales.
+series; additional series are ignored. All series are mapped to Y-axes via the
+`seriesAxes` array in `ChartOptions`. Axis count is inferred from the largest
+axis index, so mapping a series to axis `1` enables independent left and right
+Y scales.
 
 ```ts
 import { TimeSeriesChart, IDataSource } from "svg-time-series";
 import { LegendController } from "./LegendController"; // implement your own
 
 const source: IDataSource = {
+  length: data.length,
+  getSeries: (i, seriesIdx) => data[i][seriesIdx],
+};
+const options: ChartOptions = {
   startTime,
   timeStep,
-  length: data.length,
   seriesCount: 2,
   // Assign the first series to the left axis and the second to the right.
   seriesAxes: [0, 1],
-  getSeries: (i, seriesIdx) => data[i][seriesIdx],
 };
-
+const legendController = new LegendController(legend); // implement your own
 const chart = new TimeSeriesChart(
   svg,
   source,
-  (state, data) =>
-    new LegendController(legend, state, data, (ts) =>
-      new Date(ts).toISOString(),
-    ),
-  true, // enable dual Y axes
+  options,
+  legendController,
   onZoom,
   onMouseMove,
 );
@@ -86,27 +84,25 @@ length must equal `seriesCount`.
 The third argument creates a legend controller, letting you customize how
 legend entries are rendered, including timestamp formatting.
 
-For two series sharing a single Y-axis, pass `false` for `dualYAxis`:
+For two series sharing a single Y-axis, map both to axis `0`:
 
 ```ts
 const singleSource: IDataSource = {
+  length: data.length,
+  getSeries: (i, seriesIdx) => data[i][seriesIdx],
+};
+const singleOptions: ChartOptions = {
   startTime,
   timeStep,
-  length: data.length,
   seriesCount: 2,
   // Both series use the left axis
   seriesAxes: [0, 0],
-  getSeries: (i, seriesIdx) => data[i][seriesIdx],
 };
-
 const chartSingle = new TimeSeriesChart(
   svg,
   singleSource,
-  (state, data) =>
-    new LegendController(legend, state, data, (ts) =>
-      new Date(ts).toISOString(),
-    ),
-  false, // series share one axis
+  singleOptions,
+  legendController,
   onZoom,
   onMouseMove,
 );

--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -7,7 +7,11 @@ import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 
 import { LegendController } from "./LegendController.ts";
-import { ChartData, IDataSource } from "../svg-time-series/src/chart/data.ts";
+import {
+  ChartData,
+  type IDataSource,
+} from "../svg-time-series/src/chart/data.ts";
+import type { ChartOptions } from "../svg-time-series/src/chart/types.ts";
 import { setupRender } from "../svg-time-series/src/chart/render.ts";
 import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
 
@@ -93,15 +97,17 @@ describe("LegendController", () => {
   it("places highlight dot with correct y and color", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [10, 20][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 1,
-      getSeries: (i) => [10, 20][i],
       seriesAxes: [0],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, options);
+    const state = setupRender(svg as any, data, options);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
@@ -138,21 +144,23 @@ describe("LegendController", () => {
   it("handles legacy tuple return from getPoint", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [10, 20][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 1,
-      getSeries: (i) => [10, 20][i],
       seriesAxes: [0],
     };
-    const data = new ChartData(source);
+    const data = new ChartData(source, options);
     const originalGetPoint = data.getPoint.bind(data);
     // mimic old API returning [timestamp, value...]
     data.getPoint = ((idx: number) => {
       const { values, timestamp } = originalGetPoint(idx);
       return [timestamp, ...values] as any;
     }) as any;
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data, options);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
@@ -178,21 +186,23 @@ describe("LegendController", () => {
   it("ignores results missing values array", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [10, 20][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 1,
-      getSeries: (i) => [10, 20][i],
       seriesAxes: [0],
     };
-    const data = new ChartData(source);
+    const data = new ChartData(source, options);
     const originalGetPoint = data.getPoint.bind(data);
     // mimic buggy API returning only a timestamp
     data.getPoint = ((idx: number) => {
       const { timestamp } = originalGetPoint(idx);
       return { timestamp } as any;
     }) as any;
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data, options);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -1,4 +1,8 @@
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import {
+  TimeSeriesChart,
+  type IDataSource,
+  type ChartOptions,
+} from "svg-time-series";
 import { LegendController } from "../../LegendController.ts";
 import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
 import { select, Selection } from "d3-selection";
@@ -19,15 +23,17 @@ onCsv((data: [number, number][]) => {
 
   const start = performance.now();
   const source: IDataSource = {
-    startTime: Date.now(),
-    timeStep: 86400000,
     length: data.length,
-    seriesCount: 2,
-    seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
+  const options: ChartOptions = {
+    startTime: Date.now(),
+    timeStep: 86400000,
+    seriesCount: 2,
+    seriesAxes: [0, 1],
+  };
   const legendController = new LegendController(legend);
-  const chart = new TimeSeriesChart(svg, source, legendController);
+  const chart = new TimeSeriesChart(svg, source, options, legendController);
   const renderMs = performance.now() - start;
   const renderTimeEl = document.getElementById("render-time");
   if (renderTimeEl) {

--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,3 +1,3 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw(true);
+loadAndDraw([0, 1]);

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,3 +1,3 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw(false);
+loadAndDraw([0, 0]);

--- a/samples/demos/resetZoom.ts
+++ b/samples/demos/resetZoom.ts
@@ -2,8 +2,8 @@ import { loadAndDraw } from "./common.ts";
 
 // Demo entry for testing chart reset logic. Uses the updated IDataSource API.
 // A button with id 'reset-zoom' will redraw the charts to simulate a reset.
-loadAndDraw(false);
+loadAndDraw([0, 0]);
 
 document.getElementById("reset-zoom")?.addEventListener("click", () => {
-  loadAndDraw(false);
+  loadAndDraw([0, 0]);
 });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -5,6 +5,7 @@ import {
   betweenTBasesAR1,
 } from "../math/affine.ts";
 import { SegmentTree } from "segment-tree-rmq";
+import type { ChartOptions } from "./types.ts";
 
 export interface IMinMax {
   readonly min: number;
@@ -24,15 +25,7 @@ const minMaxIdentity: IMinMax = {
 };
 
 export interface IDataSource {
-  readonly startTime: number;
-  readonly timeStep: number;
   readonly length: number;
-  readonly seriesCount: number;
-  /**
-   * Mapping from series index to Y-axis index. Each entry must be either 0 or 1
-   * and the array length must equal `seriesCount`.
-   */
-  readonly seriesAxes: number[];
   getSeries(index: number, seriesIdx: number): number;
 }
 
@@ -49,20 +42,24 @@ export class ChartData {
   /**
    * Creates a new ChartData instance.
    * @param source Data source; must contain at least one point.
+   * @param options Chart configuration options.
    * @throws if the source has length 0.
    */
-  constructor(source: IDataSource) {
+  constructor(
+    source: IDataSource,
+    options: ChartOptions = source as unknown as ChartOptions,
+  ) {
     if (source.length === 0) {
       throw new Error("ChartData requires a non-empty data array");
     }
-    if (source.seriesCount < 1) {
+    if (options.seriesCount < 1) {
       throw new Error("ChartData requires at least one series");
     }
-    this.seriesCount = source.seriesCount;
-    if (source.seriesAxes == null) {
+    this.seriesCount = options.seriesCount;
+    if (options.seriesAxes == null) {
       throw new Error("ChartData requires seriesAxes mapping");
     }
-    this.seriesAxes = source.seriesAxes;
+    this.seriesAxes = options.seriesAxes;
     if (this.seriesAxes.length !== this.seriesCount) {
       throw new Error(
         `ChartData requires seriesAxes length to match seriesCount (${this.seriesCount})`,
@@ -83,8 +80,8 @@ export class ChartData {
         source.getSeries(i, j),
       ),
     );
-    this.startTime = source.startTime;
-    this.timeStep = source.timeStep;
+    this.startTime = options.startTime;
+    this.timeStep = options.timeStep;
     this.startIndex = 0;
     // bIndexFull represents the full range of data indices and remains constant
     // since append() maintains a sliding window of fixed length

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -5,7 +5,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import {
+  TimeSeriesChart,
+  type IDataSource,
+  type ChartOptions,
+} from "../draw.ts";
 import type { ILegendController, LegendContext } from "./legend.ts";
 
 class Matrix {
@@ -88,19 +92,21 @@ function createChart(data: Array<[number]>) {
   parent.appendChild(svgEl);
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i) => data[i][0],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
   };
   const legendController = new StubLegendController();
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
+    options,
     legendController,
-    false,
     () => {},
     () => {},
   );

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -5,7 +5,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import {
+  TimeSeriesChart,
+  type IDataSource,
+  type ChartOptions,
+} from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -106,7 +110,7 @@ vi.mock("./zoomState.ts", () => ({
   },
 }));
 
-function createChart(data: Array<[number, number]>, options?: any) {
+function createChart(data: Array<[number, number]>, zoomOpts?: any) {
   currentDataLength = data.length;
   const parent = document.createElement("div");
   const w = Math.max(currentDataLength - 1, 0);
@@ -128,22 +132,24 @@ function createChart(data: Array<[number, number]>, options?: any) {
     '<span class="chart-legend__blue_value"></span>';
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 2,
     seriesAxes: [0, 1],
-    getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(select(legend) as any);
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
-    legendController,
-    true,
-    () => {},
-    () => {},
     options,
+    legendController,
+    () => {},
+    () => {},
+    zoomOpts,
   );
 
   return { interaction: chart.interaction };

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -5,7 +5,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import {
+  TimeSeriesChart,
+  type IDataSource,
+  type ChartOptions,
+} from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -114,19 +118,21 @@ function createChart(data: Array<[number]>) {
     '<span class="chart-legend__green_value"></span>';
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i) => data[i][0],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
   };
   const legendController = new LegendController(select(legend) as any);
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
+    options,
     legendController,
-    false,
     () => {},
     () => {},
   );

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -5,7 +5,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import {
+  TimeSeriesChart,
+  type IDataSource,
+  type ChartOptions,
+} from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -118,12 +122,14 @@ function createChart(
     '<span class="chart-legend__blue_value"></span>';
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 2,
     seriesAxes: [0, 1],
-    getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(
     select(legend) as any,
@@ -132,8 +138,8 @@ function createChart(
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
+    options,
     legendController,
-    true,
     () => {},
     () => {},
   );
@@ -353,19 +359,21 @@ describe("chart interaction", () => {
     const mouseMoveHandler = vi.fn();
 
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [0, 1][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i) => [0, 1][i],
     };
     const legendController = new LegendController(select(legend) as any);
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       source,
+      options,
       legendController,
-      true,
       () => {},
       mouseMoveHandler,
     );

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -5,7 +5,8 @@
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
-import { ChartData, IDataSource } from "./data.ts";
+import { ChartData, type IDataSource } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import { setupRender } from "./render.ts";
 import * as domNode from "../utils/domNodeTransform.ts";
 
@@ -84,7 +85,7 @@ function createSvg() {
 describe("RenderState.refresh integration", () => {
   it("updates scales, axes and series views", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -93,8 +94,8 @@ describe("RenderState.refresh integration", () => {
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     const updateNodeSpy = vi
       .spyOn(domNode, "updateNode")
       .mockImplementation(() => {});

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -22,6 +22,7 @@ vi.mock("../axis.ts", () => {
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, type IDataSource } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import { setupRender } from "./render.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 
@@ -95,7 +96,7 @@ function createSvg() {
 describe("RenderState.refresh", () => {
   it("handles single series", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -103,8 +104,8 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -123,7 +124,7 @@ describe("RenderState.refresh", () => {
 
   it("updates dual-axis series independently", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -131,8 +132,8 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0, 1],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -153,16 +154,16 @@ describe("RenderState.refresh", () => {
 
   it("updates combined series on shared scale", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [0, 0],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
 
     state.refresh(data);
 
@@ -172,7 +173,7 @@ describe("RenderState.refresh", () => {
 
   it("refreshes after data changes", () => {
     const svg = createSvg();
-    const source1: IDataSource = {
+    const source1: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -180,10 +181,10 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0, 1],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
-    const data1 = new ChartData(source1);
-    const state = setupRender(svg as any, data1, true);
+    const data1 = new ChartData(source1, source1);
+    const state = setupRender(svg as any, data1, source1);
     state.refresh(data1);
-    const source2: IDataSource = {
+    const source2: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -191,7 +192,7 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0, 1],
       getSeries: (i, s) => (s === 0 ? [4, 5, 6][i] : [40, 50, 60][i]),
     };
-    const data2 = new ChartData(source2);
+    const data2 = new ChartData(source2, source2);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -204,7 +205,7 @@ describe("RenderState.refresh", () => {
 
   it("rebuilds axis trees after data append", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -212,8 +213,8 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
 
     expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 1, max: 3 });
 
@@ -225,7 +226,7 @@ describe("RenderState.refresh", () => {
 
   it("produces finite domain when series is all NaN", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 2,
@@ -233,15 +234,15 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0],
       getSeries: () => NaN,
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     state.refresh(data);
     expect(state.axes.y[0].scale.domain()).toEqual([Infinity, -Infinity]);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 2,
@@ -249,8 +250,8 @@ describe("RenderState.refresh", () => {
       seriesAxes: [0, 1],
       getSeries: () => NaN,
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     state.refresh(data);
     expect(state.axes.y[0].scale.domain()).toEqual([Infinity, -Infinity]);
     expect(state.axes.y[1].scale.domain()).toEqual([Infinity, -Infinity]);

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -5,7 +5,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
-import { ChartData, IDataSource } from "./data.ts";
+import { ChartData, type IDataSource } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import { setupRender } from "./render.ts";
 
 class Matrix {
@@ -83,7 +84,7 @@ function createSvg() {
 describe("buildSeries", () => {
   it("returns single series when hasSf is false", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -91,33 +92,33 @@ describe("buildSeries", () => {
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.series.length).toBe(1);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
   });
 
-  it("returns two series for combined axis", () => {
+  it("returns two series for single axis", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [0, 0],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
-    expect(state.series[1]).toMatchObject({ axisIdx: 1 });
+    expect(state.series[1]).toMatchObject({ axisIdx: 0 });
   });
 
-  it("returns two series for dualYAxis", () => {
+  it("returns two series for separate axes", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -126,8 +127,8 @@ describe("buildSeries", () => {
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 1 });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -12,6 +12,7 @@ import { ViewportTransform } from "../ViewportTransform.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData, IMinMax } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import { SegmentTree } from "segment-tree-rmq";
 import {
   createDimensions,
@@ -147,15 +148,16 @@ export function updateYScales(
 export function setupRender(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   data: ChartData,
-  dualYAxis: boolean,
+  options: ChartOptions,
 ): RenderState {
-  const seriesCount = data.seriesCount;
+  const seriesCount = options.seriesCount;
 
   const bScreenVisibleDp = createDimensions(svg);
   const bScreenXVisible = bScreenVisibleDp.x();
   const width = bScreenXVisible.getRange();
   const height = bScreenVisibleDp.y().getRange();
-  const axisCount = dualYAxis && data.seriesAxes.includes(1) ? 2 : 1;
+  const axisCount =
+    options.seriesAxes.length > 0 ? Math.max(...options.seriesAxes) + 1 : 1;
 
   const [xRange, yRange] = bScreenVisibleDp.toArr();
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
@@ -183,7 +185,7 @@ export function setupRender(
   const series: Series[] = [];
   for (let i = 0; i < seriesCount; i++) {
     const { view, path } = initSeriesNode(svg);
-    const axisIdx = data.seriesAxes[i] ?? 0;
+    const axisIdx = options.seriesAxes[i] ?? 0;
     series.push({ axisIdx, view, path, line: createLine(i) });
   }
 

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -5,7 +5,8 @@ import { describe, it, expect } from "vitest";
 import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
-import { ChartData, IDataSource } from "./data.ts";
+import { ChartData, type IDataSource } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import type { ViewportTransform } from "../ViewportTransform.ts";
 import { vi } from "vitest";
 import {
@@ -39,7 +40,7 @@ describe("createDimensions", () => {
 });
 
 describe("updateScaleX", () => {
-  const makeSource = (data: number[][]): IDataSource => ({
+  const makeSource = (data: number[][]): IDataSource & ChartOptions => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -49,7 +50,8 @@ describe("updateScaleX", () => {
   });
 
   it("adjusts domain based on visible index range", () => {
-    const cd = new ChartData(makeSource([[0], [1], [2]]));
+    const src = makeSource([[0], [1], [2]]);
+    const cd = new ChartData(src, src);
     const x = scaleTime().range([0, 100]);
     updateScaleX(x, new AR1Basis(0, 2), cd);
     const [d0, d1] = x.domain();
@@ -59,7 +61,7 @@ describe("updateScaleX", () => {
 });
 
 describe("updateScaleY", () => {
-  const makeSource = (data: number[][]): IDataSource => ({
+  const makeSource = (data: number[][]): IDataSource & ChartOptions => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -69,7 +71,8 @@ describe("updateScaleY", () => {
   });
 
   it("sets domain from visible data bounds", () => {
-    const cd = new ChartData(makeSource([[10], [20], [40]]));
+    const src = makeSource([[10], [20], [40]]);
+    const cd = new ChartData(src, src);
     const y = scaleLinear().range([100, 0]);
     const vt = {
       onReferenceViewWindowResize: vi.fn(),

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -2,7 +2,8 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
-import { ChartData, IDataSource } from "./data.ts";
+import { ChartData, type IDataSource } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import { setupRender } from "./render.ts";
 
 class Matrix {
@@ -78,36 +79,40 @@ function createSvg() {
 }
 
 describe("setupRender Y-axis modes", () => {
-  it("combines series when dualYAxis is false", () => {
+  it("combines series when both map to axis 0", () => {
     const svg = createSvg();
     const source: IDataSource = {
-      startTime: 0,
-      timeStep: 1,
       length: 3,
-      seriesCount: 2,
-      seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const options: ChartOptions = {
+      startTime: 0,
+      timeStep: 1,
+      seriesCount: 2,
+      seriesAxes: [0, 0],
+    };
+    const data = new ChartData(source, options);
+    const state = setupRender(svg as any, data, options);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
     expect(state.axes.y[1]).toBeUndefined();
   });
 
-  it("separates scales when dualYAxis is true", () => {
+  it("separates scales for distinct axes", () => {
     const svg = createSvg();
     const source: IDataSource = {
-      startTime: 0,
-      timeStep: 1,
       length: 3,
-      seriesCount: 2,
-      seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const options: ChartOptions = {
+      startTime: 0,
+      timeStep: 1,
+      seriesCount: 2,
+      seriesAxes: [0, 1],
+    };
+    const data = new ChartData(source, options);
+    const state = setupRender(svg as any, data, options);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
     expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
   });

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -25,7 +25,11 @@ vi.mock("../axis.ts", () => {
 
 import { select } from "d3-selection";
 import * as renderUtils from "./render/utils.ts";
-import { TimeSeriesChart, type IDataSource } from "../draw.ts";
+import {
+  TimeSeriesChart,
+  type IDataSource,
+  type ChartOptions,
+} from "../draw.ts";
 
 class Matrix {
   constructor(
@@ -94,12 +98,14 @@ describe("TimeSeriesChart.resize", () => {
     div.appendChild(svgEl);
 
     const source: IDataSource = {
+      length: 3,
+      getSeries: (i) => [1, 2, 3][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
     };
 
     const legend = {
@@ -113,6 +119,7 @@ describe("TimeSeriesChart.resize", () => {
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       source,
+      options,
       legend as any,
     );
 

--- a/svg-time-series/src/chart/types.ts
+++ b/svg-time-series/src/chart/types.ts
@@ -1,0 +1,6 @@
+export interface ChartOptions {
+  seriesCount: number;
+  seriesAxes: number[];
+  startTime: number;
+  timeStep: number;
+}

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,6 +4,7 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
+import type { ChartOptions } from "./chart/types.ts";
 import { renderPaths } from "./chart/render/utils.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
@@ -11,6 +12,7 @@ import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
 export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
 export type { IZoomStateOptions } from "./chart/zoomState.ts";
+export type { ChartOptions } from "./chart/types.ts";
 
 export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
@@ -28,17 +30,17 @@ export class TimeSeriesChart {
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
     data: IDataSource,
+    options: ChartOptions,
     legendController: ILegendController,
-    dualYAxis = false,
     zoomHandler: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
     zoomOptions: IZoomStateOptions = {},
   ) {
-    this.data = new ChartData(data);
+    this.data = new ChartData(data, options);
 
-    this.state = setupRender(svg, this.data, dualYAxis);
+    this.state = setupRender(svg, this.data, options);
 
     this.zoomArea = svg
       .append("rect")


### PR DESCRIPTION
## Summary
- introduce `ChartOptions` for chart configuration like series count, axes, and timing
- update ChartData, TimeSeriesChart, and rendering pipeline to consume ChartOptions
- refresh demos and benchmarks to build and pass ChartOptions objects
- derive axis count from `seriesAxes` and drop legacy `dualYAxis` flag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897750f1340832bbac054486bbe5c7f