### PR TITLE
feat: add axis manager module

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,0 +1,102 @@
+import type { Selection } from "d3-selection";
+import { scaleLinear, type ScaleLinear } from "d3-scale";
+import { SegmentTree } from "segment-tree-rmq";
+
+import { ViewportTransform } from "../ViewportTransform.ts";
+import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import type { MyAxis } from "../axis.ts";
+import type { ChartData, IMinMax } from "./data.ts";
+
+interface DomainInfo {
+  min: number;
+  max: number;
+  transform: ViewportTransform;
+  scale: ScaleLinear<number, number>;
+}
+
+export interface AxisState {
+  transform: ViewportTransform;
+  scale: ScaleLinear<number, number>;
+  tree: SegmentTree<IMinMax>;
+  axis?: MyAxis;
+  g?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+}
+
+export class AxisManager {
+  public axes: AxisState[] = [];
+  constructor(private readonly yRange: [number, number]) {}
+
+  create(treeCount: number, data: ChartData): AxisState[] {
+    this.axes = Array.from({ length: treeCount }, (_, i) => ({
+      transform: new ViewportTransform(),
+      scale: scaleLinear<number, number>().range(this.yRange),
+      tree: data.buildAxisTree(i),
+    }));
+    return this.axes;
+  }
+
+  updateScales(bIndexVisible: AR1Basis, data: ChartData): void {
+    const domains: DomainInfo[] = this.axes.map((a) => ({
+      min: Infinity,
+      max: -Infinity,
+      transform: a.transform,
+      scale: a.scale,
+    }));
+
+    const axisIndices: number[] = [];
+    for (const idx of data.seriesAxes) {
+      if (!axisIndices.includes(idx)) {
+        axisIndices.push(idx);
+      }
+    }
+
+    for (const i of axisIndices) {
+      const tree = data.buildAxisTree(i);
+      if (i < this.axes.length) {
+        this.axes[i].tree = tree;
+      }
+      const targetIdx = i < this.axes.length ? i : this.axes.length - 1;
+      const dp = data.updateScaleY(bIndexVisible, tree);
+      const [min, max] = dp.y().toArr();
+      const domain = domains[targetIdx];
+      domain.min = Math.min(domain.min, min);
+      domain.max = Math.max(domain.max, max);
+    }
+
+    for (const { min, max, transform, scale } of domains) {
+      const b = new AR1Basis(min, max);
+      const dp = DirectProductBasis.fromProjections(data.bIndexFull, b);
+      transform.onReferenceViewWindowResize(dp);
+      scale.domain([min, max]);
+    }
+  }
+}
+
+const minMaxIdentity: IMinMax = { min: Infinity, max: -Infinity } as const;
+
+function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
+  return {
+    min: Math.min(fst.min, snd.min),
+    max: Math.max(fst.max, snd.max),
+  } as const;
+}
+
+export function buildAxisTree(
+  data: ChartData,
+  axis: number,
+): SegmentTree<IMinMax> {
+  const idxs = data.seriesByAxis[axis];
+  const arr = data.data.map((row) => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const j of idxs) {
+      const val = row[j];
+      if (Number.isFinite(val)) {
+        if (val < min) min = val;
+        if (val > max) max = val;
+      }
+    }
+    return min !== Infinity ? ({ min, max } as IMinMax) : minMaxIdentity;
+  });
+  return new SegmentTree(arr, buildMinMax, minMaxIdentity);
+}

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -1,18 +1,12 @@
 import { Selection } from "d3-selection";
-import {
-  scaleLinear,
-  scaleTime,
-  type ScaleLinear,
-  type ScaleTime,
-} from "d3-scale";
+import { scaleTime, type ScaleTime, type ScaleLinear } from "d3-scale";
 import type { Line } from "d3-shape";
 
 import { MyAxis, Orientation } from "../axis.ts";
-import { ViewportTransform } from "../ViewportTransform.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
-import type { ChartData, IMinMax } from "./data.ts";
-import { SegmentTree } from "segment-tree-rmq";
+import type { ChartData } from "./data.ts";
+import { AxisManager, type AxisState } from "./axisManager.ts";
 import {
   createDimensions,
   updateScaleX,
@@ -81,14 +75,6 @@ interface Dimensions {
   height: number;
 }
 
-interface AxisState {
-  transform: ViewportTransform;
-  scale: ScaleLinear<number, number>;
-  tree: SegmentTree<IMinMax>;
-  axis?: MyAxis;
-  g?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
-}
-
 export interface Series {
   axisIdx: number;
   view?: SVGGElement;
@@ -102,46 +88,6 @@ export interface RenderState {
   dimensions: Dimensions;
   series: Series[];
   refresh: (data: ChartData) => void;
-}
-
-export function updateYScales(
-  axes: AxisState[],
-  bIndex: AR1Basis,
-  data: ChartData,
-) {
-  const domains = axes.map((a) => ({
-    min: Infinity,
-    max: -Infinity,
-    transform: a.transform,
-    scale: a.scale,
-  }));
-
-  const axisIndices: number[] = [];
-  for (const idx of data.seriesAxes) {
-    if (!axisIndices.includes(idx)) {
-      axisIndices.push(idx);
-    }
-  }
-
-  for (const i of axisIndices) {
-    const tree = data.buildAxisTree(i);
-    if (i < axes.length) {
-      axes[i].tree = tree;
-    }
-    const targetIdx = i < axes.length ? i : axes.length - 1;
-    const dp = data.updateScaleY(bIndex, tree);
-    const [min, max] = dp.y().toArr();
-    const domain = domains[targetIdx];
-    domain.min = Math.min(domain.min, min);
-    domain.max = Math.max(domain.max, max);
-  }
-
-  for (const { min, max, transform, scale } of domains) {
-    const b = new AR1Basis(min, max);
-    const dp = DirectProductBasis.fromProjections(data.bIndexFull, b);
-    transform.onReferenceViewWindowResize(dp);
-    scale.domain([min, max]);
-  }
 }
 
 export function setupRender(
@@ -161,13 +107,9 @@ export function setupRender(
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
   updateScaleX(xScale, data.bIndexFull, data);
 
-  const axesY: AxisState[] = Array.from({ length: axisCount }, (_, i) => ({
-    transform: new ViewportTransform(),
-    scale: scaleLinear<number, number>().range(yRange),
-    tree: data.buildAxisTree(i),
-  }));
-
-  updateYScales(axesY, data.bIndexFull, data);
+  const axisManager = new AxisManager(yRange as [number, number]);
+  const axesY = axisManager.create(axisCount, data);
+  axisManager.updateScales(data.bIndexFull, data);
 
   const xAxisData = setupAxes(svg, xScale, axesY, width, height);
 
@@ -201,7 +143,7 @@ export function setupRender(
       );
       updateScaleX(this.axes.x.scale, bIndexVisible, data);
 
-      updateYScales(this.axes.y, bIndexVisible, data);
+      axisManager.updateScales(bIndexVisible, data);
 
       for (const s of this.series) {
         if (s.view) {

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
-import { scaleLinear } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
-import { ViewportTransform } from "../ViewportTransform.ts";
-import { updateYScales } from "./render.ts";
+import { AxisManager } from "./axisManager.ts";
 
 class Matrix {
   constructor(
@@ -68,12 +66,6 @@ beforeAll(() => {
 
 describe("updateYScales", () => {
   it("updates domains for multiple axes", () => {
-    const axes = Array.from({ length: 3 }, () => ({
-      transform: new ViewportTransform(),
-      scale: scaleLinear().range([0, 1]),
-      tree: undefined as any,
-    }));
-
     const ranges: Record<number, { min: number; max: number }> = {
       0: { min: 1, max: 3 },
       1: { min: 10, max: 30 },
@@ -95,21 +87,18 @@ describe("updateYScales", () => {
       },
     };
 
-    const bIndexVisible = new AR1Basis(0, 10);
-    updateYScales(axes as any, bIndexVisible, data as any);
+    const axisManager = new AxisManager([0, 1]);
+    axisManager.create(3, data as any);
 
-    expect(axes[0].scale.domain()).toEqual([1, 3]);
-    expect(axes[1].scale.domain()).toEqual([10, 30]);
-    expect(axes[2].scale.domain()).toEqual([-5, 5]);
+    const bIndexVisible = new AR1Basis(0, 10);
+    axisManager.updateScales(bIndexVisible, data as any);
+
+    expect(axisManager.axes[0].scale.domain()).toEqual([1, 3]);
+    expect(axisManager.axes[1].scale.domain()).toEqual([10, 30]);
+    expect(axisManager.axes[2].scale.domain()).toEqual([-5, 5]);
   });
 
   it("merges extra axes into the last scale", () => {
-    const axes = Array.from({ length: 2 }, () => ({
-      transform: new ViewportTransform(),
-      scale: scaleLinear().range([0, 1]),
-      tree: undefined as any,
-    }));
-
     const ranges: Record<number, { min: number; max: number }> = {
       0: { min: 0, max: 1 },
       1: { min: 10, max: 20 },
@@ -131,10 +120,13 @@ describe("updateYScales", () => {
       },
     };
 
-    const bIndexVisible = new AR1Basis(0, 5);
-    updateYScales(axes as any, bIndexVisible, data as any);
+    const axisManager = new AxisManager([0, 1]);
+    axisManager.create(2, data as any);
 
-    expect(axes[0].scale.domain()).toEqual([0, 1]);
-    expect(axes[1].scale.domain()).toEqual([-5, 20]);
+    const bIndexVisible = new AR1Basis(0, 5);
+    axisManager.updateScales(bIndexVisible, data as any);
+
+    expect(axisManager.axes[0].scale.domain()).toEqual([0, 1]);
+    expect(axisManager.axes[1].scale.domain()).toEqual([-5, 20]);
   });
 });


### PR DESCRIPTION
## Summary
- add AxisManager class for managing Y-axis trees and scales
- refactor render setup to use AxisManager
- expose buildAxisTree helper from AxisManager and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977abfb7f4832ba23114b9ca9c3bb6