### PR TITLE
Handle NaN series with finite axis domains

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -236,7 +236,9 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, false);
     state.refresh(data);
-    expect(state.axes.y[0].scale.domain()).toEqual([Infinity, -Infinity]);
+    const domain = state.axes.y[0].scale.domain();
+    expect(Number.isFinite(domain[0])).toBe(true);
+    expect(Number.isFinite(domain[1])).toBe(true);
   });
 
   it("produces finite domains for dual-axis all NaN data", () => {
@@ -252,7 +254,11 @@ describe("RenderState.refresh", () => {
     const data = new ChartData(source);
     const state = setupRender(svg as any, data, true);
     state.refresh(data);
-    expect(state.axes.y[0].scale.domain()).toEqual([Infinity, -Infinity]);
-    expect(state.axes.y[1].scale.domain()).toEqual([Infinity, -Infinity]);
+    const domain0 = state.axes.y[0].scale.domain();
+    const domain1 = state.axes.y[1].scale.domain();
+    expect(Number.isFinite(domain0[0])).toBe(true);
+    expect(Number.isFinite(domain0[1])).toBe(true);
+    expect(Number.isFinite(domain1[0])).toBe(true);
+    expect(Number.isFinite(domain1[1])).toBe(true);
   });
 });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -136,11 +136,16 @@ export function updateYScales(
     domain.max = Math.max(domain.max, max);
   }
 
-  for (const { min, max, transform, scale } of domains) {
+  for (const domain of domains) {
+    let { min, max } = domain;
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      min = 0;
+      max = 1;
+    }
     const b = new AR1Basis(min, max);
     const dp = DirectProductBasis.fromProjections(data.bIndexFull, b);
-    transform.onReferenceViewWindowResize(dp);
-    scale.domain([min, max]);
+    domain.transform.onReferenceViewWindowResize(dp);
+    domain.scale.domain([min, max]);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure axis domains remain finite when data series contain only NaN
- test NaN-only series on single and dual axes using `Number.isFinite`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977b3f8e04832b8e9c7389c9cd9e2c