### PR TITLE
refactor: extract axis manager

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,0 +1,109 @@
+import { scaleLinear, type ScaleLinear } from "d3-scale";
+import { Selection } from "d3-selection";
+import { SegmentTree } from "segment-tree-rmq";
+
+import type { ChartData, IMinMax } from "./data.ts";
+import { ViewportTransform } from "../ViewportTransform.ts";
+import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import type { MyAxis } from "../axis.ts";
+
+interface DomainInfo {
+  min: number;
+  max: number;
+  transform: ViewportTransform;
+  scale: ScaleLinear<number, number>;
+}
+
+function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
+  return {
+    min: Math.min(fst.min, snd.min),
+    max: Math.max(fst.max, snd.max),
+  } as const;
+}
+
+const minMaxIdentity: IMinMax = { min: Infinity, max: -Infinity };
+
+export function buildAxisTree(
+  data: ChartData,
+  axis: number,
+): SegmentTree<IMinMax> {
+  const idxs = data.seriesByAxis[axis] ?? [];
+  const arr = data.data.map((row) => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const j of idxs) {
+      const val = row[j];
+      if (Number.isFinite(val)) {
+        if (val < min) min = val;
+        if (val > max) max = val;
+      }
+    }
+    return min !== Infinity ? ({ min, max } as IMinMax) : minMaxIdentity;
+  });
+  return new SegmentTree(arr, buildMinMax, minMaxIdentity);
+}
+
+export interface AxisState {
+  transform: ViewportTransform;
+  scale: ScaleLinear<number, number>;
+  tree: SegmentTree<IMinMax>;
+  axis?: MyAxis;
+  g?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+}
+
+export class AxisManager {
+  readonly axes: AxisState[] = [];
+  constructor(
+    private readonly yRange: readonly [number, number],
+    private data: ChartData,
+  ) {}
+
+  create(treeCount: number): AxisState[] {
+    this.axes.length = 0;
+    for (let i = 0; i < treeCount; i++) {
+      this.axes.push({
+        transform: new ViewportTransform(),
+        scale: scaleLinear<number, number>().range(this.yRange),
+        tree: buildAxisTree(this.data, i),
+      });
+    }
+    return this.axes;
+  }
+
+  updateScales(bIndexVisible: AR1Basis, data: ChartData): void {
+    this.data = data;
+    const domains: DomainInfo[] = this.axes.map((a) => ({
+      min: Infinity,
+      max: -Infinity,
+      transform: a.transform,
+      scale: a.scale,
+    }));
+
+    const axisIndices: number[] = [];
+    for (const idx of data.seriesAxes) {
+      if (!axisIndices.includes(idx)) {
+        axisIndices.push(idx);
+      }
+    }
+
+    for (const i of axisIndices) {
+      const tree = buildAxisTree(data, i);
+      if (i < this.axes.length) {
+        this.axes[i].tree = tree;
+      }
+      const targetIdx = i < this.axes.length ? i : this.axes.length - 1;
+      const dp = data.updateScaleY(bIndexVisible, tree);
+      const [min, max] = dp.y().toArr();
+      const domain = domains[targetIdx];
+      domain.min = Math.min(domain.min, min);
+      domain.max = Math.max(domain.max, max);
+    }
+
+    for (const { min, max, transform, scale } of domains) {
+      const b = new AR1Basis(min, max);
+      const dp = DirectProductBasis.fromProjections(data.bIndexFull, b);
+      transform.onReferenceViewWindowResize(dp);
+      scale.domain([min, max]);
+    }
+  }
+}

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { ChartData, IDataSource } from "./data.ts";
+import { buildAxisTree } from "./axisManager.ts";
 import { AR1Basis } from "../math/affine.ts";
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -193,8 +194,8 @@ describe("ChartData", () => {
     ]);
     expect(cd.getPoint(0).timestamp).toBe(3);
     expect(cd.getPoint(1).timestamp).toBe(4);
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
@@ -239,8 +240,8 @@ describe("ChartData", () => {
       ),
     );
     const range = new AR1Basis(0, 2);
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([10, 50]);
     expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([20, 60]);
   });
@@ -256,8 +257,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const fractionalRange = new AR1Basis(0.49, 1.49);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([10, 50]);
@@ -275,8 +276,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const fractionalRange = new AR1Basis(1.1, 1.7);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([30, 50]);
@@ -294,8 +295,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const outOfRange = new AR1Basis(-0.5, 3.5);
     expect(() => cd.bAxisVisible(outOfRange, tree0)).not.toThrow();
@@ -315,8 +316,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const leftRange = new AR1Basis(-5, -1);
     expect(() => cd.bAxisVisible(leftRange, tree0)).not.toThrow();
@@ -336,8 +337,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const rightRange = new AR1Basis(5, 10);
     expect(() => cd.bAxisVisible(rightRange, tree0)).not.toThrow();
@@ -357,8 +358,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
     expect(combined.toArr()).toEqual([-3, 10]);
     expect(dp.x().toArr()).toEqual([0, 2]);
@@ -375,8 +376,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     const range = new AR1Basis(0, 1);
     expect(tree0.query(0, 1)).toEqual({ min: Infinity, max: -Infinity });
     expect(tree1.query(0, 1)).toEqual({
@@ -403,8 +404,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     const range = new AR1Basis(0, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 5, max: 5 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 3 });
@@ -426,7 +427,7 @@ describe("ChartData", () => {
       expect(cd.data).toEqual([[0], [1]]);
       cd.append(2);
       expect(cd.data).toEqual([[1], [2]]);
-      const tree0 = cd.buildAxisTree(0);
+      const tree0 = buildAxisTree(cd, 0);
       expect(tree0.query(0, 1)).toEqual({ min: 1, max: 2 });
     });
 
@@ -446,7 +447,7 @@ describe("ChartData", () => {
 
     it("returns Infinity/-Infinity min/max when data is all NaN", () => {
       const cd = new ChartData(makeSource([[NaN], [NaN]], [0]));
-      const tree0 = cd.buildAxisTree(0);
+      const tree0 = buildAxisTree(cd, 0);
       const range = new AR1Basis(0, 1);
       expect(tree0.query(0, 1)).toEqual({
         min: Infinity,
@@ -469,8 +470,8 @@ describe("ChartData", () => {
         [0, 0, 0, 1, 1],
       ),
     );
-    let tree0 = cd.buildAxisTree(0);
-    let tree1 = cd.buildAxisTree(1);
+    let tree0 = buildAxisTree(cd, 0);
+    let tree1 = buildAxisTree(cd, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 0, max: 20 });
     expect(tree1.query(0, 1)).toEqual({ min: 100, max: 220 });
 
@@ -479,8 +480,8 @@ describe("ChartData", () => {
       [1, 20, 15, 110, 220],
       [2, 30, 25, 130, 230],
     ]);
-    tree0 = cd.buildAxisTree(0);
-    tree1 = cd.buildAxisTree(1);
+    tree0 = buildAxisTree(cd, 0);
+    tree1 = buildAxisTree(cd, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 1, max: 30 });
     expect(tree1.query(0, 1)).toEqual({ min: 110, max: 230 });
     expect(cd.getPoint(1)).toEqual({

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -4,25 +4,13 @@ import {
   DirectProductBasis,
   betweenTBasesAR1,
 } from "../math/affine.ts";
-import { SegmentTree } from "segment-tree-rmq";
+import type { SegmentTree } from "segment-tree-rmq";
 import { SlidingWindow } from "./slidingWindow.ts";
 
 export interface IMinMax {
   readonly min: number;
   readonly max: number;
 }
-
-function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
-  return {
-    min: Math.min(fst.min, snd.min),
-    max: Math.max(fst.max, snd.max),
-  } as const;
-}
-
-const minMaxIdentity: IMinMax = {
-  min: Infinity,
-  max: -Infinity,
-};
 
 export interface IDataSource {
   readonly startTime: number;
@@ -145,30 +133,6 @@ export class ChartData {
 
   private clampIndex(idx: number): number {
     return Math.min(Math.max(idx, 0), this.window.length - 1);
-  }
-
-  private buildAxisMinMax(axis: number): Array<IMinMax | undefined> {
-    const idxs = this.seriesByAxis[axis];
-    return this.window.data.map((row) => {
-      let min = Infinity;
-      let max = -Infinity;
-      for (const j of idxs) {
-        const val = row[j];
-        if (Number.isFinite(val)) {
-          if (val < min) min = val;
-          if (val > max) max = val;
-        }
-      }
-      return min !== Infinity ? ({ min, max } as IMinMax) : undefined;
-    });
-  }
-
-  buildAxisTree(axis: number): SegmentTree<IMinMax> {
-    const arr = Array.from(
-      this.buildAxisMinMax(axis),
-      (v) => v ?? minMaxIdentity,
-    );
-    return new SegmentTree(arr, buildMinMax, minMaxIdentity);
   }
 
   bAxisVisible(bIndexVisible: AR1Basis, tree: SegmentTree<IMinMax>): AR1Basis {

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -6,6 +6,7 @@ import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
+import { buildAxisTree } from "./axisManager.ts";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 
 describe("createDimensions", () => {
@@ -65,7 +66,7 @@ describe("updateScaleY", () => {
   it("sets domain from visible data bounds", () => {
     const cd = new ChartData(makeSource([[10], [20], [40]]));
     const y = scaleLinear().range([100, 0]);
-    const tree = cd.buildAxisTree(0);
+    const tree = buildAxisTree(cd, 0);
     const dp = cd.updateScaleY(new AR1Basis(0, 2), tree);
     expect(dp.y().toArr()).toEqual([10, 40]);
     y.domain(dp.y().toArr());

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
-import { scaleLinear } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
-import { ViewportTransform } from "../ViewportTransform.ts";
-import { updateYScales } from "./render.ts";
+import { AxisManager } from "./axisManager.ts";
 
 class Matrix {
   constructor(
@@ -68,35 +66,25 @@ beforeAll(() => {
 
 describe("updateYScales", () => {
   it("updates domains for multiple axes", () => {
-    const axes = Array.from({ length: 3 }, () => ({
-      transform: new ViewportTransform(),
-      scale: scaleLinear().range([0, 1]),
-      tree: undefined as any,
-    }));
-
-    const ranges: Record<number, { min: number; max: number }> = {
-      0: { min: 1, max: 3 },
-      1: { min: 10, max: 30 },
-      2: { min: -5, max: 5 },
-    };
-
     const data = {
       seriesAxes: [0, 1, 2, 1],
-      bIndexFull: new AR1Basis(0, 10),
-      buildAxisTree(axis: number) {
-        return {
-          query: () => ranges[axis],
-        } as any;
-      },
+      seriesByAxis: [[0], [1, 3], [2]],
+      data: [
+        [1, 10, -5, 10],
+        [3, 30, 5, 30],
+      ],
+      bIndexFull: new AR1Basis(0, 1),
       updateScaleY(b: AR1Basis, tree: any) {
-        const { min, max } = tree.query(0, 0);
+        const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
       },
     };
 
-    const bIndexVisible = new AR1Basis(0, 10);
-    updateYScales(axes as any, bIndexVisible, data as any);
+    const am = new AxisManager([0, 1], data as any);
+    const axes = am.create(3);
+    const bIndexVisible = new AR1Basis(0, 1);
+    am.updateScales(bIndexVisible, data as any);
 
     expect(axes[0].scale.domain()).toEqual([1, 3]);
     expect(axes[1].scale.domain()).toEqual([10, 30]);
@@ -104,35 +92,25 @@ describe("updateYScales", () => {
   });
 
   it("merges extra axes into the last scale", () => {
-    const axes = Array.from({ length: 2 }, () => ({
-      transform: new ViewportTransform(),
-      scale: scaleLinear().range([0, 1]),
-      tree: undefined as any,
-    }));
-
-    const ranges: Record<number, { min: number; max: number }> = {
-      0: { min: 0, max: 1 },
-      1: { min: 10, max: 20 },
-      2: { min: -5, max: 5 },
-    };
-
     const data = {
       seriesAxes: [0, 1, 2],
-      bIndexFull: new AR1Basis(0, 5),
-      buildAxisTree(axis: number) {
-        return {
-          query: () => ranges[axis],
-        } as any;
-      },
+      seriesByAxis: [[0], [1], [2]],
+      data: [
+        [0, 10, -5],
+        [1, 20, 5],
+      ],
+      bIndexFull: new AR1Basis(0, 1),
       updateScaleY(b: AR1Basis, tree: any) {
-        const { min, max } = tree.query(0, 0);
+        const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
       },
     };
 
-    const bIndexVisible = new AR1Basis(0, 5);
-    updateYScales(axes as any, bIndexVisible, data as any);
+    const am = new AxisManager([0, 1], data as any);
+    const axes = am.create(2);
+    const bIndexVisible = new AR1Basis(0, 1);
+    am.updateScales(bIndexVisible, data as any);
 
     expect(axes[0].scale.domain()).toEqual([0, 1]);
     expect(axes[1].scale.domain()).toEqual([-5, 20]);


### PR DESCRIPTION
## Summary
- add `AxisManager` module to build axis trees and update Y-axis scales
- refactor renderer to use `AxisManager` for axis creation and updates
- adjust tests and data utilities to use new axis helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68977d9f73f8832baebdfcb4526dbcb5