### PR TITLE
refactor: introduce SeriesManager for series creation

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -4,12 +4,14 @@
 import { bench, describe } from "vitest";
 import { select } from "d3-selection";
 import { SeriesRenderer } from "../src/chart/seriesRenderer.ts";
+import { SeriesManager } from "../src/chart/series.ts";
 import { sizes, datasets } from "./timeSeriesData.ts";
 
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   const renderer = new SeriesRenderer();
-  renderer.init(select(svg), 2, [0, 1]);
+  const manager = new SeriesManager(select(svg), 2, [0, 1]);
+  renderer.series = manager.series;
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -4,13 +4,14 @@
 import { describe, it, expect, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
 import { SeriesRenderer } from "./seriesRenderer.ts";
+import { SeriesManager } from "./series.ts";
 
 describe("SeriesRenderer", () => {
   describe("draw", () => {
     it("skips segments for NaN values", () => {
       const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
       const renderer = new SeriesRenderer();
-      renderer.init(
+      const manager = new SeriesManager(
         select(svg) as unknown as Selection<
           SVGSVGElement,
           unknown,
@@ -20,6 +21,7 @@ describe("SeriesRenderer", () => {
         2,
         [0, 1],
       );
+      renderer.series = manager.series;
       const data: Array<[number, number]> = [
         [0, 0],
         [NaN, NaN],
@@ -38,7 +40,9 @@ describe("SeriesRenderer", () => {
         "svg",
       ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
       const renderer = new SeriesRenderer();
-      const [series] = renderer.init(svgSelection, 1, [0]);
+      const manager = new SeriesManager(svgSelection, 1, [0]);
+      const [series] = manager.series;
+      renderer.series = manager.series;
       const pathNode = series.path;
       const spy = vi.spyOn(pathNode, "setAttribute");
 
@@ -51,17 +55,17 @@ describe("SeriesRenderer", () => {
       spy.mockRestore();
     });
   });
+});
 
-  describe("init", () => {
-    it("creates a view and path", () => {
-      const svgSelection = select(document.createElement("div")).append(
-        "svg",
-      ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-      const renderer = new SeriesRenderer();
-      const [series] = renderer.init(svgSelection, 1, [0]);
+describe("SeriesManager", () => {
+  it("creates a view and path", () => {
+    const svgSelection = select(document.createElement("div")).append(
+      "svg",
+    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+    const manager = new SeriesManager(svgSelection, 1, [0]);
+    const [series] = manager.series;
 
-      expect(series.view.tagName).toBe("g");
-      expect(series.path.tagName).toBe("path");
-    });
+    expect(series.view.tagName).toBe("g");
+    expect(series.path.tagName).toBe("path");
   });
 });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -15,6 +15,7 @@ import type { ChartData, IMinMax } from "./data.ts";
 import { SegmentTree } from "segment-tree-rmq";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
+import { SeriesManager } from "./series.ts";
 
 function createYAxis(
   orientation: Orientation,
@@ -180,8 +181,10 @@ export function setupRender(
     a.transform.onReferenceViewWindowResize(refDp);
   }
 
+  const seriesManager = new SeriesManager(svg, seriesCount, data.seriesAxes);
   const seriesRenderer = new SeriesRenderer();
-  const series = seriesRenderer.init(svg, seriesCount, data.seriesAxes);
+  seriesRenderer.series = seriesManager.series;
+  const { series } = seriesManager;
 
   const xAxisData = setupAxes(svg, xScale, axesY, width, height);
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -30,3 +30,14 @@ export function updateScaleX(
   const bTimeVisible = bIndexVisible.transformWith(transform);
   x.domain(bTimeVisible.toArr());
 }
+
+export function createSeriesNodes(
+  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+): { view: SVGGElement; path: SVGPathElement } {
+  const view = svg.append("g").attr("class", "view");
+  const path = view.append<SVGPathElement>("path");
+  return {
+    view: view.node() as SVGGElement,
+    path: path.node() as SVGPathElement,
+  };
+}

--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -1,0 +1,28 @@
+import { Selection } from "d3-selection";
+import { line, type Line } from "d3-shape";
+
+import type { Series } from "./render.ts";
+import { createSeriesNodes } from "./render/utils.ts";
+
+export class SeriesManager {
+  public readonly series: Series[] = [];
+
+  constructor(
+    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+    seriesCount: number,
+    seriesAxes: number[],
+  ) {
+    for (let i = 0; i < seriesCount; i++) {
+      const { view, path } = createSeriesNodes(svg);
+      const axisIdx = seriesAxes[i] ?? 0;
+      this.series.push({ axisIdx, view, path, line: this.createLine(i) });
+    }
+  }
+
+  private createLine(seriesIdx: number): Line<number[]> {
+    return line<number[]>()
+      .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
+      .x((_, i) => i)
+      .y((d) => d[seriesIdx] as number);
+  }
+}

--- a/svg-time-series/src/chart/seriesRenderer.ts
+++ b/svg-time-series/src/chart/seriesRenderer.ts
@@ -1,29 +1,7 @@
-import { Selection } from "d3-selection";
-import { line, type Line } from "d3-shape";
 import type { Series } from "./render.ts";
-
-interface SeriesNode {
-  view: SVGGElement;
-  path: SVGPathElement;
-}
 
 export class SeriesRenderer {
   public series: Series[] = [];
-
-  public init(
-    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-    seriesCount: number,
-    seriesAxes: number[],
-  ): Series[] {
-    const series: Series[] = [];
-    for (let i = 0; i < seriesCount; i++) {
-      const { view, path } = this.initSeriesNode(svg);
-      const axisIdx = seriesAxes[i] ?? 0;
-      series.push({ axisIdx, view, path, line: this.createLine(i) });
-    }
-    this.series = series;
-    return series;
-  }
 
   public draw(dataArr: number[][]): void {
     for (const s of this.series) {
@@ -31,20 +9,5 @@ export class SeriesRenderer {
         s.path.setAttribute("d", s.line(dataArr) ?? "");
       }
     }
-  }
-
-  private createLine(seriesIdx: number): Line<number[]> {
-    return line<number[]>()
-      .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
-      .x((_, i) => i)
-      .y((d) => d[seriesIdx] as number);
-  }
-
-  private initSeriesNode(
-    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-  ): SeriesNode {
-    const view = svg.append("g").attr("class", "view");
-    const path = view.append<SVGPathElement>("path").node() as SVGPathElement;
-    return { view: view.node() as SVGGElement, path };
   }
 }


### PR DESCRIPTION
## Summary
- add `SeriesManager` to create series views and paths
- delegate series node creation to `createSeriesNodes` utility
- wire `setupRender` through `SeriesManager` and simplify `SeriesRenderer`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977e780668832bb06319f64f8cf71e