### PR TITLE
refactor: encapsulate chart configuration in options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,20 @@ parameter of `TimeSeriesChart`, which enables independent left and right Y
 scales.
 
 ```ts
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "svg-time-series";
 import { LegendController } from "./LegendController"; // implement your own
 
 const source: IDataSource = {
+  length: data.length,
+  getSeries: (i, seriesIdx) => data[i][seriesIdx],
+};
+const options: ChartOptions = {
   startTime,
   timeStep,
-  length: data.length,
   seriesCount: 2,
   // Assign the first series to the left axis and the second to the right.
   seriesAxes: [0, 1],
-  getSeries: (i, seriesIdx) => data[i][seriesIdx],
+  dualYAxis: true,
 };
 
 const chart = new TimeSeriesChart(
@@ -72,7 +75,7 @@ const chart = new TimeSeriesChart(
     new LegendController(legend, state, data, (ts) =>
       new Date(ts).toISOString(),
     ),
-  true, // enable dual Y axes
+  options,
   onZoom,
   onMouseMove,
 );
@@ -90,13 +93,16 @@ For two series sharing a single Y-axis, pass `false` for `dualYAxis`:
 
 ```ts
 const singleSource: IDataSource = {
+  length: data.length,
+  getSeries: (i, seriesIdx) => data[i][seriesIdx],
+};
+const singleOptions: ChartOptions = {
   startTime,
   timeStep,
-  length: data.length,
   seriesCount: 2,
   // Both series use the left axis
   seriesAxes: [0, 0],
-  getSeries: (i, seriesIdx) => data[i][seriesIdx],
+  dualYAxis: false,
 };
 
 const chartSingle = new TimeSeriesChart(
@@ -106,7 +112,7 @@ const chartSingle = new TimeSeriesChart(
     new LegendController(legend, state, data, (ts) =>
       new Date(ts).toISOString(),
     ),
-  false, // series share one axis
+  singleOptions,
   onZoom,
   onMouseMove,
 );

--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -9,6 +9,7 @@ import { select } from "d3-selection";
 import { LegendController } from "./LegendController.ts";
 import { ChartData, IDataSource } from "../svg-time-series/src/chart/data.ts";
 import { setupRender } from "../svg-time-series/src/chart/render.ts";
+import type { ChartOptions } from "../svg-time-series/src/chart/types.ts";
 import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
 
 class Matrix {
@@ -93,15 +94,17 @@ describe("LegendController", () => {
   it("places highlight dot with correct y and color", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [10, 20][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 1,
-      getSeries: (i) => [10, 20][i],
       seriesAxes: [0],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, options);
+    const state = setupRender(svg as any, data, options);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
@@ -138,21 +141,23 @@ describe("LegendController", () => {
   it("handles legacy tuple return from getPoint", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [10, 20][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 1,
-      getSeries: (i) => [10, 20][i],
       seriesAxes: [0],
     };
-    const data = new ChartData(source);
+    const data = new ChartData(source, options);
     const originalGetPoint = data.getPoint.bind(data);
     // mimic old API returning [timestamp, value...]
     data.getPoint = ((idx: number) => {
       const { values, timestamp } = originalGetPoint(idx);
       return [timestamp, ...values] as any;
     }) as any;
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data, options);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
@@ -178,21 +183,23 @@ describe("LegendController", () => {
   it("ignores results missing values array", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [10, 20][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 1,
-      getSeries: (i) => [10, 20][i],
       seriesAxes: [0],
     };
-    const data = new ChartData(source);
+    const data = new ChartData(source, options);
     const originalGetPoint = data.getPoint.bind(data);
     // mimic buggy API returning only a timestamp
     data.getPoint = ((idx: number) => {
       const { timestamp } = originalGetPoint(idx);
       return { timestamp } as any;
     }) as any;
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data, options);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -1,4 +1,4 @@
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "svg-time-series";
 import { LegendController } from "../../LegendController.ts";
 import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
 import { select, Selection } from "d3-selection";
@@ -19,15 +19,17 @@ onCsv((data: [number, number][]) => {
 
   const start = performance.now();
   const source: IDataSource = {
-    startTime: Date.now(),
-    timeStep: 86400000,
     length: data.length,
-    seriesCount: 2,
-    seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
+  const options: ChartOptions = {
+    startTime: Date.now(),
+    timeStep: 86400000,
+    seriesCount: 2,
+    seriesAxes: [0, 1],
+  };
   const legendController = new LegendController(legend);
-  const chart = new TimeSeriesChart(svg, source, legendController);
+  const chart = new TimeSeriesChart(svg, source, legendController, options);
   const renderMs = performance.now() - start;
   const renderTimeEl = document.getElementById("render-time");
   if (renderTimeEl) {

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -2,7 +2,7 @@ import { csv } from "d3-request";
 import { ValueFn, select, selectAll, pointer } from "d3-selection";
 import { D3ZoomEvent } from "d3-zoom";
 
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "svg-time-series";
 import { LegendController } from "../LegendController.ts";
 import { measure } from "../measure.ts";
 
@@ -23,19 +23,22 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
     const svg = select(this).select<SVGSVGElement>("svg");
     const legend = select(this).select<HTMLElement>(".chart-legend");
     const source: IDataSource = {
+      length: data.length,
+      getSeries: (i, seriesIdx) => data[i][seriesIdx],
+    };
+    const options: ChartOptions = {
       startTime: Date.now(),
       timeStep: 86400000,
-      length: data.length,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, seriesIdx) => data[i][seriesIdx],
+      dualYAxis,
     };
     const legendController = new LegendController(legend);
     const chart = new TimeSeriesChart(
       svg,
       source,
       legendController,
-      dualYAxis,
+      options,
       onZoom,
       onMouseMove,
     );

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -18,7 +18,7 @@ import { TimeSeriesChart } from "svg-time-series";
 
 ```ts
 import { select } from "d3-selection";
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "svg-time-series";
 import { LegendController } from "../samples/LegendController"; // example
 
 const svg = select("#chart").append("svg").append("g").attr("class", "view");
@@ -29,11 +29,15 @@ const ny = [10, 11];
 const sf = [12, 13];
 
 const source: IDataSource = {
+  length: ny.length,
+  getSeries: (i, seriesIdx) => (seriesIdx === 0 ? ny[i] : sf[i]),
+};
+const options: ChartOptions = {
   startTime: Date.now(),
   timeStep: 1000, // time step in ms
-  length: ny.length,
   seriesCount: 2,
-  getSeries: (i, seriesIdx) => (seriesIdx === 0 ? ny[i] : sf[i]),
+  seriesAxes: [0, 1],
+  dualYAxis: true,
 };
 
 const chart = new TimeSeriesChart(
@@ -43,7 +47,7 @@ const chart = new TimeSeriesChart(
     new LegendController(legend, state, data, (ts) =>
       new Date(ts).toISOString(),
     ),
-  true, // enable dual Y axes
+  options,
   () => {},
   () => {},
 );

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "../draw.ts";
 import type { ILegendController, LegendContext } from "./legend.ts";
 
 class Matrix {
@@ -88,19 +88,22 @@ function createChart(data: Array<[number]>) {
   parent.appendChild(svgEl);
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i) => data[i][0],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
+    dualYAxis: false,
   };
   const legendController = new StubLegendController();
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
     legendController,
-    false,
+    options,
     () => {},
     () => {},
   );

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -131,19 +131,22 @@ function createChart(data: Array<[number, number]>, options?: any) {
     '<span class="chart-legend__blue_value"></span>';
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+  };
+  const chartOptions: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 2,
     seriesAxes: [0, 1],
-    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+    dualYAxis: true,
   };
   const legendController = new LegendController(select(legend) as any);
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
     legendController,
-    true,
+    chartOptions,
     () => {},
     () => {},
     options,

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -114,19 +114,22 @@ function createChart(data: Array<[number]>) {
     '<span class="chart-legend__green_value"></span>';
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i) => data[i][0],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
+    dualYAxis: false,
   };
   const legendController = new LegendController(select(legend) as any);
   const chart = new TimeSeriesChart(
     select(svgEl) as any,
     source,
     legendController,
-    false,
+    options,
     () => {},
     () => {},
   );

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart, IDataSource, ChartOptions } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 
 class Matrix {
@@ -118,12 +118,15 @@ function createChart(
     '<span class="chart-legend__blue_value"></span>';
 
   const source: IDataSource = {
+    length: data.length,
+    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+  };
+  const options: ChartOptions = {
     startTime: 0,
     timeStep: 1,
-    length: data.length,
     seriesCount: 2,
     seriesAxes: [0, 1],
-    getSeries: (i, seriesIdx) => data[i][seriesIdx],
+    dualYAxis: true,
   };
   const legendController = new LegendController(
     select(legend) as any,
@@ -133,7 +136,7 @@ function createChart(
     select(svgEl) as any,
     source,
     legendController,
-    true,
+    options,
     () => {},
     () => {},
   );
@@ -353,19 +356,22 @@ describe("chart interaction", () => {
     const mouseMoveHandler = vi.fn();
 
     const source: IDataSource = {
+      length: 2,
+      getSeries: (i) => [0, 1][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 2,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i) => [0, 1][i],
+      dualYAxis: true,
     };
     const legendController = new LegendController(select(legend) as any);
     const chart = new TimeSeriesChart(
       select(svgEl) as any,
       source,
       legendController,
-      true,
+      options,
       () => {},
       mouseMoveHandler,
     );

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -7,6 +7,7 @@ import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
+import type { ChartOptions } from "./types.ts";
 import * as domNode from "../utils/domNodeTransform.ts";
 
 class Matrix {
@@ -84,7 +85,7 @@ function createSvg() {
 describe("RenderState.refresh integration", () => {
   it("updates scales, axes and series views", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -92,9 +93,10 @@ describe("RenderState.refresh integration", () => {
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+      dualYAxis: true,
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     const updateNodeSpy = vi
       .spyOn(domNode, "updateNode")
       .mockImplementation(() => {});

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -7,6 +7,7 @@ import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
+import type { ChartOptions } from "./types.ts";
 
 class Matrix {
   constructor(
@@ -83,7 +84,7 @@ function createSvg() {
 describe("buildSeries", () => {
   it("returns single series when hasSf is false", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -91,15 +92,15 @@ describe("buildSeries", () => {
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.series.length).toBe(1);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
   });
 
   it("returns two series for combined axis", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -108,8 +109,8 @@ describe("buildSeries", () => {
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 1 });
@@ -117,7 +118,7 @@ describe("buildSeries", () => {
 
   it("returns two series for dualYAxis", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -125,9 +126,10 @@ describe("buildSeries", () => {
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+      dualYAxis: true,
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 1 });
@@ -137,7 +139,7 @@ describe("buildSeries", () => {
 describe("setupRender DOM order", () => {
   it("renders series views before axes", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -145,9 +147,10 @@ describe("setupRender DOM order", () => {
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+      dualYAxis: true,
     };
-    const data = new ChartData(source);
-    setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    setupRender(svg as any, data, source);
     const groups = svg.selectAll("g").nodes() as SVGGElement[];
     expect(groups[0].classList.contains("view")).toBe(true);
     expect(groups[1].classList.contains("view")).toBe(true);

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -15,6 +15,7 @@ import type { ChartData, IMinMax } from "./data.ts";
 import { SegmentTree } from "segment-tree-rmq";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
+import type { ChartOptions } from "./types.ts";
 
 function createYAxis(
   orientation: Orientation,
@@ -144,15 +145,15 @@ export function updateYScales(
 export function setupRender(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   data: ChartData,
-  dualYAxis: boolean,
+  options: ChartOptions,
 ): RenderState {
-  const seriesCount = data.seriesCount;
+  const { seriesCount, seriesAxes, dualYAxis = false } = options;
 
   const bScreenVisibleDp = createDimensions(svg);
   const bScreenXVisible = bScreenVisibleDp.x();
   const width = bScreenXVisible.getRange();
   const height = bScreenVisibleDp.y().getRange();
-  const axisCount = dualYAxis && data.seriesAxes.includes(1) ? 2 : 1;
+  const axisCount = dualYAxis && seriesAxes.includes(1) ? 2 : 1;
 
   const [xRange, yRange] = bScreenVisibleDp.toArr();
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
@@ -176,7 +177,7 @@ export function setupRender(
   }
 
   const seriesRenderer = new SeriesRenderer();
-  const series = seriesRenderer.init(svg, seriesCount, data.seriesAxes);
+  const series = seriesRenderer.init(svg, seriesCount, seriesAxes);
 
   const xAxisData = setupAxes(svg, xScale, axesY, width, height);
 

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -6,6 +6,7 @@ import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
+import type { ChartOptions } from "./types.ts";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 
 describe("createDimensions", () => {
@@ -33,7 +34,7 @@ describe("createDimensions", () => {
 });
 
 describe("updateScaleX", () => {
-  const makeSource = (data: number[][]): IDataSource => ({
+  const makeSource = (data: number[][]): IDataSource & ChartOptions => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -43,7 +44,8 @@ describe("updateScaleX", () => {
   });
 
   it("adjusts domain based on visible index range", () => {
-    const cd = new ChartData(makeSource([[0], [1], [2]]));
+    const source = makeSource([[0], [1], [2]]);
+    const cd = new ChartData(source, source);
     const x = scaleTime().range([0, 100]);
     updateScaleX(x, new AR1Basis(0, 2), cd);
     const [d0, d1] = x.domain();
@@ -53,7 +55,7 @@ describe("updateScaleX", () => {
 });
 
 describe("updateScaleY", () => {
-  const makeSource = (data: number[][]): IDataSource => ({
+  const makeSource = (data: number[][]): IDataSource & ChartOptions => ({
     startTime: 0,
     timeStep: 1,
     length: data.length,
@@ -63,7 +65,8 @@ describe("updateScaleY", () => {
   });
 
   it("sets domain from visible data bounds", () => {
-    const cd = new ChartData(makeSource([[10], [20], [40]]));
+    const source = makeSource([[10], [20], [40]]);
+    const cd = new ChartData(source, source);
     const y = scaleLinear().range([100, 0]);
     const tree = cd.buildAxisTree(0);
     const dp = cd.updateScaleY(new AR1Basis(0, 2), tree);

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -4,6 +4,7 @@ import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
+import type { ChartOptions } from "./types.ts";
 
 class Matrix {
   constructor(
@@ -80,7 +81,7 @@ function createSvg() {
 describe("setupRender Y-axis modes", () => {
   it("combines series when dualYAxis is false", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -88,16 +89,17 @@ describe("setupRender Y-axis modes", () => {
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+      dualYAxis: false,
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
     expect(state.axes.y[1]).toBeUndefined();
   });
 
   it("separates scales when dualYAxis is true", () => {
     const svg = createSvg();
-    const source: IDataSource = {
+    const source: IDataSource & ChartOptions = {
       startTime: 0,
       timeStep: 1,
       length: 3,
@@ -105,9 +107,10 @@ describe("setupRender Y-axis modes", () => {
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+      dualYAxis: true,
     };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const data = new ChartData(source, source);
+    const state = setupRender(svg as any, data, source);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
     expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
   });

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -25,7 +25,7 @@ vi.mock("../axis.ts", () => {
 
 import { select } from "d3-selection";
 import { SeriesRenderer } from "./seriesRenderer.ts";
-import { TimeSeriesChart, type IDataSource } from "../draw.ts";
+import { TimeSeriesChart, type IDataSource, ChartOptions } from "../draw.ts";
 
 class Matrix {
   constructor(
@@ -94,12 +94,14 @@ describe("TimeSeriesChart.resize", () => {
     div.appendChild(svgEl);
 
     const source: IDataSource = {
+      length: 3,
+      getSeries: (i) => [1, 2, 3][i],
+    };
+    const options: ChartOptions = {
       startTime: 0,
       timeStep: 1,
-      length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
     };
 
     const legend = {
@@ -114,6 +116,7 @@ describe("TimeSeriesChart.resize", () => {
       select(svgEl) as any,
       source,
       legend as any,
+      options,
     );
 
     renderSpy.mockClear();

--- a/svg-time-series/src/chart/types.ts
+++ b/svg-time-series/src/chart/types.ts
@@ -1,0 +1,12 @@
+export interface ChartOptions {
+  /** Number of time series to display */
+  seriesCount: number;
+  /** Mapping from series index to Y-axis index. */
+  seriesAxes: number[];
+  /** Unix timestamp of the first data point. */
+  startTime: number;
+  /** Time difference between consecutive points in milliseconds. */
+  timeStep: number;
+  /** Whether to enable a secondary Y axis. */
+  dualYAxis?: boolean;
+}

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,6 +4,7 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
+import type { ChartOptions } from "./chart/types.ts";
 import { createDimensions, updateScaleX } from "./chart/render/utils.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
@@ -11,6 +12,7 @@ import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
 export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
 export type { IZoomStateOptions } from "./chart/zoomState.ts";
+export type { ChartOptions } from "./chart/types.ts";
 
 export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
@@ -31,7 +33,7 @@ export class TimeSeriesChart {
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
     data: IDataSource,
     legendController: ILegendController,
-    dualYAxis = false,
+    options: ChartOptions,
     zoomHandler: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
@@ -39,9 +41,9 @@ export class TimeSeriesChart {
     zoomOptions: IZoomStateOptions = {},
   ) {
     this.svg = svg;
-    this.data = new ChartData(data);
+    this.data = new ChartData(data, options);
 
-    this.state = setupRender(svg, this.data, dualYAxis);
+    this.state = setupRender(svg, this.data, options);
 
     this.zoomArea = svg
       .append("rect")


### PR DESCRIPTION
## Summary
- introduce `ChartOptions` interface to centralize chart settings
- refactor `ChartData`, render setup, and `TimeSeriesChart` to consume `ChartOptions`
- update demos to construct `ChartOptions` with defaults for two series

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68977d4b4704832bbd9bebf2bae31c15