### PR TITLE
refactor: centralize axis management

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,0 +1,102 @@
+import { scaleLinear, type ScaleLinear } from "d3-scale";
+import type { Selection } from "d3-selection";
+import { SegmentTree } from "segment-tree-rmq";
+
+import { MyAxis } from "../axis.ts";
+import { ViewportTransform } from "../ViewportTransform.ts";
+import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import type { ChartData, IMinMax } from "./data.ts";
+
+function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
+  return {
+    min: Math.min(fst.min, snd.min),
+    max: Math.max(fst.max, snd.max),
+  } as const;
+}
+
+const minMaxIdentity: IMinMax = {
+  min: Infinity,
+  max: -Infinity,
+};
+
+export interface AxisState {
+  transform: ViewportTransform;
+  scale: ScaleLinear<number, number>;
+  tree: SegmentTree<IMinMax>;
+  axis?: MyAxis;
+  g?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+}
+
+export function buildAxisTree(
+  data: ChartData,
+  axis: number,
+): SegmentTree<IMinMax> {
+  const idxs = data.seriesByAxis[axis] ?? [];
+  const arr = data.data.map((row) => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const j of idxs) {
+      const val = row[j];
+      if (Number.isFinite(val)) {
+        if (val < min) min = val;
+        if (val > max) max = val;
+      }
+    }
+    return min !== Infinity ? ({ min, max } as IMinMax) : minMaxIdentity;
+  });
+  return new SegmentTree(arr, buildMinMax, minMaxIdentity);
+}
+
+export class AxisManager {
+  public axes: AxisState[] = [];
+
+  create(treeCount: number): AxisState[] {
+    this.axes = Array.from({ length: treeCount }, () => ({
+      transform: new ViewportTransform(),
+      scale: scaleLinear<number, number>(),
+      tree: new SegmentTree([minMaxIdentity], buildMinMax, minMaxIdentity),
+    }));
+    return this.axes;
+  }
+
+  updateScales(bIndex: AR1Basis, data: ChartData): void {
+    const domains = this.axes.map((a) => ({
+      min: Infinity,
+      max: -Infinity,
+      transform: a.transform,
+      scale: a.scale,
+    }));
+
+    const axisIndices: number[] = [];
+    for (const idx of data.seriesAxes) {
+      if (!axisIndices.includes(idx)) {
+        axisIndices.push(idx);
+      }
+    }
+
+    for (const i of axisIndices) {
+      const tree = buildAxisTree(data, i);
+      if (i < this.axes.length) {
+        this.axes[i].tree = tree;
+      }
+      const targetIdx = i < this.axes.length ? i : this.axes.length - 1;
+      const dp = data.updateScaleY(bIndex, tree);
+      const [min, max] = dp.y().toArr();
+      const domain = domains[targetIdx];
+      domain.min = Math.min(domain.min, min);
+      domain.max = Math.max(domain.max, max);
+    }
+
+    for (const domain of domains) {
+      let { min, max } = domain;
+      if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        min = 0;
+        max = 1;
+      }
+      const b = new AR1Basis(min, max);
+      const dp = DirectProductBasis.fromProjections(data.bIndexFull, b);
+      domain.transform.onReferenceViewWindowResize(dp);
+      domain.scale.domain([min, max]);
+    }
+  }
+}

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { ChartData, IDataSource } from "./data.ts";
+import { buildAxisTree } from "./axisManager.ts";
 import { AR1Basis } from "../math/affine.ts";
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
@@ -193,8 +194,8 @@ describe("ChartData", () => {
     ]);
     expect(cd.getPoint(0).timestamp).toBe(3);
     expect(cd.getPoint(1).timestamp).toBe(4);
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
@@ -239,8 +240,8 @@ describe("ChartData", () => {
       ),
     );
     const range = new AR1Basis(0, 2);
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([10, 50]);
     expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([20, 60]);
   });
@@ -256,8 +257,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const fractionalRange = new AR1Basis(0.49, 1.49);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([10, 50]);
@@ -275,8 +276,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const fractionalRange = new AR1Basis(1.1, 1.7);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([30, 50]);
@@ -294,8 +295,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const outOfRange = new AR1Basis(-0.5, 3.5);
     expect(() => cd.bAxisVisible(outOfRange, tree0)).not.toThrow();
@@ -315,8 +316,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const leftRange = new AR1Basis(-5, -1);
     expect(() => cd.bAxisVisible(leftRange, tree0)).not.toThrow();
@@ -336,8 +337,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
 
     const rightRange = new AR1Basis(5, 10);
     expect(() => cd.bAxisVisible(rightRange, tree0)).not.toThrow();
@@ -357,8 +358,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
     expect(combined.toArr()).toEqual([-3, 10]);
     expect(dp.x().toArr()).toEqual([0, 2]);
@@ -375,8 +376,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     const range = new AR1Basis(0, 1);
     expect(tree0.query(0, 1)).toEqual({ min: Infinity, max: -Infinity });
     expect(tree1.query(0, 1)).toEqual({
@@ -403,8 +404,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = cd.buildAxisTree(0);
-    const tree1 = cd.buildAxisTree(1);
+    const tree0 = buildAxisTree(cd, 0);
+    const tree1 = buildAxisTree(cd, 1);
     const range = new AR1Basis(0, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 5, max: 5 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 3 });
@@ -426,7 +427,7 @@ describe("ChartData", () => {
       expect(cd.data).toEqual([[0], [1]]);
       cd.append(2);
       expect(cd.data).toEqual([[1], [2]]);
-      const tree0 = cd.buildAxisTree(0);
+      const tree0 = buildAxisTree(cd, 0);
       expect(tree0.query(0, 1)).toEqual({ min: 1, max: 2 });
     });
 
@@ -446,7 +447,7 @@ describe("ChartData", () => {
 
     it("returns Infinity/-Infinity min/max when data is all NaN", () => {
       const cd = new ChartData(makeSource([[NaN], [NaN]], [0]));
-      const tree0 = cd.buildAxisTree(0);
+      const tree0 = buildAxisTree(cd, 0);
       const range = new AR1Basis(0, 1);
       expect(tree0.query(0, 1)).toEqual({
         min: Infinity,
@@ -469,8 +470,8 @@ describe("ChartData", () => {
         [0, 0, 0, 1, 1],
       ),
     );
-    let tree0 = cd.buildAxisTree(0);
-    let tree1 = cd.buildAxisTree(1);
+    let tree0 = buildAxisTree(cd, 0);
+    let tree1 = buildAxisTree(cd, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 0, max: 20 });
     expect(tree1.query(0, 1)).toEqual({ min: 100, max: 220 });
 
@@ -479,8 +480,8 @@ describe("ChartData", () => {
       [1, 20, 15, 110, 220],
       [2, 30, 25, 130, 230],
     ]);
-    tree0 = cd.buildAxisTree(0);
-    tree1 = cd.buildAxisTree(1);
+    tree0 = buildAxisTree(cd, 0);
+    tree1 = buildAxisTree(cd, 1);
     expect(tree0.query(0, 1)).toEqual({ min: 1, max: 30 });
     expect(tree1.query(0, 1)).toEqual({ min: 110, max: 230 });
     expect(cd.getPoint(1)).toEqual({

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -12,18 +12,6 @@ export interface IMinMax {
   readonly max: number;
 }
 
-function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
-  return {
-    min: Math.min(fst.min, snd.min),
-    max: Math.max(fst.max, snd.max),
-  } as const;
-}
-
-const minMaxIdentity: IMinMax = {
-  min: Infinity,
-  max: -Infinity,
-};
-
 export interface IDataSource {
   readonly startTime: number;
   readonly timeStep: number;
@@ -146,31 +134,6 @@ export class ChartData {
   private clampIndex(idx: number): number {
     return Math.min(Math.max(idx, 0), this.window.length - 1);
   }
-
-  private buildAxisMinMax(axis: number): Array<IMinMax | undefined> {
-    const idxs = this.seriesByAxis[axis];
-    return this.window.data.map((row) => {
-      let min = Infinity;
-      let max = -Infinity;
-      for (const j of idxs) {
-        const val = row[j];
-        if (Number.isFinite(val)) {
-          if (val < min) min = val;
-          if (val > max) max = val;
-        }
-      }
-      return min !== Infinity ? ({ min, max } as IMinMax) : undefined;
-    });
-  }
-
-  buildAxisTree(axis: number): SegmentTree<IMinMax> {
-    const arr = Array.from(
-      this.buildAxisMinMax(axis),
-      (v) => v ?? minMaxIdentity,
-    );
-    return new SegmentTree(arr, buildMinMax, minMaxIdentity);
-  }
-
   bAxisVisible(bIndexVisible: AR1Basis, tree: SegmentTree<IMinMax>): AR1Basis {
     const [minIdxX, maxIdxX] = bIndexVisible.toArr();
     let startIdx = Math.floor(minIdxX);

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -1,18 +1,12 @@
 import { Selection } from "d3-selection";
-import {
-  scaleLinear,
-  scaleTime,
-  type ScaleLinear,
-  type ScaleTime,
-} from "d3-scale";
+import { scaleTime, type ScaleTime, type ScaleLinear } from "d3-scale";
 import type { Line } from "d3-shape";
 
 import { MyAxis, Orientation } from "../axis.ts";
-import { ViewportTransform } from "../ViewportTransform.ts";
+import { AxisManager, AxisState } from "./axisManager.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
-import type { ChartData, IMinMax } from "./data.ts";
-import { SegmentTree } from "segment-tree-rmq";
+import type { ChartData } from "./data.ts";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 
@@ -77,14 +71,6 @@ interface Dimensions {
   height: number;
 }
 
-interface AxisState {
-  transform: ViewportTransform;
-  scale: ScaleLinear<number, number>;
-  tree: SegmentTree<IMinMax>;
-  axis?: MyAxis;
-  g?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
-}
-
 export interface Series {
   axisIdx: number;
   view?: SVGGElement;
@@ -93,57 +79,13 @@ export interface Series {
 }
 
 export interface RenderState {
+  axisManager: AxisManager;
   axes: Axes;
   bScreenXVisible: AR1Basis;
   dimensions: Dimensions;
   series: Series[];
   seriesRenderer: SeriesRenderer;
   refresh: (data: ChartData) => void;
-}
-
-export function updateYScales(
-  axes: AxisState[],
-  bIndex: AR1Basis,
-  data: ChartData,
-) {
-  const domains = axes.map((a) => ({
-    min: Infinity,
-    max: -Infinity,
-    transform: a.transform,
-    scale: a.scale,
-  }));
-
-  const axisIndices: number[] = [];
-  for (const idx of data.seriesAxes) {
-    if (!axisIndices.includes(idx)) {
-      axisIndices.push(idx);
-    }
-  }
-
-  for (const i of axisIndices) {
-    const tree = data.buildAxisTree(i);
-    if (i < axes.length) {
-      axes[i].tree = tree;
-    }
-    const targetIdx = i < axes.length ? i : axes.length - 1;
-    const dp = data.updateScaleY(bIndex, tree);
-    const [min, max] = dp.y().toArr();
-    const domain = domains[targetIdx];
-    domain.min = Math.min(domain.min, min);
-    domain.max = Math.max(domain.max, max);
-  }
-
-  for (const domain of domains) {
-    let { min, max } = domain;
-    if (!Number.isFinite(min) || !Number.isFinite(max)) {
-      min = 0;
-      max = 1;
-    }
-    const b = new AR1Basis(min, max);
-    const dp = DirectProductBasis.fromProjections(data.bIndexFull, b);
-    domain.transform.onReferenceViewWindowResize(dp);
-    domain.scale.domain([min, max]);
-  }
 }
 
 export function setupRender(
@@ -163,13 +105,12 @@ export function setupRender(
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
   updateScaleX(xScale, data.bIndexFull, data);
 
-  const axesY: AxisState[] = Array.from({ length: axisCount }, (_, i) => ({
-    transform: new ViewportTransform(),
-    scale: scaleLinear<number, number>().range(yRange),
-    tree: data.buildAxisTree(i),
-  }));
-
-  updateYScales(axesY, data.bIndexFull, data);
+  const axisManager = new AxisManager();
+  const axesY = axisManager.create(axisCount);
+  for (const a of axesY) {
+    a.scale.range(yRange);
+  }
+  axisManager.updateScales(data.bIndexFull, data);
 
   const refDp = DirectProductBasis.fromProjections(
     data.bIndexFull,
@@ -189,6 +130,7 @@ export function setupRender(
   const dimensions: Dimensions = { width, height };
 
   const state: RenderState = {
+    axisManager,
     axes,
     bScreenXVisible,
     dimensions,
@@ -200,7 +142,7 @@ export function setupRender(
       );
       updateScaleX(this.axes.x.scale, bIndexVisible, data);
 
-      updateYScales(this.axes.y, bIndexVisible, data);
+      this.axisManager.updateScales(bIndexVisible, data);
 
       for (const s of this.series) {
         if (s.view) {

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -6,6 +6,7 @@ import { select, Selection } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData, IDataSource } from "./data.ts";
+import { buildAxisTree } from "./axisManager.ts";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 
 describe("createDimensions", () => {
@@ -65,7 +66,7 @@ describe("updateScaleY", () => {
   it("sets domain from visible data bounds", () => {
     const cd = new ChartData(makeSource([[10], [20], [40]]));
     const y = scaleLinear().range([100, 0]);
-    const tree = cd.buildAxisTree(0);
+    const tree = buildAxisTree(cd, 0);
     const dp = cd.updateScaleY(new AR1Basis(0, 2), tree);
     expect(dp.y().toArr()).toEqual([10, 40]);
     y.domain(dp.y().toArr());


### PR DESCRIPTION
## Summary
- introduce AxisManager to build axis trees and update y-scales
- refactor render pipeline to use AxisManager for scale updates
- update tests for new AxisManager API

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6897813f1ac4832ba972e7a528df51ae