### PR TITLE
refactor: derive series count from axes

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -10,7 +10,7 @@ import { sizes, datasets } from "./timeSeriesData.ts";
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   const renderer = new SeriesRenderer();
-  const manager = new SeriesManager(select(svg), 2, [0, 1]);
+  const manager = new SeriesManager(select(svg), [0, 1]);
   renderer.series = manager.series;
 
   sizes.forEach((size, idx) => {

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -18,7 +18,6 @@ describe("SeriesRenderer", () => {
           HTMLElement,
           unknown
         >,
-        2,
         [0, 1],
       );
       renderer.series = manager.series;
@@ -40,7 +39,7 @@ describe("SeriesRenderer", () => {
         "svg",
       ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
       const renderer = new SeriesRenderer();
-      const manager = new SeriesManager(svgSelection, 1, [0]);
+      const manager = new SeriesManager(svgSelection, [0]);
       const [series] = manager.series;
       renderer.series = manager.series;
       const pathNode = series.path;
@@ -62,7 +61,7 @@ describe("SeriesManager", () => {
     const svgSelection = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const manager = new SeriesManager(svgSelection, 1, [0]);
+    const manager = new SeriesManager(svgSelection, [0]);
     const [series] = manager.series;
 
     expect(series.view.tagName).toBe("g");

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -94,8 +94,6 @@ export function setupRender(
   data: ChartData,
   dualYAxis: boolean,
 ): RenderState {
-  const seriesCount = data.seriesCount;
-
   const bScreenVisibleDp = createDimensions(svg);
   const bScreenXVisible = bScreenVisibleDp.x();
   const width = bScreenXVisible.getRange();
@@ -122,7 +120,7 @@ export function setupRender(
     a.transform.onReferenceViewWindowResize(refDp);
   }
 
-  const seriesManager = new SeriesManager(svg, seriesCount, data.seriesAxes);
+  const seriesManager = new SeriesManager(svg, data.seriesAxes);
   const seriesRenderer = new SeriesRenderer();
   seriesRenderer.series = seriesManager.series;
   const { series } = seriesManager;

--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -5,18 +5,16 @@ import type { Series } from "./render.ts";
 import { createSeriesNodes } from "./render/utils.ts";
 
 export class SeriesManager {
-  public readonly series: Series[] = [];
+  public readonly series: Series[];
 
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-    seriesCount: number,
     seriesAxes: number[],
   ) {
-    for (let i = 0; i < seriesCount; i++) {
+    this.series = seriesAxes.map((axisIdx, i) => {
       const { view, path } = createSeriesNodes(svg);
-      const axisIdx = seriesAxes[i] ?? 0;
-      this.series.push({ axisIdx, view, path, line: this.createLine(i) });
-    }
+      return { axisIdx: axisIdx ?? 0, view, path, line: this.createLine(i) };
+    });
   }
 
   private createLine(seriesIdx: number): Line<number[]> {


### PR DESCRIPTION
## Summary
- derive series count from axes array and simplify SeriesManager
- adjust renderer setup to construct SeriesManager without explicit count
- update tests and benchmark for SeriesManager API change
- build `series` array via `seriesAxes.map`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68978a70c950832bb48f21ffa4373f5a