### PR TITLE
refactor: separate axis model and render state

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -19,13 +19,15 @@ const minMaxIdentity: IMinMax = {
   max: -Infinity,
 };
 
-export interface AxisState {
+export interface AxisModel {
   transform: ViewportTransform;
   scale: ScaleLinear<number, number>;
   tree: SegmentTree<IMinMax>;
-  // These are attached during rendering, so they start undefined.
-  axis?: MyAxis;
-  g?: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+}
+
+export interface AxisRenderState {
+  axis: MyAxis;
+  g: Selection<SVGGElement, unknown, HTMLElement, unknown>;
 }
 
 export function buildAxisTree(
@@ -49,9 +51,9 @@ export function buildAxisTree(
 }
 
 export class AxisManager {
-  public axes: AxisState[] = [];
+  public axes: AxisModel[] = [];
 
-  create(treeCount: number): AxisState[] {
+  create(treeCount: number): AxisModel[] {
     this.axes = Array.from({ length: treeCount }, () => ({
       transform: new ViewportTransform(),
       scale: scaleLinear<number, number>(),

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -115,8 +115,12 @@ describe("RenderState.refresh integration", () => {
     expect(ySfAfter).not.toEqual(ySfBefore);
 
     expect((state.axes.x.axis as any).scale1.domain()).toEqual(xAfter);
-    expect((state.axes.y[0].axis as any).scale1.domain()).toEqual(yNyAfter);
-    expect((state.axes.y[1].axis as any).scale1.domain()).toEqual(ySfAfter);
+    expect((state.axisRenders[0].axis as any).scale1.domain()).toEqual(
+      yNyAfter,
+    );
+    expect((state.axisRenders[1].axis as any).scale1.domain()).toEqual(
+      ySfAfter,
+    );
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);
     for (const s of state.series) {

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -66,6 +66,7 @@ describe("ZoomState.destroy", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } as any }],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -104,6 +105,7 @@ describe("ZoomState.destroy", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } as any }],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -60,6 +60,7 @@ describe("ZoomState", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any, { transform: y2 } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -97,6 +98,7 @@ describe("ZoomState", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -131,6 +133,7 @@ describe("ZoomState", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -166,6 +169,7 @@ describe("ZoomState", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -206,6 +210,7 @@ describe("ZoomState", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -241,6 +246,7 @@ describe("ZoomState", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -270,6 +276,7 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       transforms: [y],
+      axisRenders: [],
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -59,6 +59,7 @@ describe("ZoomState transform state", () => {
         x: { axis: {} as any, g: {} as any, scale: {} as any },
         y: [{ transform: y } as any],
       },
+      axisRenders: [],
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -114,10 +114,10 @@ export class TimeSeriesChart {
     axisX.g.remove();
     (axisX as unknown as { g?: typeof axisX.g }).g = undefined;
 
-    for (const axis of this.state.axes.y) {
-      axis.g?.remove();
-      axis.g = undefined;
+    for (const r of this.state.axisRenders) {
+      r.g.remove();
     }
+    this.state.axisRenders.length = 0;
     this.state.axes.y.length = 0;
   }
 


### PR DESCRIPTION
## Summary
- split axis config into `AxisModel` and `AxisRenderState`
- move DOM attachment out of `AxisManager` and track with `axisRenders`
- adjust chart disposal and tests to new axis interfaces

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689794a236dc832b9d20347e370198ed