### PR TITLE
Require SVG elements on Series and simplify cleanup

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -108,7 +108,7 @@ describe("LegendController", () => {
       getPoint: data.getPoint.bind(data),
       length: data.length,
       series: state.series.map((s) => ({
-        path: s.path as SVGPathElement,
+        path: s.path,
         transform: state.axes.y[s.axisIdx].transform,
       })),
     });
@@ -159,7 +159,7 @@ describe("LegendController", () => {
       getPoint: data.getPoint.bind(data),
       length: data.length,
       series: state.series.map((s) => ({
-        path: s.path as SVGPathElement,
+        path: s.path,
         transform: state.axes.y[s.axisIdx].transform,
       })),
     });
@@ -199,7 +199,7 @@ describe("LegendController", () => {
       getPoint: data.getPoint.bind(data),
       length: data.length,
       series: state.series.map((s) => ({
-        path: s.path as SVGPathElement,
+        path: s.path,
         transform: state.axes.y[s.axisIdx].transform,
       })),
     });

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -50,8 +50,8 @@ interface Dimensions {
 
 export interface Series {
   axisIdx: number;
-  view?: SVGGElement;
-  path?: SVGPathElement;
+  view: SVGGElement;
+  path: SVGPathElement;
   line: Line<number[]>;
 }
 
@@ -138,11 +138,8 @@ export function setupRender(
       this.axisManager.updateScales(bIndexVisible, data);
 
       for (const s of this.series) {
-        if (s.view) {
-          const t =
-            this.axes.y[s.axisIdx]?.transform ?? this.axes.y[0].transform;
-          updateNode(s.view, t.matrix);
-        }
+        const t = this.axes.y[s.axisIdx]?.transform ?? this.axes.y[0].transform;
+        updateNode(s.view, t.matrix);
       }
       this.axisRenders.forEach((r) => r.axis.axisUp(r.g));
       this.axes.x.axis.axisUp(this.axes.x.g);

--- a/svg-time-series/src/chart/seriesRenderer.ts
+++ b/svg-time-series/src/chart/seriesRenderer.ts
@@ -5,9 +5,7 @@ export class SeriesRenderer {
 
   public draw(dataArr: number[][]): void {
     for (const s of this.series) {
-      if (s.path) {
-        s.path.setAttribute("d", s.line(dataArr) ?? "");
-      }
+      s.path.setAttribute("d", s.line(dataArr) ?? "");
     }
   }
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -56,7 +56,7 @@ export class TimeSeriesChart {
       getPoint: (idx) => this.data.getPoint(idx),
       length: this.data.length,
       series: this.state.series.map((s) => ({
-        path: s.path as SVGPathElement,
+        path: s.path,
         transform:
           this.state.axes.y[s.axisIdx]?.transform ??
           this.state.axes.y[0].transform,
@@ -104,10 +104,8 @@ export class TimeSeriesChart {
     this.legendController.destroy();
 
     for (const s of this.state.series) {
-      s.path?.remove();
-      s.view?.remove();
-      s.path = undefined;
-      s.view = undefined;
+      s.path.remove();
+      s.view.remove();
     }
     this.state.series.length = 0;
     const axisX = this.state.axes.x;


### PR DESCRIPTION
## Summary
- make `Series` view and path elements mandatory and always update transforms
- remove optional path guard in `SeriesRenderer`
- simplify dispose logic and legend context to rely on non-null series elements
- update legend tests to use guaranteed `path` members

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979766d908832ba94d4a337a4ae4c2