### PR TITLE
refactor: require explicit dimensions for resize

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,7 +4,7 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { createDimensions, updateScaleX } from "./chart/render/utils.ts";
+import { updateScaleX } from "./chart/render/utils.ts";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
@@ -131,28 +131,18 @@ export class TimeSeriesChart {
     this.zoomState.setScaleExtent(extent);
   };
 
-  public resize = (dimensions?: { width?: number; height?: number }) => {
-    let width: number;
-    let height: number;
-    let bScreenVisible: DirectProductBasis;
+  public resize = (dimensions: { width: number; height: number }) => {
+    const { width, height } = dimensions;
+    this.svg.attr("width", width).attr("height", height);
 
-    if (dimensions?.width != null && dimensions?.height != null) {
-      width = dimensions.width;
-      height = dimensions.height;
-      this.svg.attr("width", width).attr("height", height);
-      const bScreenXVisible = new AR1Basis(0, width);
-      const bScreenYVisible = new AR1Basis(height, 0);
-      bScreenVisible = DirectProductBasis.fromProjections(
-        bScreenXVisible,
-        bScreenYVisible,
-      );
-      this.state.bScreenXVisible = bScreenXVisible;
-    } else {
-      bScreenVisible = createDimensions(this.svg);
-      this.state.bScreenXVisible = bScreenVisible.x();
-      width = this.state.bScreenXVisible.getRange();
-      height = bScreenVisible.y().getRange();
-    }
+    const bScreenXVisible = new AR1Basis(0, width);
+    const bScreenYVisible = new AR1Basis(height, 0);
+    const bScreenVisible = DirectProductBasis.fromProjections(
+      bScreenXVisible,
+      bScreenYVisible,
+    );
+
+    this.state.bScreenXVisible = bScreenXVisible;
 
     this.state.dimensions.width = width;
     this.state.dimensions.height = height;


### PR DESCRIPTION
## Summary
- require explicit `width` and `height` when resizing a `TimeSeriesChart`
- remove `createDimensions` fallback and compute bases directly from provided dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979c5d4e70832bb72a25a9ad2fbee8