### PR TITLE
Respect provided axis indices in series manager

### DIFF
--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -67,4 +67,13 @@ describe("SeriesManager", () => {
     expect(series.view.tagName).toBe("g");
     expect(series.path.tagName).toBe("path");
   });
+
+  it("throws when a series axis is undefined", () => {
+    const svgSelection = select(document.createElement("div")).append(
+      "svg",
+    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+    expect(
+      () => new SeriesManager(svgSelection, [undefined as unknown as number]),
+    ).toThrow(/seriesAxes\[0\]/);
+  });
 });

--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -12,8 +12,13 @@ export class SeriesManager {
     seriesAxes: number[],
   ) {
     this.series = seriesAxes.map((axisIdx, i) => {
+      if (axisIdx == null) {
+        throw new Error(
+          `SeriesManager requires seriesAxes[${i}] to be defined`,
+        );
+      }
       const { view, path } = createSeriesNodes(svg);
-      return { axisIdx: axisIdx ?? 0, view, path, line: this.createLine(i) };
+      return { axisIdx, view, path, line: this.createLine(i) };
     });
   }
 


### PR DESCRIPTION
## Summary
- prevent SeriesManager from defaulting missing series axis index to 0
- validate seriesAxes entries and throw when undefined
- test SeriesManager error handling for undefined axis mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979b60b124832b95b2deda2b84b8e3