### PR TITLE
feat: validate series axis mappings

### DIFF
--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -27,7 +27,7 @@ onCsv((data: [number, number][]) => {
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(legend);
-  const chart = new TimeSeriesChart(svg, source, legendController);
+  const chart = new TimeSeriesChart(svg, source, legendController, true);
   const renderMs = performance.now() - start;
   const renderTimeEl = document.getElementById("render-time");
   if (renderTimeEl) {

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -27,7 +27,7 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
       timeStep: 86400000,
       length: data.length,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: dualYAxis ? [0, 1] : [0, 0],
       getSeries: (i, seriesIdx) => data[i][seriesIdx],
     };
     const legendController = new LegendController(legend);

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -158,7 +158,7 @@ describe("RenderState.refresh", () => {
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [0, 0],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data = new ChartData(source);

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -97,7 +97,25 @@ describe("buildSeries", () => {
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
   });
 
-  it("returns two series for combined axis", () => {
+  it("returns two series for shared axis", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 3,
+      seriesCount: 2,
+      seriesAxes: [0, 0],
+      getSeries: (i, seriesIdx) =>
+        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg as any, data, false);
+    expect(state.series.length).toBe(2);
+    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
+    expect(state.series[1]).toMatchObject({ axisIdx: 0 });
+  });
+
+  it("throws when second axis requested without dualYAxis", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
@@ -109,10 +127,9 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
-    expect(state.series.length).toBe(2);
-    expect(state.series[0]).toMatchObject({ axisIdx: 0 });
-    expect(state.series[1]).toMatchObject({ axisIdx: 1 });
+    expect(() => setupRender(svg as any, data, false)).toThrow(
+      "axes.y must contain an entry for every series.axisIdx",
+    );
   });
 
   it("returns two series for dualYAxis", () => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -75,7 +75,14 @@ export function setupRender(
   const bScreenXVisible = bScreenVisibleDp.x();
   const width = bScreenXVisible.getRange();
   const height = bScreenVisibleDp.y().getRange();
-  const axisCount = dualYAxis && data.seriesAxes.includes(1) ? 2 : 1;
+  const maxAxisIdx = data.seriesAxes.reduce(
+    (max, idx) => Math.max(max, idx),
+    0,
+  );
+  if (maxAxisIdx > 0 && !dualYAxis) {
+    throw new Error("axes.y must contain an entry for every series.axisIdx");
+  }
+  const axisCount = dualYAxis ? maxAxisIdx + 1 : 1;
 
   const [xRange, yRange] = bScreenVisibleDp.toArr();
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
@@ -138,7 +145,7 @@ export function setupRender(
       this.axisManager.updateScales(bIndexVisible, data);
 
       for (const s of this.series) {
-        const t = this.axes.y[s.axisIdx]?.transform ?? this.axes.y[0].transform;
+        const t = this.axes.y[s.axisIdx].transform;
         updateNode(s.view, t.matrix);
       }
       this.axisRenders.forEach((r) => r.axis.axisUp(r.g));

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -78,7 +78,7 @@ function createSvg() {
 }
 
 describe("setupRender Y-axis modes", () => {
-  it("combines series when dualYAxis is false", () => {
+  it("throws when dualYAxis is false but series uses second axis", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
@@ -90,9 +90,9 @@ describe("setupRender Y-axis modes", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
-    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
-    expect(state.axes.y[1]).toBeUndefined();
+    expect(() => setupRender(svg as any, data, false)).toThrow(
+      "axes.y must contain an entry for every series.axisIdx",
+    );
   });
 
   it("separates scales when dualYAxis is true", () => {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -57,9 +57,7 @@ export class TimeSeriesChart {
       length: this.data.length,
       series: this.state.series.map((s) => ({
         path: s.path,
-        transform:
-          this.state.axes.y[s.axisIdx]?.transform ??
-          this.state.axes.y[0].transform,
+        transform: this.state.axes.y[s.axisIdx].transform,
       })),
     };
     this.legendController.init(context);


### PR DESCRIPTION
## Summary
- validate that each series has a corresponding Y axis and throw when misconfigured
- simplify axis transform lookups now that axes are guaranteed
- adjust tests and samples for updated Y-axis validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979c73c338832bb8ab7123871660a8