### PR TITLE
feat: manage x axis scale in AxisManager

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,4 +1,4 @@
-import { scaleLinear, type ScaleLinear } from "d3-scale";
+import { scaleLinear, type ScaleLinear, type ScaleTime } from "d3-scale";
 import type { Selection } from "d3-selection";
 import { SegmentTree } from "segment-tree-rmq";
 
@@ -6,6 +6,7 @@ import { MyAxis } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
 import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
 import type { ChartData, IMinMax } from "./data.ts";
+import { updateScaleX } from "./render/utils.ts";
 
 function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
   return {
@@ -52,6 +53,7 @@ export function buildAxisTree(
 
 export class AxisManager {
   public axes: AxisModel[] = [];
+  public x!: ScaleTime<number, number>;
 
   create(treeCount: number): AxisModel[] {
     this.axes = Array.from({ length: treeCount }, () => ({
@@ -62,7 +64,13 @@ export class AxisManager {
     return this.axes;
   }
 
+  setXAxis(scale: ScaleTime<number, number>): void {
+    this.x = scale;
+  }
+
   updateScales(bIndex: AR1Basis, data: ChartData): void {
+    updateScaleX(this.x, bIndex, data);
+
     const domains = this.axes.map((a) => ({
       min: Infinity,
       max: -Infinity,

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -11,7 +11,7 @@ import {
 import { updateNode } from "../utils/domNodeTransform.ts";
 import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData } from "./data.ts";
-import { createDimensions, updateScaleX } from "./render/utils.ts";
+import { createDimensions } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 import { SeriesManager } from "./series.ts";
 
@@ -79,9 +79,9 @@ export function setupRender(
 
   const [xRange, yRange] = bScreenVisibleDp.toArr();
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
-  updateScaleX(xScale, data.bIndexFull, data);
 
   const axisManager = new AxisManager();
+  axisManager.setXAxis(xScale);
   const axesY = axisManager.create(axisCount);
   for (const a of axesY) {
     a.scale.range(yRange);
@@ -133,7 +133,6 @@ export function setupRender(
       const bIndexVisible = this.axes.y[0].transform.fromScreenToModelBasisX(
         this.bScreenXVisible,
       );
-      updateScaleX(this.axes.x.scale, bIndexVisible, data);
 
       this.axisManager.updateScales(bIndexVisible, data);
 

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
-import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import { scaleTime } from "d3-scale";
+import {
+  AR1Basis,
+  DirectProductBasis,
+  betweenTBasesAR1,
+} from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
 
 class Matrix {
@@ -67,6 +72,7 @@ beforeAll(() => {
 describe("updateScales", () => {
   it("updates domains for multiple axes", () => {
     const axisManager = new AxisManager();
+    axisManager.setXAxis(scaleTime().range([0, 1]));
     const axes = axisManager.create(3);
     axes.forEach((a) => a.scale.range([0, 1]));
 
@@ -78,6 +84,9 @@ describe("updateScales", () => {
         [3, 30, 5, 25],
       ],
       bIndexFull: new AR1Basis(0, 1),
+      indexToTime() {
+        return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
+      },
       updateScaleY(b: AR1Basis, tree: any) {
         const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);
@@ -95,6 +104,7 @@ describe("updateScales", () => {
 
   it("merges extra axes into the last scale", () => {
     const axisManager = new AxisManager();
+    axisManager.setXAxis(scaleTime().range([0, 1]));
     const axes = axisManager.create(2);
     axes.forEach((a) => a.scale.range([0, 1]));
 
@@ -106,6 +116,9 @@ describe("updateScales", () => {
         [1, 20, 5],
       ],
       bIndexFull: new AR1Basis(0, 1),
+      indexToTime() {
+        return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
+      },
       updateScaleY(b: AR1Basis, tree: any) {
         const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,7 +4,7 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { createDimensions, updateScaleX } from "./chart/render/utils.ts";
+import { createDimensions } from "./chart/render/utils.ts";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
@@ -163,12 +163,6 @@ export class TimeSeriesChart {
     for (const a of this.state.axes.y) {
       a.transform.onViewPortResize(bScreenVisible);
     }
-
-    const bIndexVisible =
-      this.state.axes.y[0].transform.fromScreenToModelBasisX(
-        this.state.bScreenXVisible,
-      );
-    updateScaleX(this.state.axes.x.scale, bIndexVisible, this.data);
 
     this.state.refresh(this.data);
     this.state.seriesRenderer.draw(this.data.data);


### PR DESCRIPTION
## Summary
- store x-axis scale in AxisManager and invoke `updateScaleX` from `updateScales`
- set x-axis scale during render setup and delegate scale updates to AxisManager refresh
- remove manual x-axis scale updates from draw resize logic
- require x-axis scale and update tests accordingly

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979aaf46f8832b8aede59cd228dd0a