### PR TITLE
Require explicit zoom scale extent

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -10,7 +10,7 @@ import { drawProc } from "../utils/drawProc.ts";
 import type { RenderState } from "./render.ts";
 
 export interface IZoomStateOptions {
-  scaleExtent?: [number, number];
+  scaleExtent: [number, number];
 }
 
 export class ZoomState {
@@ -27,9 +27,9 @@ export class ZoomState {
     private zoomCallback: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
-    options: IZoomStateOptions = {},
+    options: IZoomStateOptions = { scaleExtent: [1, 40] },
   ) {
-    this.scaleExtent = options.scaleExtent ?? [1, 40];
+    this.scaleExtent = options.scaleExtent;
     this.zoomBehavior = d3zoom<SVGRectElement, unknown>()
       .scaleExtent(this.scaleExtent)
       .translateExtent([

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -37,7 +37,7 @@ export class TimeSeriesChart {
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
-    zoomOptions: IZoomStateOptions = {},
+    zoomOptions?: IZoomStateOptions,
   ) {
     this.svg = svg;
     this.data = new ChartData(data);


### PR DESCRIPTION
## Summary
- make `scaleExtent` mandatory in `IZoomStateOptions` with a default of `[1, 40]`
- allow `TimeSeriesChart` to pass optional zoom options relying on `ZoomState`'s default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68979c54c970832b875a68007c861a7f