### PR TITLE
refactor(chart): drop undefined checks for required fields

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -56,9 +56,6 @@ export class ChartData {
       throw new Error("ChartData requires timeStep to be greater than 0");
     }
     this.seriesCount = source.seriesCount;
-    if (source.seriesAxes == null) {
-      throw new Error("ChartData requires seriesAxes mapping");
-    }
     this.seriesAxes = source.seriesAxes;
     if (this.seriesAxes.length !== this.seriesCount) {
       throw new Error(

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -67,13 +67,4 @@ describe("SeriesManager", () => {
     expect(series.view.tagName).toBe("g");
     expect(series.path.tagName).toBe("path");
   });
-
-  it("throws when a series axis is undefined", () => {
-    const svgSelection = select(document.createElement("div")).append(
-      "svg",
-    ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    expect(
-      () => new SeriesManager(svgSelection, [undefined as unknown as number]),
-    ).toThrow(/seriesAxes\[0\]/);
-  });
 });

--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -12,11 +12,6 @@ export class SeriesManager {
     seriesAxes: number[],
   ) {
     this.series = seriesAxes.map((axisIdx, i) => {
-      if (axisIdx == null) {
-        throw new Error(
-          `SeriesManager requires seriesAxes[${i}] to be defined`,
-        );
-      }
       const { view, path } = createSeriesNodes(svg);
       return { axisIdx, view, path, line: this.createLine(i) };
     });
@@ -24,7 +19,7 @@ export class SeriesManager {
 
   private createLine(seriesIdx: number): Line<number[]> {
     return line<number[]>()
-      .defined((d) => !(isNaN(d[seriesIdx]) || d[seriesIdx] == null))
+      .defined((d) => !isNaN(d[seriesIdx]))
       .x((_, i) => i)
       .y((d) => d[seriesIdx] as number);
   }

--- a/svg-time-series/src/chart/slidingWindow.ts
+++ b/svg-time-series/src/chart/slidingWindow.ts
@@ -16,7 +16,7 @@ export class SlidingWindow {
       }
       let valueIdx = 0;
       for (const val of row) {
-        if (val == null || (!Number.isFinite(val) && !Number.isNaN(val))) {
+        if (!Number.isFinite(val) && !Number.isNaN(val)) {
           throw new Error(
             `SlidingWindow requires row ${rowIdx} series ${valueIdx} value to be a finite number or NaN`,
           );
@@ -36,7 +36,7 @@ export class SlidingWindow {
     }
     let valueIdx = 0;
     for (const val of values) {
-      if (val == null || (!Number.isFinite(val) && !Number.isNaN(val))) {
+      if (!Number.isFinite(val) && !Number.isNaN(val)) {
         throw new Error(
           `SlidingWindow.append requires series ${valueIdx} value to be a finite number or NaN`,
         );


### PR DESCRIPTION
## Summary
- streamline ChartData initialization by requiring `seriesAxes`
- assume defined axis indices in SeriesManager and simplify line definition
- relax SlidingWindow to treat only numeric validity

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897a405c3e0832b8815f6847012db19