### PR TITLE
Derive Y-axis mode from series data

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ work is possible. Keep watching!
 Charts can display one or two data series. The library supports at most two
 series; additional series are ignored. By default, all series share a single
 Y-axis whose scale is computed from the combined minimum and maximum of every
-series. To draw series with different units, pass `true` for the `dualYAxis`
-parameter of `TimeSeriesChart`, which enables independent left and right Y
-scales.
+series. To draw series with different units, assign each series to a Y-axis via
+the `seriesAxes` array. If any series is assigned to axis index 1, a second
+independent Y scale is created automatically.
 
 ```ts
 import { TimeSeriesChart, IDataSource } from "svg-time-series";
@@ -72,7 +72,6 @@ const chart = new TimeSeriesChart(
     new LegendController(legend, state, data, (ts) =>
       new Date(ts).toISOString(),
     ),
-  true, // enable dual Y axes
   onZoom,
   onMouseMove,
 );
@@ -86,7 +85,7 @@ length must equal `seriesCount`.
 The third argument creates a legend controller, letting you customize how
 legend entries are rendered, including timestamp formatting.
 
-For two series sharing a single Y-axis, pass `false` for `dualYAxis`:
+For two series sharing a single Y-axis, assign both series to axis 0:
 
 ```ts
 const singleSource: IDataSource = {
@@ -106,7 +105,6 @@ const chartSingle = new TimeSeriesChart(
     new LegendController(legend, state, data, (ts) =>
       new Date(ts).toISOString(),
     ),
-  false, // series share one axis
   onZoom,
   onMouseMove,
 );

--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -101,7 +101,7 @@ describe("LegendController", () => {
       seriesAxes: [0],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
@@ -152,7 +152,7 @@ describe("LegendController", () => {
       const { values, timestamp } = originalGetPoint(idx);
       return [timestamp, ...values] as any;
     }) as any;
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({
@@ -192,7 +192,7 @@ describe("LegendController", () => {
       const { timestamp } = originalGetPoint(idx);
       return { timestamp } as any;
     }) as any;
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
     select(state.series[0].path).attr("stroke", "green");
     const lc = new LegendController(legendDiv as any);
     lc.init({

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -27,7 +27,7 @@ onCsv((data: [number, number][]) => {
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(legend);
-  const chart = new TimeSeriesChart(svg, source, legendController, true);
+  const chart = new TimeSeriesChart(svg, source, legendController);
   const renderMs = performance.now() - start;
   const renderTimeEl = document.getElementById("render-time");
   if (renderTimeEl) {

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -6,7 +6,10 @@ import { TimeSeriesChart, IDataSource } from "svg-time-series";
 import { LegendController } from "../LegendController.ts";
 import { measure } from "../measure.ts";
 
-export function drawCharts(data: [number, number][], dualYAxis = false) {
+export function drawCharts(
+  data: [number, number][],
+  seriesAxes: number[] = [0, 0],
+) {
   const charts: TimeSeriesChart[] = [];
 
   const onZoom = (
@@ -40,7 +43,7 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
       timeStep: 86400000,
       length: data.length,
       seriesCount: 2,
-      seriesAxes: dualYAxis ? [0, 1] : [0, 0],
+      seriesAxes,
       getSeries: (i, seriesIdx) => data[i][seriesIdx],
     };
     const legendController = new LegendController(legend);
@@ -52,7 +55,6 @@ export function drawCharts(data: [number, number][], dualYAxis = false) {
       svg,
       source,
       legendController,
-      dualYAxis,
       zoomHandler,
       onMouseMove,
     );
@@ -96,9 +98,9 @@ interface Resize {
 
 const resize: Resize = { interval: 60, request: null, timer: null, eval: null };
 
-export function loadAndDraw(dualYAxis = false) {
+export function loadAndDraw(seriesAxes: number[] = [0, 0]) {
   onCsv((data: [number, number][]) => {
-    drawCharts(data, dualYAxis);
+    drawCharts(data, seriesAxes);
 
     resize.request = function () {
       if (resize.timer) clearTimeout(resize.timer);
@@ -110,7 +112,7 @@ export function loadAndDraw(dualYAxis = false) {
         .append("svg")
         .append("g")
         .attr("class", "view");
-      drawCharts(data, dualYAxis);
+      drawCharts(data, seriesAxes);
     };
   });
 }

--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,3 +1,3 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw(true);
+loadAndDraw([0, 1]);

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,3 +1,3 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw(false);
+loadAndDraw([0, 0]);

--- a/samples/demos/resetZoom.ts
+++ b/samples/demos/resetZoom.ts
@@ -2,8 +2,8 @@ import { loadAndDraw } from "./common.ts";
 
 // Demo entry for testing chart reset logic. Uses the updated IDataSource API.
 // A button with id 'reset-zoom' will redraw the charts to simulate a reset.
-loadAndDraw(false);
+loadAndDraw([0, 0]);
 
 document.getElementById("reset-zoom")?.addEventListener("click", () => {
-  loadAndDraw(false);
+  loadAndDraw([0, 0]);
 });

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -33,6 +33,8 @@ const source: IDataSource = {
   timeStep: 1000, // time step in ms
   length: ny.length,
   seriesCount: 2,
+  // Use the left axis for the first series and the right axis for the second
+  seriesAxes: [0, 1],
   getSeries: (i, seriesIdx) => (seriesIdx === 0 ? ny[i] : sf[i]),
 };
 
@@ -43,7 +45,6 @@ const chart = new TimeSeriesChart(
     new LegendController(legend, state, data, (ts) =>
       new Date(ts).toISOString(),
     ),
-  true, // enable dual Y axes
   () => {},
   () => {},
 );

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -100,7 +100,6 @@ function createChart(data: Array<[number]>) {
     select(svgEl) as any,
     source,
     legendController,
-    false,
     () => {},
     () => {},
   );

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -143,7 +143,6 @@ function createChart(data: Array<[number, number]>, options?: any) {
     select(svgEl) as any,
     source,
     legendController,
-    true,
     () => {},
     () => {},
     options,

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -126,7 +126,6 @@ function createChart(data: Array<[number]>) {
     select(svgEl) as any,
     source,
     legendController,
-    false,
     () => {},
     () => {},
   );

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -133,7 +133,6 @@ function createChart(
     select(svgEl) as any,
     source,
     legendController,
-    true,
     () => {},
     () => {},
   );
@@ -350,7 +349,6 @@ describe("chart interaction", () => {
       select(svgEl) as any,
       source,
       legendController,
-      true,
       () => {},
       mouseMoveHandler,
     );

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -94,7 +94,7 @@ describe("RenderState.refresh integration", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const state = setupRender(svg as any, data);
     const updateNodeSpy = vi
       .spyOn(domNode, "updateNode")
       .mockImplementation(() => {});

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -104,7 +104,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -132,7 +132,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const state = setupRender(svg as any, data);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -162,7 +162,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
 
     state.refresh(data);
 
@@ -181,7 +181,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data1 = new ChartData(source1);
-    const state = setupRender(svg as any, data1, true);
+    const state = setupRender(svg as any, data1);
     state.refresh(data1);
     const source2: IDataSource = {
       startTime: 0,
@@ -213,7 +213,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
 
     expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 1, max: 3 });
 

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -81,7 +81,7 @@ function createSvg() {
 }
 
 describe("buildSeries", () => {
-  it("returns single series when hasSf is false", () => {
+  it("returns single series for single-axis data", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
@@ -92,7 +92,7 @@ describe("buildSeries", () => {
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
     expect(state.series.length).toBe(1);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
   });
@@ -109,13 +109,13 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, false);
+    const state = setupRender(svg as any, data);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 0 });
   });
 
-  it("throws when second axis requested without dualYAxis", () => {
+  it("returns two series for separate axes", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
@@ -127,24 +127,7 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    expect(() => setupRender(svg as any, data, false)).toThrow(
-      "axes.y must contain an entry for every series.axisIdx",
-    );
-  });
-
-  it("returns two series for dualYAxis", () => {
-    const svg = createSvg();
-    const source: IDataSource = {
-      startTime: 0,
-      timeStep: 1,
-      length: 3,
-      seriesCount: 2,
-      seriesAxes: [0, 1],
-      getSeries: (i, seriesIdx) =>
-        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
-    };
-    const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const state = setupRender(svg as any, data);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 1 });
@@ -164,7 +147,7 @@ describe("setupRender DOM order", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    setupRender(svg as any, data, true);
+    setupRender(svg as any, data);
     const groups = svg.selectAll("g").nodes() as SVGGElement[];
     expect(groups[0].classList.contains("view")).toBe(true);
     expect(groups[1].classList.contains("view")).toBe(true);

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -69,7 +69,6 @@ export interface RenderState {
 export function setupRender(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   data: ChartData,
-  dualYAxis: boolean,
 ): RenderState {
   const bScreenVisibleDp = createDimensions(svg);
   const bScreenXVisible = bScreenVisibleDp.x();
@@ -79,10 +78,7 @@ export function setupRender(
     (max, idx) => Math.max(max, idx),
     0,
   );
-  if (maxAxisIdx > 0 && !dualYAxis) {
-    throw new Error("axes.y must contain an entry for every series.axisIdx");
-  }
-  const axisCount = dualYAxis ? maxAxisIdx + 1 : 1;
+  const axisCount = maxAxisIdx + 1;
 
   const [xRange, yRange] = bScreenVisibleDp.toArr();
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -78,24 +78,24 @@ function createSvg() {
 }
 
 describe("setupRender Y-axis modes", () => {
-  it("throws when dualYAxis is false but series uses second axis", () => {
+  it("combines scales when series share an axis", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
       timeStep: 1,
       length: 3,
       seriesCount: 2,
-      seriesAxes: [0, 1],
+      seriesAxes: [0, 0],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    expect(() => setupRender(svg as any, data, false)).toThrow(
-      "axes.y must contain an entry for every series.axisIdx",
-    );
+    const state = setupRender(svg as any, data);
+    expect(state.axes.y).toHaveLength(1);
+    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
   });
 
-  it("separates scales when dualYAxis is true", () => {
+  it("separates scales when series use different axes", () => {
     const svg = createSvg();
     const source: IDataSource = {
       startTime: 0,
@@ -107,7 +107,7 @@ describe("setupRender Y-axis modes", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data, true);
+    const state = setupRender(svg as any, data);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
     expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
   });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,7 +4,6 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { createDimensions, updateScaleX } from "./chart/render/utils.ts";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
@@ -32,7 +31,6 @@ export class TimeSeriesChart {
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
     data: IDataSource,
     legendController: ILegendController,
-    dualYAxis = false,
     zoomHandler: (
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
@@ -42,7 +40,7 @@ export class TimeSeriesChart {
     this.svg = svg;
     this.data = new ChartData(data);
 
-    this.state = setupRender(svg, this.data, dualYAxis);
+    this.state = setupRender(svg, this.data);
 
     this.zoomArea = svg
       .append("rect")


### PR DESCRIPTION
## Summary
- infer secondary Y-axis automatically by inspecting `seriesAxes`
- drop `dualYAxis` constructor flag and update demos
- document new `seriesAxes` workflow for single and dual axis setups

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b4e0a1bc832bb817e0af5d5b9475