### PR TITLE
chore: use flex layout for demo charts

### DIFF
--- a/samples/demos/index.css
+++ b/samples/demos/index.css
@@ -53,12 +53,11 @@ g.view:nth-child(2) > circle {
 }
 
 .charts {
-  height: calc(100vh - 2rem);
   display: flex;
   flex-direction: column;
 }
 .chart {
-  height: calc(20% - 0.4rem);
+  flex: 1;
   margin: 0.2rem;
   display: flex;
 }


### PR DESCRIPTION
## Summary
- use flexbox for chart layout in demos

## Testing
- `curl -s http://localhost:5173/demos/demo1.html | grep -o 'class="chart"' | wc -l`
- `curl -s http://localhost:5173/demos/demo2.html | grep -o 'class="chart"' | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6897b7804be8832b9a7816363efb3c22