### PR TITLE
feat: set default zoom options

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -139,15 +139,25 @@ function createChart(data: Array<[number, number]>, options?: any) {
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(select(legend) as any);
-  const chart = new TimeSeriesChart(
-    select(svgEl) as any,
-    source,
-    legendController,
-    true,
-    () => {},
-    () => {},
-    options,
-  );
+  const chart =
+    options === undefined
+      ? new TimeSeriesChart(
+          select(svgEl) as any,
+          source,
+          legendController,
+          true,
+          () => {},
+          () => {},
+        )
+      : new TimeSeriesChart(
+          select(svgEl) as any,
+          source,
+          legendController,
+          true,
+          () => {},
+          () => {},
+          options,
+        );
 
   return { interaction: chart.interaction };
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -4,7 +4,6 @@ import { D3ZoomEvent } from "d3-zoom";
 import { ChartData, IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { createDimensions, updateScaleX } from "./chart/render/utils.ts";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
@@ -37,7 +36,7 @@ export class TimeSeriesChart {
       event: D3ZoomEvent<SVGRectElement, unknown>,
     ) => void = () => {},
     mouseMoveHandler: (event: MouseEvent) => void = () => {},
-    zoomOptions?: IZoomStateOptions,
+    zoomOptions: IZoomStateOptions = { scaleExtent: [1, 40] },
   ) {
     this.svg = svg;
     this.data = new ChartData(data);


### PR DESCRIPTION
## Summary
- provide default zoom state options in TimeSeriesChart constructor
- update reset-zoom tests to omit undefined zoom options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b6f06f64832b99a94d4af75b7980