### PR TITLE
feat: validate zoom scale extent values

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -297,4 +297,52 @@ describe("ZoomState", () => {
     zs.updateExtents({ width: 20, height: 30 });
     expect(scaleSpy).toHaveBeenCalledWith([2, 80]);
   });
+
+  it.each([
+    [1, 10],
+    [0.5, 20],
+  ])("accepts valid scale extent %j", (min, max) => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axisRenders: [],
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      state,
+      vi.fn(),
+    );
+
+    expect(() => zs.setScaleExtent([min, max])).not.toThrow();
+  });
+
+  it.each([
+    [0, 10],
+    [-1, 10],
+    [1, 1],
+    [5, 3],
+    [1, 0],
+    [1, -5],
+    [Infinity, 10],
+    [NaN, 10],
+    [1, Infinity],
+    [1, NaN],
+  ])("rejects invalid scale extent %j", (min, max) => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axisRenders: [],
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      state,
+      vi.fn(),
+    );
+
+    expect(() => zs.setScaleExtent([min, max])).toThrow(
+      /scaleExtent must be two finite, positive numbers/,
+    );
+  });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -19,6 +19,20 @@ export class ZoomState {
   private scheduleRefresh: () => void;
   private cancelRefresh: () => void;
   private scaleExtent: [number, number];
+  private validateScaleExtent(extent: [number, number]) {
+    const [min, max] = extent;
+    if (
+      !Number.isFinite(min) ||
+      !Number.isFinite(max) ||
+      min <= 0 ||
+      max <= 0 ||
+      min >= max
+    ) {
+      throw new Error(
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${min}, ${max}]`,
+      );
+    }
+  }
 
   constructor(
     private zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -29,6 +43,7 @@ export class ZoomState {
     ) => void = () => {},
     options: IZoomStateOptions = { scaleExtent: [1, 40] },
   ) {
+    this.validateScaleExtent(options.scaleExtent);
     this.scaleExtent = options.scaleExtent;
     this.zoomBehavior = d3zoom<SVGRectElement, unknown>()
       .scaleExtent(this.scaleExtent)
@@ -74,6 +89,7 @@ export class ZoomState {
   };
 
   public setScaleExtent = (extent: [number, number]) => {
+    this.validateScaleExtent(extent);
     this.scaleExtent = extent;
     this.zoomBehavior.scaleExtent(extent);
   };


### PR DESCRIPTION
## Summary
- validate zoom scale extents and ensure min/max are finite and ordered
- add tests for valid and invalid scale extent inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897b6a79878832ba9637867178b9815