### PR TITLE
feat: validate zero-scale and zero-span transforms

### DIFF
--- a/svg-time-series/src/affine.test.ts
+++ b/svg-time-series/src/affine.test.ts
@@ -5,6 +5,7 @@ import {
   DirectProduct,
   DirectProductBasis,
   betweenTBasesDirectProduct,
+  betweenBasesAR1,
 } from "./math/affine.ts";
 
 describe("AR1 and AR1Basis", () => {
@@ -27,6 +28,15 @@ describe("AR1 and AR1Basis", () => {
     const transformed = basis.transformWith(t);
     expect(transformed.toArr()).toEqual([3, 23]);
     expect(transformed.getRange()).toBeCloseTo(20);
+  });
+
+  it("throws an error when inverting a zero-scale AR1 transform", () => {
+    const t = new AR1([0, 5]);
+    expect(() => t.inverse()).toThrow(/zero scale/);
+  });
+
+  it("throws an error for zero-span input in betweenBasesAR1", () => {
+    expect(() => betweenBasesAR1([1, 1], [0, 1])).toThrow(/zero span/);
   });
 });
 

--- a/svg-time-series/src/math/affine.ts
+++ b/svg-time-series/src/math/affine.ts
@@ -9,6 +9,9 @@ export class AR1 {
 
   inverse(): AR1 {
     const [a, b] = this.m;
+    if (a === 0) {
+      throw new Error("AR1.inverse: zero scale factor");
+    }
     return new AR1([1 / a, -b / a]);
   }
 
@@ -49,10 +52,11 @@ export function betweenBasesAR1(
 ): AR1 {
   const [b11, b12] = b1;
   const [b21, b22] = b2;
-  return new AR1([
-    (b21 - b22) / (b11 - b12),
-    -(b12 * b21 - b11 * b22) / (b11 - b12),
-  ]);
+  const span = b11 - b12;
+  if (span === 0) {
+    throw new Error("betweenBasesAR1: zero span basis");
+  }
+  return new AR1([(b21 - b22) / span, -(b12 * b21 - b11 * b22) / span]);
 }
 
 export function betweenTBasesAR1(b1: AR1Basis, b2: AR1Basis): AR1 {


### PR DESCRIPTION
## Summary
- prevent `AR1.inverse` from inverting transforms with zero scale
- guard `betweenBasesAR1` against zero-span bases
- test zero-scale inverse and zero-span basis error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897b67ec1d8832ba6f03df9d0d47552