### PR TITLE
Standardize demo HTML document structure

### DIFF
--- a/samples/demos/demo1.html
+++ b/samples/demos/demo1.html
@@ -1,23 +1,30 @@
-﻿<!doctype html>
-<meta charset="utf-8" />
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1"
-/>
-<div id="fps">n/a</div>
-<div class="charts">
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <link href="index.css" rel="stylesheet" type="text/css" />
+    <title>SVG Time Series Demo 1</title>
+  </head>
+  <body>
+    <div id="fps">n/a</div>
+    <div class="charts">
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
     </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-</div>
-<script type="module" src="demo1.ts"></script>
-<link href="index.css" type="text/css" rel="stylesheet" />
+    <script type="module" src="demo1.ts"></script>
+  </body>
+</html>

--- a/samples/demos/demo2.html
+++ b/samples/demos/demo2.html
@@ -1,71 +1,78 @@
-﻿<!doctype html>
-<meta charset="utf-8" />
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1"
-/>
-<div id="fps">n/a</div>
-<div class="charts">
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <link href="index.css" rel="stylesheet" type="text/css" />
+    <title>SVG Time Series Demo 2</title>
+  </head>
+  <body>
+    <div id="fps">n/a</div>
+    <div class="charts">
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
     </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
-    </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
-    </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
-    </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
-    </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-</div>
-<script type="module" src="demo2.ts"></script>
-<link href="index.css" type="text/css" rel="stylesheet" />
+    <script type="module" src="demo2.ts"></script>
+  </body>
+</html>

--- a/samples/demos/resetZoom.html
+++ b/samples/demos/resetZoom.html
@@ -1,23 +1,30 @@
 <!doctype html>
-<meta charset="utf-8" />
-<meta
-  name="viewport"
-  content="width=device-width, initial-scale=1, maximum-scale=1"
-/>
-<button id="reset">Reset Zoom</button>
-<div class="charts">
-  <div class="chart">
-    <div class="chart-drawing">
-      <svg></svg>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1"
+    />
+    <link href="index.css" rel="stylesheet" type="text/css" />
+    <title>SVG Time Series Reset Zoom Demo</title>
+  </head>
+  <body>
+    <button id="reset">Reset Zoom</button>
+    <div class="charts">
+      <div class="chart">
+        <div class="chart-drawing">
+          <svg></svg>
+        </div>
+        <div class="chart-legend">
+          <div class="chart-legend__time"></div>
+          <div class="chart-legend__green_caption">NY:</div>
+          <div class="chart-legend__green_value"></div>
+          <div class="chart-legend__blue_caption">SF:</div>
+          <div class="chart-legend__blue_value"></div>
+        </div>
+      </div>
     </div>
-    <div class="chart-legend">
-      <div class="chart-legend__time"></div>
-      <div class="chart-legend__green_caption">NY:</div>
-      <div class="chart-legend__green_value"></div>
-      <div class="chart-legend__blue_caption">SF:</div>
-      <div class="chart-legend__blue_value"></div>
-    </div>
-  </div>
-</div>
-<script type="module" src="resetZoom.ts"></script>
-<link href="index.css" type="text/css" rel="stylesheet" />
+    <script type="module" src="resetZoom.ts"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- wrap demo HTML pages with html/head/body tags
- move meta and link tags into head and add titles
- keep module scripts at end of body

## Testing
- `npm run format`
- `git commit` (runs lint, typecheck, tests)


------
https://chatgpt.com/codex/tasks/task_e_6897ba9d5b7c832b8a61fd344efb21b1