### PR TITLE
feat: validate axis indices

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -86,14 +86,16 @@ export class AxisManager {
     }
 
     for (const i of axisIndices) {
-      const tree = buildAxisTree(data, i);
-      if (i < this.axes.length) {
-        this.axes[i].tree = tree;
+      if (i >= this.axes.length) {
+        throw new Error(
+          `Series axis index ${i} out of bounds (max ${this.axes.length - 1})`,
+        );
       }
-      const targetIdx = i < this.axes.length ? i : this.axes.length - 1;
+      const tree = buildAxisTree(data, i);
+      this.axes[i].tree = tree;
       const dp = data.updateScaleY(bIndex, tree);
       const [min, max] = dp.y().toArr();
-      const domain = domains[targetIdx];
+      const domain = domains[i];
       domain.min = Math.min(domain.min, min);
       domain.max = Math.max(domain.max, max);
     }

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -102,11 +102,10 @@ describe("updateScales", () => {
     expect(axes[2].scale.domain()).toEqual([-5, 5]);
   });
 
-  it("merges extra axes into the last scale", () => {
+  it("throws when a series references an out-of-range axis index", () => {
     const axisManager = new AxisManager();
     axisManager.setXAxis(scaleTime().range([0, 1]));
-    const axes = axisManager.create(2);
-    axes.forEach((a) => a.scale.range([0, 1]));
+    axisManager.create(2).forEach((a) => a.scale.range([0, 1]));
 
     const data = {
       seriesAxes: [0, 1, 2],
@@ -127,9 +126,8 @@ describe("updateScales", () => {
     };
 
     const bIndexVisible = new AR1Basis(0, 1);
-    axisManager.updateScales(bIndexVisible, data as any);
-
-    expect(axes[0].scale.domain()).toEqual([0, 1]);
-    expect(axes[1].scale.domain()).toEqual([-5, 20]);
+    expect(() => axisManager.updateScales(bIndexVisible, data as any)).toThrow(
+      /axis index 2/i,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- validate axis indices to prevent out-of-range series references
- test: assert that invalid axis indices throw

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bae5b5d4832b964279acbde49a80