### PR TITLE
feat: validate zoom scale extent

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -345,4 +345,86 @@ describe("ZoomState", () => {
       /scaleExtent must be two finite, positive numbers/,
     );
   });
+
+  it("rejects scale extents that do not contain exactly two values", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axisRenders: [],
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      state,
+      vi.fn(),
+    );
+
+    expect(() => zs.setScaleExtent([1] as any)).toThrow(
+      /scaleExtent must be two finite, positive numbers/,
+    );
+    expect(() => zs.setScaleExtent([1, 2, 3] as any)).toThrow(
+      /scaleExtent must be two finite, positive numbers/,
+    );
+  });
+
+  it.each([
+    [0, 10],
+    [-1, 10],
+    [1, 1],
+    [5, 3],
+    [1, 0],
+    [1, -5],
+    [Infinity, 10],
+    [NaN, 10],
+    [1, Infinity],
+    [1, NaN],
+  ])("rejects invalid constructor scale extent %j", (min, max) => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axisRenders: [],
+    } as unknown as RenderState;
+
+    expect(
+      () =>
+        new ZoomState(
+          rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+          state,
+          vi.fn(),
+          undefined,
+          { scaleExtent: [min, max] },
+        ),
+    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+  });
+
+  it("rejects constructor scale extents without exactly two values", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axisRenders: [],
+    } as unknown as RenderState;
+
+    expect(
+      () =>
+        new ZoomState(
+          rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+          state,
+          vi.fn(),
+          undefined,
+          { scaleExtent: [1] as any },
+        ),
+    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+    expect(
+      () =>
+        new ZoomState(
+          rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+          state,
+          vi.fn(),
+          undefined,
+          { scaleExtent: [1, 2, 3] as any },
+        ),
+    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+  });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -20,8 +20,15 @@ export class ZoomState {
   private cancelRefresh: () => void;
   private scaleExtent: [number, number];
   private validateScaleExtent(extent: [number, number]) {
+    if (!Array.isArray(extent) || extent.length !== 2) {
+      throw new Error(
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${extent}`,
+      );
+    }
     const [min, max] = extent;
     if (
+      typeof min !== "number" ||
+      typeof max !== "number" ||
       !Number.isFinite(min) ||
       !Number.isFinite(max) ||
       min <= 0 ||
@@ -29,7 +36,7 @@ export class ZoomState {
       min >= max
     ) {
       throw new Error(
-        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${min}, ${max}]`,
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${extent}]`,
       );
     }
   }


### PR DESCRIPTION
## Summary
- validate scale extents for constructor and setter
- test for invalid scale extents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bac79f18832bbd5c92fa4c839b04