### PR TITLE
Add time-to-index conversion with tests

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -173,6 +173,48 @@ describe("ChartData", () => {
     });
   });
 
+  it("converts time to index and back", () => {
+    const cd = new ChartData(
+      makeSource(
+        [
+          [10, 20],
+          [30, 40],
+          [50, 60],
+        ],
+        [0, 1],
+      ),
+    );
+    const transform = cd.indexToTime();
+    for (let i = 0; i < cd.length; i++) {
+      const t = transform.applyToPoint(i);
+      const idx = cd.timeToIndex(t);
+      expect(idx).toBeCloseTo(i);
+      const t2 = transform.applyToPoint(idx);
+      expect(t2).toBeCloseTo(t);
+    }
+  });
+
+  it("clamps out-of-range times and validates input", () => {
+    const cd = new ChartData(
+      makeSource(
+        [
+          [10, 20],
+          [30, 40],
+          [50, 60],
+        ],
+        [0, 1],
+      ),
+    );
+    const transform = cd.indexToTime();
+    const earliest = transform.applyToPoint(0);
+    const latest = transform.applyToPoint(cd.length - 1);
+    expect(cd.timeToIndex(earliest - 1000)).toBe(0);
+    expect(cd.timeToIndex(latest + 1000)).toBe(cd.length - 1);
+    expect(() => cd.timeToIndex(NaN)).toThrow(/time/);
+    expect(() => cd.timeToIndex(Infinity)).toThrow(/time/);
+    expect(() => cd.timeToIndex(-Infinity)).toThrow(/time/);
+  });
+
   it("reflects latest window after multiple appends", () => {
     const cd = new ChartData(
       makeSource(

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -128,6 +128,17 @@ export class ChartData {
     return betweenTBasesAR1(bIndexBase, bTimeBase);
   }
 
+  timeToIndex(time: number): number {
+    if (!Number.isFinite(time)) {
+      throw new Error(
+        "ChartData.timeToIndex requires time to be a finite number",
+      );
+    }
+    const transform = this.indexToTime().inverse();
+    const idx = transform.applyToPoint(time);
+    return this.clampIndex(idx);
+  }
+
   private clampIndex(idx: number): number {
     return Math.min(Math.max(idx, 0), this.window.length - 1);
   }


### PR DESCRIPTION
## Summary
- implement `timeToIndex` using inverse of `indexToTime`
- validate inputs and clamp time-to-index results
- test round-trip consistency, clamping, and input validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bd436ca4832bb98099064d4ce299