### PR TITLE
feat: validate SVG parent in createDimensions

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -81,6 +81,7 @@ function createSvgAndLegend() {
       contentType: "text/html",
     },
   );
+  (globalThis as any).HTMLElement = dom.window.HTMLElement;
   const div = dom.window.document.getElementById("c") as any;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -75,6 +75,7 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
+  (globalThis as any).HTMLElement = dom.window.HTMLElement;
   const div = dom.window.document.getElementById("c") as any;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -86,6 +86,7 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
+  (globalThis as any).HTMLElement = dom.window.HTMLElement;
   const div = dom.window.document.getElementById("c") as any;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -74,6 +74,7 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
+  (globalThis as any).HTMLElement = dom.window.HTMLElement;
   const div = dom.window.document.getElementById("c") as any;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -31,6 +31,30 @@ describe("createDimensions", () => {
     expect(dp.x().toArr()).toEqual([0, width]);
     expect(dp.y().toArr()).toEqual([height, 0]);
   });
+
+  it("throws when SVG lacks a parent", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const selection = select(svg) as unknown as Selection<
+      SVGSVGElement,
+      unknown,
+      HTMLElement,
+      unknown
+    >;
+    expect(() => createDimensions(selection)).toThrow(/HTMLElement parent/);
+  });
+
+  it("throws when parent is not an HTMLElement", () => {
+    const frag = document.createDocumentFragment();
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    frag.appendChild(svg);
+    const selection = select(svg) as unknown as Selection<
+      SVGSVGElement,
+      unknown,
+      HTMLElement,
+      unknown
+    >;
+    expect(() => createDimensions(selection)).toThrow(/HTMLElement parent/);
+  });
 });
 
 describe("updateScaleX", () => {

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -71,6 +71,7 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
+  (globalThis as any).HTMLElement = dom.window.HTMLElement;
   const div = dom.window.document.getElementById("c") as any;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -6,8 +6,17 @@ import type { ChartData } from "../data.ts";
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
 ): DirectProductBasis {
-  const node: SVGSVGElement = svg.node() as SVGSVGElement;
-  const div: HTMLElement = node.parentNode as HTMLElement;
+  const node = svg.node();
+  if (!node) {
+    throw new Error("SVG selection contains no node");
+  }
+
+  const parent = node.parentNode;
+  if (!(parent instanceof HTMLElement)) {
+    throw new Error("SVG element must be attached to an HTMLElement parent");
+  }
+
+  const div = parent;
 
   const width = div.clientWidth;
   const height = div.clientHeight;


### PR DESCRIPTION
## Summary
- ensure `createDimensions` throws when the SVG is missing an `HTMLElement` parent
- cover parentless and non-HTMLElement parents in tests
- update JSDOM-based tests to expose `HTMLElement` globally

## Testing
- `npm run format`
- `git commit -am "feat: validate SVG parent in createDimensions"`


------
https://chatgpt.com/codex/tasks/task_e_6897bd574770832bbd9169d3a4059097