### PR TITLE
Add model-to-screen conversion helpers

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { beforeAll, describe, expect, it } from "vitest";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 
@@ -136,6 +137,39 @@ describe("ViewportTransform", () => {
     const p = (vt as any).toModelPoint(70, 20) as { x: number; y: number };
     expect(p.x).toBeCloseTo(3);
     expect(p.y).toBeCloseTo(2);
+  });
+
+  it("round-trips between screen and model coordinates", () => {
+    const vt = new ViewportTransform();
+
+    vt.onViewPortResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 100),
+        new AR1Basis(0, 100),
+      ),
+    );
+    vt.onReferenceViewWindowResize(
+      DirectProductBasis.fromProjections(
+        new AR1Basis(0, 10),
+        new AR1Basis(0, 10),
+      ),
+    );
+    vt.onZoomPan({ x: 10, k: 2 } as any);
+
+    const xScreen = 70;
+    const xModel = vt.fromScreenToModelX(xScreen);
+    expect(vt.toScreenFromModelX(xModel)).toBeCloseTo(xScreen);
+
+    const yScreen = 20;
+    const yModel = vt.fromScreenToModelY(yScreen);
+    expect(vt.toScreenFromModelY(yModel)).toBeCloseTo(yScreen);
+
+    const basisScreen = new AR1Basis(20, 40);
+    const basisModel = vt.fromScreenToModelBasisX(basisScreen);
+    const roundTrip = vt.toScreenFromModelBasisX(basisModel);
+    const [p1, p2] = roundTrip.toArr();
+    expect(p1).toBeCloseTo(20);
+    expect(p2).toBeCloseTo(40);
   });
 
   it("keeps pan offset constant when scaling", () => {

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -51,6 +51,10 @@ export class ViewportTransform {
     return new DOMPoint(x, y).matrixTransform(this.composedMatrix.inverse());
   }
 
+  private toScreenPoint(x: number, y: number) {
+    return new DOMPoint(x, y).matrixTransform(this.composedMatrix);
+  }
+
   public fromScreenToModelX(x: number) {
     return this.toModelPoint(x, 0).x;
   }
@@ -61,6 +65,20 @@ export class ViewportTransform {
 
   public fromScreenToModelBasisX(b: AR1Basis) {
     const transformPoint = (x: number) => this.toModelPoint(x, 0).x;
+    const [p1, p2] = b.toArr().map(transformPoint);
+    return new AR1Basis(p1, p2);
+  }
+
+  public toScreenFromModelX(x: number) {
+    return this.toScreenPoint(x, 0).x;
+  }
+
+  public toScreenFromModelY(y: number) {
+    return this.toScreenPoint(0, y).y;
+  }
+
+  public toScreenFromModelBasisX(b: AR1Basis) {
+    const transformPoint = (x: number) => this.toScreenPoint(x, 0).x;
     const [p1, p2] = b.toArr().map(transformPoint);
     return new AR1Basis(p1, p2);
   }


### PR DESCRIPTION
## Summary
- add `toScreenPoint` helper and expose model-to-screen conversions
- test round-trip between model and screen coordinates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bd2a01a4832b934e3c9dfe52844a