### PR TITLE
fix: update axis ranges on resize

### DIFF
--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -174,5 +174,7 @@ describe("TimeSeriesChart.resize", () => {
     const arg = resizeSpy.mock.calls[0][0];
     expect(arg.x().toArr()).toEqual([0, 250]);
     expect(arg.y().toArr()).toEqual([120, 0]);
+    expect(chartAny.state.axes.x.scale.range()).toEqual([0, 250]);
+    expect(chartAny.state.axes.y[0].scale.range()).toEqual([120, 0]);
   });
 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -138,6 +138,7 @@ export class TimeSeriesChart {
       bScreenYVisible,
     );
 
+    this.state.axes.x.scale.range([0, width]);
     this.state.bScreenXVisible = bScreenXVisible;
 
     this.state.dimensions.width = width;
@@ -148,6 +149,7 @@ export class TimeSeriesChart {
 
     for (const a of this.state.axes.y) {
       a.transform.onViewPortResize(bScreenVisible);
+      a.scale.range([height, 0]);
     }
 
     this.state.refresh(this.data);


### PR DESCRIPTION
## Summary
- update chart resize to adjust axis scale ranges
- verify axis scale ranges update in resize tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bd1e647c832b9f88ea1263f8bb08