### PR TITLE
refactor: rename render state variables

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -59,7 +59,7 @@ export interface RenderState {
   axisManager: AxisManager;
   axes: Axes;
   axisRenders: AxisRenderState[];
-  bScreenXVisible: AR1Basis;
+  screenXBasis: AR1Basis;
   dimensions: Dimensions;
   series: Series[];
   seriesRenderer: SeriesRenderer;
@@ -70,34 +70,34 @@ export function setupRender(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
   data: ChartData,
 ): RenderState {
-  const bScreenVisibleDp = createDimensions(svg);
-  const bScreenXVisible = bScreenVisibleDp.x();
-  const width = bScreenXVisible.getRange();
-  const height = bScreenVisibleDp.y().getRange();
+  const screenBasis = createDimensions(svg);
+  const screenXBasis = screenBasis.x();
+  const width = screenXBasis.getRange();
+  const height = screenBasis.y().getRange();
   const maxAxisIdx = data.seriesAxes.reduce(
     (max, idx) => Math.max(max, idx),
     0,
   );
   const axisCount = maxAxisIdx + 1;
 
-  const [xRange, yRange] = bScreenVisibleDp.toArr();
+  const [xRange, yRange] = screenBasis.toArr();
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
 
   const axisManager = new AxisManager();
   axisManager.setXAxis(xScale);
-  const axesY = axisManager.create(axisCount);
-  for (const a of axesY) {
+  const yAxes = axisManager.create(axisCount);
+  for (const a of yAxes) {
     a.scale.range(yRange);
   }
   axisManager.updateScales(data.bIndexFull, data);
 
-  const refDp = DirectProductBasis.fromProjections(
+  const referenceBasis = DirectProductBasis.fromProjections(
     data.bIndexFull,
     bPlaceholder,
   );
-  for (const a of axesY) {
-    a.transform.onViewPortResize(bScreenVisibleDp);
-    a.transform.onReferenceViewWindowResize(refDp);
+  for (const a of yAxes) {
+    a.transform.onViewPortResize(screenBasis);
+    a.transform.onReferenceViewWindowResize(referenceBasis);
   }
 
   const seriesManager = new SeriesManager(svg, data.seriesAxes);
@@ -109,11 +109,11 @@ export function setupRender(
     .setTickSize(height)
     .setTickPadding(8 - height);
   xAxis.setScale(xScale);
-  const gX = svg.append("g").attr("class", "axis");
-  gX.call(xAxis.axis.bind(xAxis));
+  const xAxisGroup = svg.append("g").attr("class", "axis");
+  xAxisGroup.call(xAxis.axis.bind(xAxis));
 
   // Build render state for each Y axis separately from the model.
-  const axisRenders: AxisRenderState[] = axesY.map((a, i) => {
+  const axisRenders: AxisRenderState[] = yAxes.map((a, i) => {
     const orientation = i === 0 ? Orientation.Right : Orientation.Left;
     const axis = createYAxis(orientation, a.scale, width);
     const g = svg.append("g").attr("class", "axis");
@@ -121,20 +121,23 @@ export function setupRender(
     return { axis, g };
   });
 
-  const axes: Axes = { x: { axis: xAxis, g: gX, scale: xScale }, y: axesY };
+  const axes: Axes = {
+    x: { axis: xAxis, g: xAxisGroup, scale: xScale },
+    y: yAxes,
+  };
   const dimensions: Dimensions = { width, height };
 
   const state: RenderState = {
     axisManager,
     axes,
     axisRenders,
-    bScreenXVisible,
+    screenXBasis,
     dimensions,
     series,
     seriesRenderer,
     refresh(this: RenderState, data: ChartData) {
       const bIndexVisible = this.axes.y[0].transform.fromScreenToModelBasisX(
-        this.bScreenXVisible,
+        this.screenXBasis,
       );
 
       this.axisManager.updateScales(bIndexVisible, data);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -131,14 +131,14 @@ export class TimeSeriesChart {
     const { width, height } = dimensions;
     this.svg.attr("width", width).attr("height", height);
 
-    const bScreenXVisible = new AR1Basis(0, width);
+    const screenXBasis = new AR1Basis(0, width);
     const bScreenYVisible = new AR1Basis(height, 0);
     const bScreenVisible = DirectProductBasis.fromProjections(
-      bScreenXVisible,
+      screenXBasis,
       bScreenYVisible,
     );
 
-    this.state.bScreenXVisible = bScreenXVisible;
+    this.state.screenXBasis = screenXBasis;
 
     this.state.dimensions.width = width;
     this.state.dimensions.height = height;


### PR DESCRIPTION
## Summary
- rename screen and axis variables in chart rendering for clarity
- update draw logic to use new render state property

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897bcba4640832b9aa4fe219f662f4b