### PR TITLE
refactor: rename render state screen basis

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -139,7 +139,7 @@ export class TimeSeriesChart {
     );
 
     this.state.axes.x.scale.range([0, width]);
-    this.state.bScreenXVisible = bScreenXVisible;
+    this.state.screenXBasis = bScreenXVisible;
 
     this.state.dimensions.width = width;
     this.state.dimensions.height = height;


### PR DESCRIPTION
## Summary
- rename bScreenVisibleDp -> screenBasis and bScreenXVisible -> screenXBasis
- rename axesY -> yAxes and gX -> xAxisGroup
- rename refDp -> referenceBasis and update draw.ts accordingly

## Testing
- `npm run format`
- `git commit -am "refactor: rename render state screen basis"`


------
https://chatgpt.com/codex/tasks/task_e_6897c17961c8832bab0dd6c1cbf7fe19