### PR TITLE
test: remove explicit any from tests

### DIFF
--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
 import type { ILegendController, LegendContext } from "./legend.ts";
@@ -55,7 +55,14 @@ vi.mock("../axis.ts", () => ({
 
 vi.mock("d3-zoom", () => ({
   zoom: () => {
-    const behavior: any = () => {};
+    interface ZoomBehavior {
+      (): void;
+      scaleExtent: () => ZoomBehavior;
+      translateExtent: () => ZoomBehavior;
+      on: () => ZoomBehavior;
+      transform: () => void;
+    }
+    const behavior = (() => {}) as ZoomBehavior;
     behavior.scaleExtent = () => behavior;
     behavior.translateExtent = () => behavior;
     behavior.on = () => behavior;
@@ -97,7 +104,7 @@ function createChart(data: Array<[number]>) {
   };
   const legendController = new StubLegendController();
   const chart = new TimeSeriesChart(
-    select(svgEl) as any,
+    select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
     source,
     legendController,
     () => {},
@@ -109,7 +116,9 @@ function createChart(data: Array<[number]>) {
 
 beforeEach(() => {
   vi.useFakeTimers();
-  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+  (
+    SVGSVGElement.prototype as unknown as { createSVGMatrix: () => Matrix }
+  ).createSVGMatrix = () => new Matrix();
 });
 
 afterEach(() => {

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -1,9 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unused-vars */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
@@ -34,7 +34,7 @@ class Point {
   }
 }
 
-(globalThis as any).DOMPoint = Point;
+(globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;
@@ -46,7 +46,7 @@ vi.mock("../utils/domNodeTransform.ts", () => ({
 }));
 
 let currentDataLength = 0;
-const transformInstances: any[] = [];
+const transformInstances: Array<{ onZoomPan: vi.Mock }> = [];
 vi.mock("../ViewportTransform.ts", () => ({
   ViewportTransform: class {
     constructor() {
@@ -63,7 +63,7 @@ vi.mock("../ViewportTransform.ts", () => ({
   },
 }));
 
-const axisInstances: any[] = [];
+const axisInstances: Array<{ axisUpCalls: number; axisUp: vi.Mock }> = [];
 vi.mock("../axis.ts", () => ({
   Orientation: { Bottom: 0, Right: 1 },
   MyAxis: class {
@@ -84,7 +84,14 @@ vi.mock("../axis.ts", () => ({
 
 vi.mock("d3-zoom", () => ({
   zoom: () => {
-    const behavior: any = () => {};
+    interface ZoomBehavior {
+      (): void;
+      scaleExtent: () => ZoomBehavior;
+      translateExtent: () => ZoomBehavior;
+      on: () => ZoomBehavior;
+      transform: () => void;
+    }
+    const behavior = (() => {}) as ZoomBehavior;
     behavior.scaleExtent = () => behavior;
     behavior.translateExtent = () => behavior;
     behavior.on = () => behavior;
@@ -126,11 +133,11 @@ function createChart(
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };
   const legendController = new LegendController(
-    select(legend) as any,
+    select(legend) as Selection<HTMLElement, unknown, null, undefined>,
     formatTime,
   );
   const chart = new TimeSeriesChart(
-    select(svgEl) as any,
+    select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
     source,
     legendController,
     () => {},
@@ -152,7 +159,9 @@ beforeEach(() => {
   updateNodeCalls = 0;
   transformInstances.length = 0;
   axisInstances.length = 0;
-  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+  (
+    SVGSVGElement.prototype as unknown as { createSVGMatrix: () => Matrix }
+  ).createSVGMatrix = () => new Matrix();
 });
 
 afterEach(() => {
@@ -176,7 +185,9 @@ describe("chart interaction", () => {
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
 
-    zoom({ transform: { x: 10, k: 2 } } as any);
+    zoom({ transform: { x: 10, k: 2 } } as unknown as {
+      transform: { x: number; k: number };
+    });
     vi.runAllTimers();
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
@@ -344,9 +355,11 @@ describe("chart interaction", () => {
       seriesAxes: [0, 1],
       getSeries: (i) => [0, 1][i],
     };
-    const legendController = new LegendController(select(legend) as any);
+    const legendController = new LegendController(
+      select(legend) as Selection<HTMLElement, unknown, null, undefined>,
+    );
     const chart = new TimeSeriesChart(
-      select(svgEl) as any,
+      select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
       source,
       legendController,
       () => {},

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 
 vi.mock("../utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
@@ -9,7 +8,7 @@ vi.mock("../axis.ts", () => {
   return {
     MyAxis: class {
       axisUp = vi.fn();
-      axis = vi.fn((s: any) => s);
+      axis = vi.fn((s: unknown) => s);
       ticks = vi.fn().mockReturnThis();
       setTickSize = vi.fn().mockReturnThis();
       setTickPadding = vi.fn().mockReturnThis();
@@ -20,7 +19,7 @@ vi.mock("../axis.ts", () => {
 });
 
 import { JSDOM } from "jsdom";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { ChartData, type IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
@@ -77,8 +76,8 @@ class Point {
 }
 
 beforeAll(() => {
-  (globalThis as any).DOMMatrix = Matrix;
-  (globalThis as any).DOMPoint = Point;
+  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
+  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
 });
 
 function createSvg() {
@@ -86,11 +85,18 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
-  (globalThis as any).HTMLElement = dom.window.HTMLElement;
-  const div = dom.window.document.getElementById("c") as any;
+  (
+    globalThis as unknown as { HTMLElement: typeof dom.window.HTMLElement }
+  ).HTMLElement = dom.window.HTMLElement;
+  const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  return select(div).select("svg");
+  return select(div).select("svg") as Selection<
+    SVGSVGElement,
+    unknown,
+    HTMLElement,
+    unknown
+  >;
 }
 
 describe("RenderState.refresh", () => {
@@ -105,7 +111,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -133,7 +139,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     const updateNodeMock = vi.mocked(updateNode);
     updateNodeMock.mockClear();
 
@@ -163,7 +169,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
 
     state.refresh(data);
 
@@ -182,7 +188,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
     };
     const data1 = new ChartData(source1);
-    const state = setupRender(svg as any, data1);
+    const state = setupRender(svg, data1);
     state.refresh(data1);
     const source2: IDataSource = {
       startTime: 0,
@@ -214,7 +220,7 @@ describe("RenderState.refresh", () => {
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
 
     expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 1, max: 3 });
 

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -1,10 +1,9 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 
@@ -65,8 +64,8 @@ class Point {
 }
 
 beforeAll(() => {
-  (globalThis as any).DOMMatrix = Matrix;
-  (globalThis as any).DOMPoint = Point;
+  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
+  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
 });
 
 function createSvg() {
@@ -74,11 +73,18 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
-  (globalThis as any).HTMLElement = dom.window.HTMLElement;
-  const div = dom.window.document.getElementById("c") as any;
+  (
+    globalThis as unknown as { HTMLElement: typeof dom.window.HTMLElement }
+  ).HTMLElement = dom.window.HTMLElement;
+  const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  return select(div).select("svg");
+  return select(div).select("svg") as Selection<
+    SVGSVGElement,
+    unknown,
+    HTMLElement,
+    unknown
+  >;
 }
 
 describe("buildSeries", () => {
@@ -93,7 +99,7 @@ describe("buildSeries", () => {
       getSeries: (i) => [1, 2, 3][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     expect(state.series.length).toBe(1);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
   });
@@ -110,7 +116,7 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 0 });
@@ -128,7 +134,7 @@ describe("buildSeries", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     expect(state.series.length).toBe(2);
     expect(state.series[0]).toMatchObject({ axisIdx: 0 });
     expect(state.series[1]).toMatchObject({ axisIdx: 1 });
@@ -148,7 +154,7 @@ describe("setupRender DOM order", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    setupRender(svg as any, data);
+    setupRender(svg, data);
     const groups = svg.selectAll("g").nodes() as SVGGElement[];
     expect(groups[0].classList.contains("view")).toBe(true);
     expect(groups[1].classList.contains("view")).toBe(true);

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { JSDOM } from "jsdom";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 
@@ -62,8 +61,8 @@ class Point {
 }
 
 beforeAll(() => {
-  (globalThis as any).DOMMatrix = Matrix;
-  (globalThis as any).DOMPoint = Point;
+  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
+  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
 });
 
 function createSvg() {
@@ -71,11 +70,18 @@ function createSvg() {
     pretendToBeVisual: true,
     contentType: "text/html",
   });
-  (globalThis as any).HTMLElement = dom.window.HTMLElement;
-  const div = dom.window.document.getElementById("c") as any;
+  (
+    globalThis as unknown as { HTMLElement: typeof dom.window.HTMLElement }
+  ).HTMLElement = dom.window.HTMLElement;
+  const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  return select(div).select("svg");
+  return select(div).select("svg") as Selection<
+    SVGSVGElement,
+    unknown,
+    HTMLElement,
+    unknown
+  >;
 }
 
 describe("setupRender Y-axis modes", () => {
@@ -91,7 +97,7 @@ describe("setupRender Y-axis modes", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     expect(state.axes.y).toHaveLength(1);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
   });
@@ -108,7 +114,7 @@ describe("setupRender Y-axis modes", () => {
         seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
     };
     const data = new ChartData(source);
-    const state = setupRender(svg as any, data);
+    const state = setupRender(svg, data);
     expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
     expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
   });

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeAll } from "vitest";
 import { scaleTime } from "d3-scale";
 import {
@@ -7,6 +6,7 @@ import {
   betweenTBasesAR1,
 } from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
+import type { ChartData } from "./data.ts";
 
 class Matrix {
   constructor(
@@ -65,8 +65,8 @@ class Point {
 }
 
 beforeAll(() => {
-  (globalThis as any).DOMMatrix = Matrix;
-  (globalThis as any).DOMPoint = Point;
+  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
+  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
 });
 
 describe("updateScales", () => {
@@ -87,7 +87,12 @@ describe("updateScales", () => {
       indexToTime() {
         return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
       },
-      updateScaleY(b: AR1Basis, tree: any) {
+      updateScaleY(
+        b: AR1Basis,
+        tree: {
+          query: (start: number, end: number) => { min: number; max: number };
+        },
+      ) {
         const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
@@ -95,7 +100,7 @@ describe("updateScales", () => {
     };
 
     const bIndexVisible = new AR1Basis(0, 1);
-    axisManager.updateScales(bIndexVisible, data as any);
+    axisManager.updateScales(bIndexVisible, data as unknown as ChartData);
 
     expect(axes[0].scale.domain()).toEqual([1, 3]);
     expect(axes[1].scale.domain()).toEqual([10, 30]);
@@ -118,7 +123,12 @@ describe("updateScales", () => {
       indexToTime() {
         return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
       },
-      updateScaleY(b: AR1Basis, tree: any) {
+      updateScaleY(
+        b: AR1Basis,
+        tree: {
+          query: (start: number, end: number) => { min: number; max: number };
+        },
+      ) {
         const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
@@ -126,8 +136,8 @@ describe("updateScales", () => {
     };
 
     const bIndexVisible = new AR1Basis(0, 1);
-    expect(() => axisManager.updateScales(bIndexVisible, data as any)).toThrow(
-      /axis index 2/i,
-    );
+    expect(() =>
+      axisManager.updateScales(bIndexVisible, data as unknown as ChartData),
+    ).toThrow(/axis index 2/i);
   });
 });

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { select, Selection } from "d3-selection";
 import type { RenderState } from "./render.ts";
@@ -63,8 +62,8 @@ describe("ZoomState.destroy", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } as any }],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -102,8 +101,8 @@ describe("ZoomState.destroy", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } as any }],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
       },
       axisRenders: [],
     } as unknown as RenderState;

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { select, Selection } from "d3-selection";
 import type { RenderState } from "./render.ts";
@@ -57,8 +56,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any, { transform: y2 } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }, { transform: y2 }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -95,8 +94,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -130,8 +129,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -166,8 +165,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -202,8 +201,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -243,8 +242,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -281,8 +280,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -395,12 +394,12 @@ describe("ZoomState", () => {
       vi.fn(),
     );
 
-    expect(() => zs.setScaleExtent([1] as any)).toThrow(
+    expect(() => zs.setScaleExtent([1] as unknown as [number, number])).toThrow(
       /scaleExtent must be two finite, positive numbers/,
     );
-    expect(() => zs.setScaleExtent([1, 2, 3] as any)).toThrow(
-      /scaleExtent must be two finite, positive numbers/,
-    );
+    expect(() =>
+      zs.setScaleExtent([1, 2, 3] as unknown as [number, number]),
+    ).toThrow(/scaleExtent must be two finite, positive numbers/);
   });
 
   it.each([
@@ -449,7 +448,7 @@ describe("ZoomState", () => {
           state,
           vi.fn(),
           undefined,
-          { scaleExtent: [1] as any },
+          { scaleExtent: [1] as unknown as [number, number] },
         ),
     ).toThrow(/scaleExtent must be two finite, positive numbers/);
     expect(
@@ -459,7 +458,7 @@ describe("ZoomState", () => {
           state,
           vi.fn(),
           undefined,
-          { scaleExtent: [1, 2, 3] as any },
+          { scaleExtent: [1, 2, 3] as unknown as [number, number] },
         ),
     ).toThrow(/scaleExtent must be two finite, positive numbers/);
   });

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { select, Selection } from "d3-selection";
 import type { RenderState } from "./render.ts";
@@ -56,8 +55,8 @@ describe("ZoomState transform state", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
-        x: { axis: {} as any, g: {} as any, scale: {} as any },
-        y: [{ transform: y } as any],
+        x: { axis: {}, g: {}, scale: {} },
+        y: [{ transform: y }],
       },
       axisRenders: [],
     } as unknown as RenderState;
@@ -78,7 +77,12 @@ describe("ZoomState transform state", () => {
     vi.runAllTimers();
 
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 1, k: 2 });
-    expect((zs as any).currentPanZoomTransformState).toBeNull();
+    interface ZoomStateInternal {
+      currentPanZoomTransformState: unknown;
+    }
+    expect(
+      (zs as unknown as ZoomStateInternal).currentPanZoomTransformState,
+    ).toBeNull();
 
     transformSpy.mockClear();
     refresh.mockClear();


### PR DESCRIPTION
## Summary
- drop file-level `no-explicit-any` disables across test suite
- replace `any` in mocks and stubs with interfaces or `unknown`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c41a72f8832b8c5551fec048476b