### PR TITLE
feat: allow optional axis group

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -105,8 +105,10 @@ export class TimeSeriesChart {
     }
     this.state.series.length = 0;
     const axisX = this.state.axes.x;
-    axisX.g.remove();
-    (axisX as unknown as { g?: typeof axisX.g }).g = undefined;
+    if (axisX.g) {
+      axisX.g.remove();
+      axisX.g = undefined;
+    }
 
     for (const r of this.state.axisRenders) {
       r.g.remove();


### PR DESCRIPTION
## Summary
- allow AxisData to store optional SVG group
- update render logic to handle missing group
- clean up axis group without casting

## Testing
- `npm run typecheck --workspace=svg-time-series`


------
https://chatgpt.com/codex/tasks/task_e_68984a01e8ec832b812badfa344aa562