### PR TITLE
chore: enforce stricter lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,13 +13,13 @@ export default tsEslint.config(
   {
     rules: {
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/no-empty-object-type": "warn",
-      "@typescript-eslint/no-unused-vars": "warn",
-      "@typescript-eslint/no-unsafe-function-type": "warn",
+      "@typescript-eslint/no-empty-object-type": "error",
+      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-unsafe-function-type": "error",
       "@typescript-eslint/no-non-null-assertion": "off",
-      "@typescript-eslint/no-useless-constructor": "warn",
-      "prefer-const": "off",
-      "prefer-spread": "warn",
+      "@typescript-eslint/no-useless-constructor": "error",
+      "prefer-const": "error",
+      "prefer-spread": "error",
     },
   },
   {

--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -150,19 +150,19 @@ export class MyAxis {
       positions.push((this.scale2.bandwidth ? center : id)(this.scale2.copy()));
     }
     let tick = context
-        .selectAll<SVGGElement, [number, number]>(".tick")
-        .data(values, (d: [number, number]) =>
-          d[1] === 0 ? this.scale1(d[0]) : (this.scale2 as ScaleType)(d[0]),
-        )
-        .order(),
-      tickExit = tick.exit(),
-      tickEnter = tick.enter().append("g").attr("class", "tick"),
-      line = tick.select<SVGLineElement>("line"),
-      text = tick.select<SVGTextElement>("text"),
-      k =
-        this.orient === Orientation.Top || this.orient === Orientation.Left
-          ? -1
-          : 1;
+      .selectAll<SVGGElement, [number, number]>(".tick")
+      .data(values, (d: [number, number]) =>
+        d[1] === 0 ? this.scale1(d[0]) : (this.scale2 as ScaleType)(d[0]),
+      )
+      .order();
+    const tickExit = tick.exit();
+    const tickEnter = tick.enter().append("g").attr("class", "tick");
+    let line = tick.select<SVGLineElement>("line");
+    let text = tick.select<SVGTextElement>("text");
+    const k =
+      this.orient === Orientation.Top || this.orient === Orientation.Left
+        ? -1
+        : 1;
     let x = "";
     const y =
       this.orient === Orientation.Left || this.orient === Orientation.Right
@@ -236,15 +236,15 @@ export class MyAxis {
       positions.push((this.scale2.bandwidth ? center : id)(this.scale2.copy()));
     }
     let tick = context
-        .selectAll<SVGGElement, [number, number]>(".tick")
-        .data(values, (d: [number, number]) =>
-          d[1] === 0 ? this.scale1(d[0]) : (this.scale2 as ScaleType)(d[0]),
-        )
-        .order(),
-      tickExit = tick.exit(),
-      tickEnter = tick.enter().append("g").attr("class", "tick"),
-      line = tick.select<SVGLineElement>("line"),
-      text = tick.select<SVGTextElement>("text");
+      .selectAll<SVGGElement, [number, number]>(".tick")
+      .data(values, (d: [number, number]) =>
+        d[1] === 0 ? this.scale1(d[0]) : (this.scale2 as ScaleType)(d[0]),
+      )
+      .order();
+    const tickExit = tick.exit();
+    const tickEnter = tick.enter().append("g").attr("class", "tick");
+    let line = tick.select<SVGLineElement>("line");
+    let text = tick.select<SVGTextElement>("text");
 
     let x = "";
     const y =


### PR DESCRIPTION
## Summary
- escalate several TypeScript eslint rules and prefer-const/spread to errors
- adjust axis tick rendering code to satisfy prefer-const

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68985119cc2c832b9da2f0c2eec0e7fe