### PR TITLE
refactor: unify axis tree reduction

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -36,18 +36,11 @@ export function buildAxisTree(
   axis: number,
 ): SegmentTree<IMinMax> {
   const idxs = data.seriesByAxis[axis] ?? [];
-  const arr = data.data.map((row) => {
-    let min = Infinity;
-    let max = -Infinity;
-    for (const j of idxs) {
-      const val = row[j];
-      if (Number.isFinite(val)) {
-        if (val < min) min = val;
-        if (val > max) max = val;
-      }
-    }
-    return min !== Infinity ? ({ min, max } as IMinMax) : minMaxIdentity;
-  });
+  const arr = data.data.map((row) =>
+    idxs
+      .map((j) => ({ min: row[j], max: row[j] }))
+      .reduce(buildMinMax, minMaxIdentity),
+  );
   return new SegmentTree(arr, buildMinMax, minMaxIdentity);
 }
 


### PR DESCRIPTION
## Summary
- map axis row values to min/max monoid elements before reducing, aligning `buildAxisTree` with the segment tree's min/max monoid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68984996df24832ba749984ce7351e38