### PR TITLE
refactor axis tree with monoid

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -36,18 +36,14 @@ export function buildAxisTree(
   axis: number,
 ): SegmentTree<IMinMax> {
   const idxs = data.seriesByAxis[axis] ?? [];
-  const arr = data.data.map((row) => {
-    let min = Infinity;
-    let max = -Infinity;
-    for (const j of idxs) {
-      const val = row[j]!;
-      if (Number.isFinite(val)) {
-        if (val < min) min = val;
-        if (val > max) max = val;
-      }
-    }
-    return min !== Infinity ? ({ min, max } as IMinMax) : minMaxIdentity;
-  });
+  const arr = data.data.map((row) =>
+    idxs
+      .map((j) => {
+        const v = row[j]!;
+        return { min: v, max: v } as IMinMax;
+      })
+      .reduce(buildMinMax, minMaxIdentity),
+  );
   return new SegmentTree(arr, buildMinMax, minMaxIdentity);
 }
 


### PR DESCRIPTION
## Summary
- refactor `buildAxisTree` to map series values to monoid elements and reduce with the segment tree's `buildMinMax`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68985499cfe0832b937e583f5dc99741