### PR TITLE
feat: support LegendPoint union

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -78,27 +78,18 @@ export class LegendController implements ILegendController {
   }
 
   private update() {
-    const rawPoint = this.context.getPoint(this.highlightedDataIdx) as unknown;
-    let values: number[] | undefined;
-    let timestamp: number | undefined;
+    const rawPoint = this.context.getPoint(this.highlightedDataIdx);
+    let values: number[];
+    let timestamp: number;
+
     if (Array.isArray(rawPoint)) {
-      const arr = rawPoint as number[];
-      timestamp = arr[0];
-      values = arr.slice(1);
-    } else if (
-      rawPoint &&
-      typeof rawPoint === "object" &&
-      "values" in (rawPoint as Record<string, unknown>) &&
-      "timestamp" in (rawPoint as Record<string, unknown>)
-    ) {
-      ({ values, timestamp } = rawPoint as {
-        values: number[];
-        timestamp: number;
-      });
-    }
-    if (!values || timestamp === undefined) {
+      [timestamp, ...values] = rawPoint;
+    } else if (rawPoint && Array.isArray(rawPoint.values)) {
+      ({ timestamp, values } = rawPoint);
+    } else {
       return;
     }
+
     const greenData = values[0];
     const blueData = values[1];
     this.legendTime.text(this.formatTime(timestamp));

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -5,8 +5,12 @@ export interface LegendSeriesInfo {
   transform: ViewportTransform;
 }
 
+export type LegendPoint =
+  | { values: number[]; timestamp: number }
+  | [number, ...number[]];
+
 export interface LegendContext {
-  getPoint(idx: number): { values: number[]; timestamp: number };
+  getPoint(idx: number): LegendPoint;
   length: number;
   series: readonly LegendSeriesInfo[];
 }


### PR DESCRIPTION
## Summary
- allow legend points to be tuples or objects
- update LegendController to use a discriminated union when parsing points

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988b8baa8c832bbfae3521f657ccf3