### PR TITLE
test: centralize DOM polyfills

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -1,8 +1,8 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-non-null-assertion */
-import { describe, it, expect, vi, beforeAll } from "vitest";
+
+import { describe, it, expect, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 
@@ -10,68 +10,7 @@ import { LegendController } from "./LegendController.ts";
 import { ChartData, IDataSource } from "../svg-time-series/src/chart/data.ts";
 import { setupRender } from "../svg-time-series/src/chart/render.ts";
 import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as any).DOMMatrix = Matrix;
-  (globalThis as any).DOMPoint = Point;
-  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
-});
+import { Matrix, Point } from "../test/setupDom.ts";
 
 function createSvgAndLegend() {
   const dom = new JSDOM(

--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -1,68 +1,10 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+import "../../test/setupDom.ts";
 import { beforeAll, describe, expect, it } from "vitest";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return new Matrix(1, 0, 0, 1, tx, ty).multiply(this);
-  }
-
-  scale(sx: number, sy: number) {
-    return new Matrix(sx, 0, 0, sy, 0, 0).multiply(this);
-  }
-
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
 
 let ViewportTransform: typeof import("./ViewportTransform.ts").ViewportTransform;
 
 beforeAll(async () => {
-  (globalThis as any).DOMMatrix = Matrix;
-  (globalThis as any).DOMPoint = Point;
   ({ ViewportTransform } = await import("./ViewportTransform.ts"));
 });
 

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -1,0 +1,63 @@
+class Matrix {
+  constructor(
+    public a = 1,
+    public b = 0,
+    public c = 0,
+    public d = 1,
+    public e = 0,
+    public f = 0,
+  ) {}
+
+  multiply(m: Matrix) {
+    return new Matrix(
+      this.a * m.a + this.c * m.b,
+      this.b * m.a + this.d * m.b,
+      this.a * m.c + this.c * m.d,
+      this.b * m.c + this.d * m.d,
+      this.a * m.e + this.c * m.f + this.e,
+      this.b * m.e + this.d * m.f + this.f,
+    );
+  }
+
+  translate(tx: number, ty: number) {
+    return new Matrix(1, 0, 0, 1, tx, ty).multiply(this);
+  }
+
+  scale(sx: number, sy: number) {
+    return new Matrix(sx, 0, 0, sy, 0, 0).multiply(this);
+  }
+
+  inverse() {
+    const det = this.a * this.d - this.b * this.c;
+    return new Matrix(
+      this.d / det,
+      -this.b / det,
+      -this.c / det,
+      this.a / det,
+      (this.c * this.f - this.d * this.e) / det,
+      (this.b * this.e - this.a * this.f) / det,
+    );
+  }
+}
+
+class Point {
+  constructor(
+    public x = 0,
+    public y = 0,
+  ) {}
+
+  matrixTransform(m: Matrix) {
+    return new Point(
+      this.x * m.a + this.y * m.c + m.e,
+      this.x * m.b + this.y * m.d + m.f,
+    );
+  }
+}
+
+(globalThis as any).DOMMatrix = Matrix;
+(globalThis as any).DOMPoint = Point;
+if (typeof SVGSVGElement !== "undefined") {
+  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+}
+
+export { Matrix, Point };


### PR DESCRIPTION
## Summary
- add shared DOM polyfill utility for tests
- consume DOM polyfill in LegendController and ViewportTransform tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68988b985edc832b8dbe2f69a4e5674c