### PR TITLE
chore: enable strict optional checking

### DIFF
--- a/segment-tree-rmq/bench/segmentTree.bench.ts
+++ b/segment-tree-rmq/bench/segmentTree.bench.ts
@@ -22,7 +22,7 @@ describe("SegmentTree performance", () => {
   let ui = 0;
 
   bench("update", () => {
-    tree.update(updateIndices[ui], random());
+    tree.update(updateIndices[ui]!, random());
     ui = (ui + 1) % updateIndices.length;
   });
 
@@ -34,7 +34,7 @@ describe("SegmentTree performance", () => {
   let qi = 0;
 
   bench("query", () => {
-    const [l, r] = queryRanges[qi];
+    const [l, r] = queryRanges[qi]!;
     tree.query(l, r);
     qi = (qi + 1) % queryRanges.length;
   });

--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -44,7 +44,7 @@ export class MyAxis {
   private tickPadding: number;
   private orient: Orientation;
   private scale1: ScaleType;
-  private scale2?: ScaleType;
+  private scale2: ScaleType | undefined;
 
   constructor(orient: Orientation, scale1: ScaleType, scale2?: ScaleType) {
     this.orient = orient;

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -106,7 +106,7 @@ export class TimeSeriesChart {
     this.state.series.length = 0;
     const axisX = this.state.axes.x;
     axisX.g.remove();
-    (axisX as unknown as { g?: typeof axisX.g }).g = undefined;
+    delete (axisX as unknown as { g?: typeof axisX.g }).g;
 
     for (const r of this.state.axisRenders) {
       r.g.remove();

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "useDefineForClassFields": true,
-    "skipLibCheck": true,
     "module": "ESNext",
     "esModuleInterop": true,
     "lib": ["dom", "es7"],
@@ -12,6 +11,8 @@
     "isolatedModules": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "strict": true
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
## Summary
- tighten TypeScript checks by enabling `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`
- adjust code for new strict options

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68988ec593b4832ba1f52370208880b7