### PR TITLE
chore: enforce no-explicit-any and refactor types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default tsEslint.config(
   prettierConfig,
   {
     rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-empty-object-type": "error",
       "@typescript-eslint/no-unused-vars": "error",
       "@typescript-eslint/no-unsafe-function-type": "error",
@@ -25,5 +25,8 @@ export default tsEslint.config(
   {
     files: ["**/*.test.ts"],
     ...vitest.configs.recommended,
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
   },
 );

--- a/svg-time-series/bench/viewportTransform.bench.ts
+++ b/svg-time-series/bench/viewportTransform.bench.ts
@@ -60,8 +60,12 @@ class Point {
 }
 
 // polyfill DOMMatrix and DOMPoint for Node environment
-(globalThis as any).DOMMatrix = Matrix;
-(globalThis as any).DOMPoint = Point;
+const globalObj = globalThis as typeof globalThis & {
+  DOMMatrix: typeof Matrix;
+  DOMPoint: typeof Point;
+};
+globalObj.DOMMatrix = Matrix;
+globalObj.DOMPoint = Point;
 
 describe("ViewportTransform performance", () => {
   const vt = new ViewportTransform();

--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -11,7 +11,7 @@ const formatIdentity = (d: number | Date) => `${d}`;
 
 function center(scale: ScaleType) {
   const width = (scale.bandwidth?.() ?? 0) / 2;
-  return (d: number | Date) => scale(d as any) + width;
+  return (d: number | Date) => scale(d) + width;
 }
 
 type PositionFn<D> = (d: D) => number;
@@ -207,8 +207,10 @@ export class MyAxis {
             ? "end"
             : "middle",
       )
-      .each(function (this: SVGGElement) {
-        (this as any).__axis = positions[0];
+      .each(function (
+        this: SVGGElement & { __axis?: PositionFn<number | Date> },
+      ) {
+        this.__axis = positions[0]!;
       });
   }
 

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -54,10 +54,18 @@ class Point {
   }
 }
 
-(globalThis as any).DOMMatrix = Matrix;
-(globalThis as any).DOMPoint = Point;
+const globalObj = globalThis as typeof globalThis & {
+  DOMMatrix: typeof Matrix;
+  DOMPoint: typeof Point;
+};
+globalObj.DOMMatrix = Matrix;
+globalObj.DOMPoint = Point;
 if (typeof SVGSVGElement !== "undefined") {
-  (SVGSVGElement.prototype as any).createSVGMatrix = () => new Matrix();
+  (
+    SVGSVGElement.prototype as SVGSVGElement & {
+      createSVGMatrix: () => Matrix;
+    }
+  ).createSVGMatrix = () => new Matrix();
 }
 
 export { Matrix, Point };


### PR DESCRIPTION
## Summary
- enforce `@typescript-eslint/no-explicit-any` across sources and allow it only in tests
- replace remaining `any` usages in source and helper files with typed constructs
- update DOM polyfills for tests and benchmarks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689894538f0c832ba0e109183041be71