### PR TITLE
fix: display both series in demo

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -108,10 +108,7 @@ export function loadAndDraw(seriesAxes: number[] = [0, 0]) {
     };
     resize.eval = function () {
       selectAll("svg").remove();
-      selectAll(".chart-drawing")
-        .append("svg")
-        .append("g")
-        .attr("class", "view");
+      selectAll(".chart-drawing").append("svg");
       drawCharts(data, seriesAxes);
     };
   });


### PR DESCRIPTION
## Summary
- fix demo resize logic to avoid extra placeholder view that hid the second series

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689899a53138832ba3d173719417d341