### PR TITLE
Fix axis range computation for series with data gaps

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -40,7 +40,7 @@ export function buildAxisTree(
     idxs
       .map((j) => {
         const v = row[j]!;
-        return { min: v, max: v } as IMinMax;
+        return Number.isFinite(v) ? { min: v, max: v } : minMaxIdentity;
       })
       .reduce(buildMinMax, minMaxIdentity),
   );

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { ChartData, IDataSource } from "./data.ts";
 import { buildAxisTree } from "./axisManager.ts";
 import { AR1Basis } from "../math/affine.ts";
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 describe("ChartData", () => {
   const makeSource = (data: number[][], seriesAxes: number[]): IDataSource => ({
@@ -436,6 +435,12 @@ describe("ChartData", () => {
           ),
         ),
     ).not.toThrow();
+  });
+
+  it("ignores NaN values when building axis tree", () => {
+    const cd = new ChartData(makeSource([[1], [NaN], [3]], [0]));
+    const tree = buildAxisTree(cd, 0);
+    expect(tree.query(0, 2)).toEqual({ min: 1, max: 3 });
   });
 
   describe("single-axis", () => {


### PR DESCRIPTION
## Summary
- ignore NaN values when building axis segment trees so y-axis ranges reflect actual data
- add unit test verifying axis tree skips NaNs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898a0b996fc832b9d54f1e47f7fda67