### PR TITLE
fix: correct DOMMatrix conversion in onZoomPan

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -42,7 +42,7 @@ export class ViewportTransform {
   }
 
   public onZoomPan(t: ZoomTransform): this {
-    this.zoomTransform = new DOMMatrix().scale(t.k, 1).translate(t.x, 0);
+    this.zoomTransform = new DOMMatrix().translate(t.x, 0).scale(t.k, 1);
     this.updateComposedMatrix();
     return this;
   }

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -20,11 +20,11 @@ class Matrix {
   }
 
   translate(tx: number, ty: number) {
-    return new Matrix(1, 0, 0, 1, tx, ty).multiply(this);
+    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
   }
 
   scale(sx: number, sy: number) {
-    return new Matrix(sx, 0, 0, sy, 0, 0).multiply(this);
+    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
   }
 
   inverse() {


### PR DESCRIPTION
## Summary
- fix zoomPan transform order by translating before scaling
- adjust DOMMatrix test polyfill to use post-multiplication like the real API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c900cce0832b857ea1c7938cdd3b