### PR TITLE
chore: tighten tsconfig strictness

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
     "useDefineForClassFields": true,
     "module": "ESNext",
     "esModuleInterop": true,
-    "lib": ["dom", "es7"],
+    "lib": ["dom", "es2022"],
     "target": "ES2022",
     "noImplicitAny": true,
     "moduleResolution": "bundler",
@@ -13,6 +13,10 @@
     "noEmit": true,
     "strict": true,
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
## Summary
- replace deprecated es7 lib target with es2022
- enable additional TypeScript strictness checks

## Testing
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6898d97fc5e0832b98b8488535949b44