### PR TITLE
refactor: remove any casts from viewport transform tests

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -1,5 +1,6 @@
 import "../../test/setupDom.ts";
 import { beforeAll, describe, expect, it } from "vitest";
+import { zoomIdentity } from "d3-zoom";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 
 let ViewportTransform: typeof import("./ViewportTransform.ts").ViewportTransform;
@@ -30,7 +31,7 @@ describe("ViewportTransform", () => {
     expect(vt.fromScreenToModelY(20)).toBeCloseTo(2);
 
     // apply zoom: translate 10 and scale 2 on X
-    vt.onZoomPan({ x: 10, k: 2 } as any);
+    vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
     expect(vt.fromScreenToModelX(70)).toBeCloseTo(3);
     // Y axis unaffected by zoom transform
     expect(vt.fromScreenToModelY(20)).toBeCloseTo(2);
@@ -51,7 +52,7 @@ describe("ViewportTransform", () => {
         new AR1Basis(0, 10),
       ),
     );
-    vt.onZoomPan({ x: 10, k: 2 } as any);
+    vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const basis = vt.fromScreenToModelBasisX(new AR1Basis(20, 40));
     const [p1, p2] = basis.toArr();
@@ -74,11 +75,12 @@ describe("ViewportTransform", () => {
         new AR1Basis(0, 10),
       ),
     );
-    vt.onZoomPan({ x: 10, k: 2 } as any);
+    vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
-    const p = (vt as any).toModelPoint(70, 20) as { x: number; y: number };
-    expect(p.x).toBeCloseTo(3);
-    expect(p.y).toBeCloseTo(2);
+    const x = vt.fromScreenToModelX(70);
+    const y = vt.fromScreenToModelY(20);
+    expect(x).toBeCloseTo(3);
+    expect(y).toBeCloseTo(2);
   });
 
   it("round-trips between screen and model coordinates", () => {
@@ -96,7 +98,7 @@ describe("ViewportTransform", () => {
         new AR1Basis(0, 10),
       ),
     );
-    vt.onZoomPan({ x: 10, k: 2 } as any);
+    vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const xScreen = 70;
     const xModel = vt.fromScreenToModelX(xScreen);
@@ -116,9 +118,9 @@ describe("ViewportTransform", () => {
 
   it("keeps pan offset constant when scaling", () => {
     const vt = new ViewportTransform();
-    vt.onZoomPan({ x: 50, k: 1 } as any);
+    vt.onZoomPan(zoomIdentity.translate(50, 0));
     const t1 = vt.matrix.e;
-    vt.onZoomPan({ x: 50, k: 2 } as any);
+    vt.onZoomPan(zoomIdentity.translate(50, 0).scale(2));
     const t2 = vt.matrix.e;
     expect(t1).toBeCloseTo(50);
     expect(t2).toBeCloseTo(50);


### PR DESCRIPTION
## Summary
- use `zoomIdentity` for zoom/pan transforms in `ViewportTransform` tests
- drop `any` casts by relying on dedicated coordinate helpers

## Testing
- `git commit -am "refactor: remove any casts from viewport transform tests" && git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6898d97676b8832b8852f787530f9379