### PR TITLE
test: type DOMMatrix in view zoom transform test

### DIFF
--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -117,10 +117,10 @@ describe("viewZoomTransform helpers", () => {
   });
 
   it("updates SVG node transform with a matrix", () => {
-    const calls: any[] = [];
+    const calls: DOMMatrix[] = [];
     const baseVal = {
-      createSVGTransformFromMatrix: (m: any) => ({ m }),
-      initialize(t: any) {
+      createSVGTransformFromMatrix: (m: DOMMatrix) => ({ m }),
+      initialize(t: { m: DOMMatrix }) {
         calls.push(t.m);
       },
     };


### PR DESCRIPTION
## Summary
- replace loose `any` typing in viewZoomTransform tests with `DOMMatrix`
- type `createSVGTransformFromMatrix` and `initialize` mock parameters

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898d9704bc4832ba59a807eb70984cc