### PR TITLE
refactor: centralize DOMMatrix and DOMPoint stubs

### DIFF
--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -7,22 +7,8 @@ import { select, type Selection } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
 import type { ILegendController, LegendContext } from "./legend.ts";
-
-class Matrix {
-  constructor(
-    public tx = 0,
-    public ty = 0,
-  ) {}
-  translate(tx: number, ty: number) {
-    return new Matrix(this.tx + tx, this.ty + ty);
-  }
-  scaleNonUniform(_sx: number, _sy: number) {
-    return this;
-  }
-  multiply(_m: Matrix) {
-    return this;
-  }
-}
+import "../../../test/setupDom.ts";
+import type { Matrix } from "../../../test/setupDom.ts";
 
 vi.mock("../utils/domNodeTransform.ts", () => ({
   updateNode: (_node: SVGGraphicsElement, _matrix: Matrix) => {},
@@ -116,9 +102,6 @@ function createChart(data: Array<[number]>) {
 
 beforeEach(() => {
   vi.useFakeTimers();
-  (
-    SVGSVGElement.prototype as unknown as { createSVGMatrix: () => Matrix }
-  ).createSVGMatrix = () => new Matrix();
 });
 
 afterEach(() => {

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-unused-vars, @typescript-eslint/no-useless-constructor */
+/* eslint-disable @typescript-eslint/no-useless-constructor */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
@@ -11,22 +11,8 @@ import {
   type IZoomStateOptions,
 } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
-
-class Matrix {
-  constructor(
-    public tx = 0,
-    public ty = 0,
-  ) {}
-  translate(tx: number, ty: number) {
-    return new Matrix(this.tx + tx, this.ty + ty);
-  }
-  scaleNonUniform(_sx: number, _sy: number) {
-    return this;
-  }
-  multiply(_m: Matrix) {
-    return this;
-  }
-}
+import "../../../test/setupDom.ts";
+import type { Matrix } from "../../../test/setupDom.ts";
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 vi.mock("../utils/domNodeTransform.ts", () => ({
@@ -169,9 +155,6 @@ beforeEach(() => {
   nodeTransforms.clear();
   transformInstances.length = 0;
   zoomOptions = undefined;
-  (
-    SVGSVGElement.prototype as unknown as { createSVGMatrix: () => Matrix }
-  ).createSVGMatrix = () => new Matrix();
 });
 
 afterEach(() => {

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -1,40 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unused-vars */
+
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
-
-class Matrix {
-  constructor(
-    public tx = 0,
-    public ty = 0,
-  ) {}
-  translate(tx: number, ty: number) {
-    return new Matrix(this.tx + tx, this.ty + ty);
-  }
-  scaleNonUniform(_sx: number, _sy: number) {
-    return this;
-  }
-  multiply(_m: Matrix) {
-    return this;
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-  matrixTransform(m: Matrix) {
-    return new Point(this.x + m.tx, this.y + m.ty);
-  }
-}
-
-(globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
+import { Matrix } from "../../../test/setupDom.ts";
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -1,40 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-unused-vars */
+
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { select, type Selection } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
 import { TimeSeriesChart, IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
-
-class Matrix {
-  constructor(
-    public tx = 0,
-    public ty = 0,
-  ) {}
-  translate(tx: number, ty: number) {
-    return new Matrix(this.tx + tx, this.ty + ty);
-  }
-  scaleNonUniform(_sx: number, _sy: number) {
-    return this;
-  }
-  multiply(_m: Matrix) {
-    return this;
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-  matrixTransform(m: Matrix) {
-    return new Point(this.x + m.tx, this.y + m.ty);
-  }
-}
-
-(globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
+import { Matrix } from "../../../test/setupDom.ts";
 
 const nodeTransforms = new Map<SVGGraphicsElement, Matrix>();
 let updateNodeCalls = 0;

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -1,73 +1,13 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import * as domNode from "../utils/domNodeTransform.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
-  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
-});
+import "../../../test/setupDom.ts";
 
 function createSvg() {
   const dom = new JSDOM(`<div id="c"><svg></svg></div>`, {

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
 vi.mock("../axis.ts", () => {
@@ -23,62 +23,7 @@ import { select, type Selection } from "d3-selection";
 import { ChartData, type IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
-  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
-});
+import "../../../test/setupDom.ts";
 
 function createSvg() {
   const dom = new JSDOM(`<div id="c"><svg></svg></div>`, {

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -1,72 +1,12 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
-  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
-});
+import "../../../test/setupDom.ts";
 
 function createSvg() {
   const dom = new JSDOM(`<div id="c"><svg></svg></div>`, {

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -1,69 +1,9 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
 import { select, type Selection } from "d3-selection";
 import { ChartData, IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
-  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
-});
+import "../../../test/setupDom.ts";
 
 function createSvg() {
   const dom = new JSDOM(`<div id="c"><svg></svg></div>`, {

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeAll, vi } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 vi.mock("../utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
 interface AxisMock {
@@ -28,62 +28,7 @@ vi.mock("../axis.ts", () => {
 import { select, type Selection } from "d3-selection";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 import { TimeSeriesChart, type IDataSource } from "../draw.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
-  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
-});
+import "../../../test/setupDom.ts";
 
 describe("TimeSeriesChart.resize", () => {
   it("updates axes, paths, and legend", () => {

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { scaleTime } from "d3-scale";
 import {
   AR1Basis,
@@ -7,67 +7,7 @@ import {
 } from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
 import type { ChartData } from "./data.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-
-  inverse() {
-    const det = this.a * this.d - this.b * this.c;
-    return new Matrix(
-      this.d / det,
-      -this.b / det,
-      -this.c / det,
-      this.a / det,
-      (this.c * this.f - this.d * this.e) / det,
-      (this.b * this.e - this.a * this.f) / det,
-    );
-  }
-}
-
-class Point {
-  constructor(
-    public x = 0,
-    public y = 0,
-  ) {}
-
-  matrixTransform(m: Matrix) {
-    return new Point(
-      this.x * m.a + this.y * m.c + m.e,
-      this.x * m.b + this.y * m.d + m.f,
-    );
-  }
-}
-
-beforeAll(() => {
-  (globalThis as unknown as { DOMMatrix: typeof Matrix }).DOMMatrix = Matrix;
-  (globalThis as unknown as { DOMPoint: typeof Point }).DOMPoint = Point;
-});
+import "../../../test/setupDom.ts";
 
 describe("updateScales", () => {
   it("updates domains for multiple axes", () => {

--- a/svg-time-series/src/utils/domMatrix.test.ts
+++ b/svg-time-series/src/utils/domMatrix.test.ts
@@ -5,52 +5,17 @@ import {
   applyAR1ToMatrixY,
   applyDirectProductToMatrix,
 } from "./domMatrix.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-}
+import { Matrix } from "../../../test/setupDom.ts";
 
 describe("applyAR1ToMatrix helpers", () => {
   it("translates and scales along X axis", () => {
-    const matrix = applyAR1ToMatrixX(
-      new AR1([2, 3]),
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const matrix = applyAR1ToMatrixX(new AR1([2, 3]), new Matrix());
     expect(matrix.a).toBeCloseTo(2);
     expect(matrix.e).toBeCloseTo(3);
   });
 
   it("translates and scales along Y axis", () => {
-    const matrix = applyAR1ToMatrixY(
-      new AR1([4, 5]),
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const matrix = applyAR1ToMatrixY(new AR1([4, 5]), new Matrix());
     expect(matrix.d).toBeCloseTo(4);
     expect(matrix.f).toBeCloseTo(5);
   });
@@ -59,10 +24,7 @@ describe("applyAR1ToMatrix helpers", () => {
 describe("applyDirectProductToMatrix", () => {
   it("combines independent AR1 transforms", () => {
     const dp = new DirectProduct(new AR1([2, 3]), new AR1([4, 5]));
-    const matrix = applyDirectProductToMatrix(
-      dp,
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const matrix = applyDirectProductToMatrix(dp, new Matrix());
     expect(matrix.a).toBeCloseTo(2);
     expect(matrix.d).toBeCloseTo(4);
     expect(matrix.e).toBeCloseTo(3);

--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { updateNode } from "./domNodeTransform.ts";
+import { Matrix } from "../../../test/setupDom.ts";
 
 class FakeSVGMatrix {
   constructor(
@@ -54,27 +55,13 @@ describe("updateNode", () => {
     const matrix = new FakeSVGMatrix();
     matrix.e = 10;
     matrix.f = 20;
-    updateNode(node, matrix as unknown as SVGMatrix);
+    updateNode(node, matrix as any);
     expect(node.transform.baseVal.last).toBe(matrix);
   });
 
   it("converts DOMMatrix to SVGMatrix", () => {
     const node = createNode();
-    const domMatrix = new (class {
-      constructor(
-        public a = 1,
-        public b = 0,
-        public c = 0,
-        public d = 1,
-        public e = 0,
-        public f = 0,
-      ) {}
-      translate(tx: number, ty: number) {
-        this.e += tx;
-        this.f += ty;
-        return this;
-      }
-    })().translate(5, 6) as unknown as DOMMatrix;
+    const domMatrix = new Matrix().translate(5, 6);
     updateNode(node, domMatrix);
     const last = node.transform.baseVal.last as FakeSVGMatrix;
     expect(last).toBeInstanceOf(FakeSVGMatrix);

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -12,36 +12,7 @@ import {
   applyDirectProductToMatrix,
 } from "./utils/domMatrix.ts";
 import { updateNode } from "./utils/domNodeTransform.ts";
-
-class Matrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-
-  multiply(m: Matrix) {
-    return new Matrix(
-      this.a * m.a + this.c * m.b,
-      this.b * m.a + this.d * m.b,
-      this.a * m.c + this.c * m.d,
-      this.b * m.c + this.d * m.d,
-      this.a * m.e + this.c * m.f + this.e,
-      this.b * m.e + this.d * m.f + this.f,
-    );
-  }
-
-  translate(tx: number, ty: number) {
-    return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
-  }
-
-  scale(sx: number, sy: number) {
-    return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
-  }
-}
+import { Matrix } from "../../test/setupDom.ts";
 
 describe("AR1 and AR1Basis", () => {
   it("composes and inverts transformations", () => {
@@ -71,7 +42,7 @@ describe("AR1 and AR1Basis", () => {
 
 describe("DirectProduct", () => {
   it("applies independent transforms on axes", () => {
-    const identity = new Matrix() as unknown as DOMMatrix;
+    const identity = new Matrix();
     const b1 = new DirectProductBasis([0, 0], [1, 1]);
     const b2 = new DirectProductBasis([10, 10], [20, 30]);
     const dp = betweenTBasesDirectProduct(b1, b2);
@@ -101,17 +72,11 @@ describe("DirectProductBasis utilities", () => {
 
 describe("viewZoomTransform helpers", () => {
   it("applies AR1 transforms along X and Y axes", () => {
-    const mx = applyAR1ToMatrixX(
-      new AR1([2, 3]),
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const mx = applyAR1ToMatrixX(new AR1([2, 3]), new Matrix());
     expect(mx.a).toBeCloseTo(2);
     expect(mx.e).toBeCloseTo(3);
 
-    const my = applyAR1ToMatrixY(
-      new AR1([3, 4]),
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const my = applyAR1ToMatrixY(new AR1([3, 4]), new Matrix());
     expect(my.d).toBeCloseTo(3);
     expect(my.f).toBeCloseTo(4);
   });
@@ -127,8 +92,8 @@ describe("viewZoomTransform helpers", () => {
     const node = {
       transform: { baseVal },
       ownerSVGElement: { createSVGMatrix: () => new Matrix() },
-    } as unknown as SVGGraphicsElement;
-    const matrix = new Matrix(1, 0, 0, 1, 2, 3) as unknown as DOMMatrix;
+    } as any as SVGGraphicsElement;
+    const matrix = new Matrix(1, 0, 0, 1, 2, 3);
 
     updateNode(node, matrix);
     expect(calls[0]).toBe(matrix);

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -1,4 +1,5 @@
-class Matrix {
+class Matrix implements DOMMatrix {
+  [key: string]: unknown;
   constructor(
     public a = 1,
     public b = 0,
@@ -7,6 +8,19 @@ class Matrix {
     public e = 0,
     public f = 0,
   ) {}
+
+  get tx() {
+    return this.e;
+  }
+  set tx(v: number) {
+    this.e = v;
+  }
+  get ty() {
+    return this.f;
+  }
+  set ty(v: number) {
+    this.f = v;
+  }
 
   multiply(m: Matrix) {
     return new Matrix(
@@ -18,13 +32,28 @@ class Matrix {
       this.b * m.e + this.d * m.f + this.f,
     );
   }
+  multiplySelf(m: Matrix) {
+    return Object.assign(this, this.multiply(m));
+  }
 
   translate(tx: number, ty: number) {
     return this.multiply(new Matrix(1, 0, 0, 1, tx, ty));
   }
+  translateSelf(tx: number, ty: number) {
+    return Object.assign(this, this.translate(tx, ty));
+  }
 
-  scale(sx: number, sy: number) {
+  scale(sx: number, sy = sx) {
     return this.multiply(new Matrix(sx, 0, 0, sy, 0, 0));
+  }
+  scaleSelf(sx: number, sy = sx) {
+    return Object.assign(this, this.scale(sx, sy));
+  }
+  scaleNonUniform(sx: number, sy: number) {
+    return this.scale(sx, sy);
+  }
+  scaleNonUniformSelf(sx: number, sy: number) {
+    return Object.assign(this, this.scaleNonUniform(sx, sy));
   }
 
   inverse() {
@@ -38,18 +67,37 @@ class Matrix {
       (this.b * this.e - this.a * this.f) / det,
     );
   }
+
+  get is2D() {
+    return true;
+  }
+  get isIdentity() {
+    return (
+      this.a === 1 &&
+      this.b === 0 &&
+      this.c === 0 &&
+      this.d === 1 &&
+      this.e === 0 &&
+      this.f === 0
+    );
+  }
 }
 
-class Point {
+class Point implements DOMPoint {
+  [key: string]: unknown;
   constructor(
     public x = 0,
     public y = 0,
+    public z = 0,
+    public w = 1,
   ) {}
 
   matrixTransform(m: Matrix) {
     return new Point(
       this.x * m.a + this.y * m.c + m.e,
       this.x * m.b + this.y * m.d + m.f,
+      this.z,
+      this.w,
     );
   }
 }
@@ -63,7 +111,7 @@ globalObj.DOMPoint = Point;
 if (typeof SVGSVGElement !== "undefined") {
   (
     SVGSVGElement.prototype as SVGSVGElement & {
-      createSVGMatrix: () => Matrix;
+      createSVGMatrix(): Matrix;
     }
   ).createSVGMatrix = () => new Matrix();
 }


### PR DESCRIPTION
## Summary
- add Matrix and Point helpers implementing DOMMatrix/DOMPoint and expose them globally
- simplify tests to import shared stubs instead of redefining Matrix/Point and using `unknown` casts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898dd4afd28832b90241f6d03411ad2