### PR TITLE
chore: enable type-aware linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,10 +7,16 @@ import vitest from "@vitest/eslint-plugin";
 
 export default tsEslint.config(
   eslint.configs.recommended,
-  ...tsEslint.configs.recommended,
-  ...tsEslint.configs.strict,
+  ...tsEslint.configs.recommendedTypeChecked,
+  ...tsEslint.configs.strictTypeChecked,
   prettierConfig,
   {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-empty-object-type": "error",
@@ -25,8 +31,16 @@ export default tsEslint.config(
   {
     files: ["**/*.test.ts"],
     ...vitest.configs.recommended,
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
+    languageOptions: {
+      parserOptions: {
+        project: [
+          "./tsconfig.json",
+          "./segment-tree-rmq/tsconfig.json",
+          "./svg-time-series/tsconfig.eslint.json",
+          "./samples/tsconfig.json",
+        ],
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
 );

--- a/svg-time-series/src/axis.test.ts
+++ b/svg-time-series/src/axis.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
-import { select } from "d3-selection";
+import { select, type Selection } from "d3-selection";
 import { scaleLinear } from "d3-scale";
 import { MyAxis, Orientation } from "./axis.ts";
 
@@ -10,8 +10,8 @@ function createGroup() {
   const dom = new JSDOM(`<svg xmlns="${NS}"></svg>`, {
     contentType: "image/svg+xml",
   });
-  const svg = dom.window.document.querySelector("svg") as SVGSVGElement;
-  const g = dom.window.document.createElementNS(NS, "g") as SVGGElement;
+  const svg = dom.window.document.querySelector("svg")!;
+  const g = dom.window.document.createElementNS(NS, "g");
   svg.appendChild(g);
   return { g };
 }
@@ -23,7 +23,14 @@ describe("MyAxis tick creation", () => {
     const axis = new MyAxis(Orientation.Bottom, scale).setTickValues([
       0, 50, 100,
     ]);
-    axis.axis(select(g) as any);
+    axis.axis(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     const ticks = Array.from(g.querySelectorAll(".tick"));
     expect(ticks.map((t) => t.getAttribute("transform"))).toEqual([
@@ -40,7 +47,14 @@ describe("MyAxis tick creation", () => {
     const scale1 = scaleLinear().domain([0, 100]).range([0, 100]);
     const scale2 = scaleLinear().domain([0, 1]).range([0, 200]);
     const axis = new MyAxis(Orientation.Bottom, scale1, scale2).ticks(3);
-    axis.axis(select(g) as any);
+    axis.axis(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     const ticks = Array.from(g.querySelectorAll(".tick"));
     expect(ticks.length).toBe(6);
@@ -63,12 +77,26 @@ describe("MyAxis tick creation", () => {
     const scale1 = scaleLinear().domain([0, 100]).range([0, 100]);
     const scale2 = scaleLinear().domain([0, 1]).range([0, 200]);
     const axis = new MyAxis(Orientation.Bottom, scale1, scale2).ticks(3);
-    axis.axis(select(g) as any);
+    axis.axis(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     scale1.range([0, 200]);
     scale2.range([0, 400]);
     axis.setScale(scale1, scale2);
-    axis.axisUp(select(g) as any);
+    axis.axisUp(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     const ticks = Array.from(g.querySelectorAll(".tick"));
     expect(ticks.map((t) => t.getAttribute("transform"))).toEqual([

--- a/svg-time-series/tsconfig.eslint.json
+++ b/svg-time-series/tsconfig.eslint.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": true
+  },
+  "include": ["eslint.config.js", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- enable type-aware lint rules and configure project-aware parser options
- remove permissive any casting in axis tests
- add tsconfig files so ESLint can locate project configs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898df332778832b90e43ba809652849