### PR TITLE
refactor: remove any casts in tests

### DIFF
--- a/svg-time-series/src/axis.test.ts
+++ b/svg-time-series/src/axis.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
-import { select } from "d3-selection";
+import { select, Selection } from "d3-selection";
 import { scaleLinear } from "d3-scale";
 import { MyAxis, Orientation } from "./axis.ts";
 
@@ -23,7 +23,14 @@ describe("MyAxis tick creation", () => {
     const axis = new MyAxis(Orientation.Bottom, scale).setTickValues([
       0, 50, 100,
     ]);
-    axis.axis(select(g) as any);
+    axis.axis(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     const ticks = Array.from(g.querySelectorAll(".tick"));
     expect(ticks.map((t) => t.getAttribute("transform"))).toEqual([
@@ -40,7 +47,14 @@ describe("MyAxis tick creation", () => {
     const scale1 = scaleLinear().domain([0, 100]).range([0, 100]);
     const scale2 = scaleLinear().domain([0, 1]).range([0, 200]);
     const axis = new MyAxis(Orientation.Bottom, scale1, scale2).ticks(3);
-    axis.axis(select(g) as any);
+    axis.axis(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     const ticks = Array.from(g.querySelectorAll(".tick"));
     expect(ticks.length).toBe(6);
@@ -63,12 +77,26 @@ describe("MyAxis tick creation", () => {
     const scale1 = scaleLinear().domain([0, 100]).range([0, 100]);
     const scale2 = scaleLinear().domain([0, 1]).range([0, 200]);
     const axis = new MyAxis(Orientation.Bottom, scale1, scale2).ticks(3);
-    axis.axis(select(g) as any);
+    axis.axis(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     scale1.range([0, 200]);
     scale2.range([0, 400]);
     axis.setScale(scale1, scale2);
-    axis.axisUp(select(g) as any);
+    axis.axisUp(
+      select(g) as unknown as Selection<
+        SVGGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+    );
 
     const ticks = Array.from(g.querySelectorAll(".tick"));
     expect(ticks.map((t) => t.getAttribute("transform"))).toEqual([

--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -55,7 +55,7 @@ describe("updateNode", () => {
     const matrix = new FakeSVGMatrix();
     matrix.e = 10;
     matrix.f = 20;
-    updateNode(node, matrix as any);
+    updateNode(node, matrix as unknown as SVGMatrix);
     expect(node.transform.baseVal.last).toBe(matrix);
   });
 

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -92,7 +92,7 @@ describe("viewZoomTransform helpers", () => {
     const node = {
       transform: { baseVal },
       ownerSVGElement: { createSVGMatrix: () => new Matrix() },
-    } as any as SVGGraphicsElement;
+    } as unknown as SVGGraphicsElement;
     const matrix = new Matrix(1, 0, 0, 1, 2, 3);
 
     updateNode(node, matrix);


### PR DESCRIPTION
## Summary
- replace `any` casts in DOM node transform test with typed SVGMatrix
- refine axis test d3 selections to avoid `any`
- remove `any` usage in view zoom transform test

## Testing
- `npm run lint --workspaces --if-present`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689915c19500832b8b032dbb2a113cda