### PR TITLE
chore: use import type for Selection and related imports

### DIFF
--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -1,4 +1,5 @@
-import { Selection, select } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { updateNode } from "../svg-time-series/src/utils/domNodeTransform.ts";
 import type {
   ILegendController,

--- a/samples/benchmarks/axis-draw-transform/draw.ts
+++ b/samples/benchmarks/axis-draw-transform/draw.ts
@@ -1,5 +1,5 @@
 ﻿import { scaleLinear, scaleTime } from "d3-scale";
-import { BaseType, Selection } from "d3-selection";
+import type { BaseType, Selection } from "d3-selection";
 
 import { MyAxis, Orientation } from "../../../svg-time-series/src/axis.ts";
 import { animateBench, animateCosDown } from "../bench.ts";

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -1,7 +1,9 @@
-import { TimeSeriesChart, IDataSource } from "svg-time-series";
+import { TimeSeriesChart } from "svg-time-series";
+import type { IDataSource } from "svg-time-series";
 import { LegendController } from "../../LegendController.ts";
 import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
-import { select, Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 
 onCsv((data: [number, number][]) => {
   const svg = select(".chart-drawing svg") as Selection<

--- a/samples/benchmarks/demo2-without-grid/draw.ts
+++ b/samples/benchmarks/demo2-without-grid/draw.ts
@@ -1,17 +1,14 @@
-import { D3ZoomEvent, zoom } from "d3-zoom";
+import type { D3ZoomEvent } from "d3-zoom";
+import { zoom } from "d3-zoom";
 import { SegmentTree } from "segment-tree-rmq";
 import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
 import { timeout as runTimeout } from "d3-timer";
-import { selectAll, Selection } from "d3-selection";
-import {
-  scaleLinear,
-  scaleOrdinal,
-  scaleTime,
-  ScaleLinear,
-  ScaleOrdinal,
-  ScaleTime,
-} from "d3-scale";
-import { line, Line } from "d3-shape";
+import type { Selection } from "d3-selection";
+import { selectAll } from "d3-selection";
+import { scaleLinear, scaleOrdinal, scaleTime } from "d3-scale";
+import type { ScaleLinear, ScaleOrdinal, ScaleTime } from "d3-scale";
+import { line } from "d3-shape";
+import type { Line } from "d3-shape";
 
 interface IChartData {
   name: string;

--- a/samples/benchmarks/path-draw-transform-d3/draw.ts
+++ b/samples/benchmarks/path-draw-transform-d3/draw.ts
@@ -1,4 +1,4 @@
-﻿import { BaseType, Selection } from "d3-selection";
+﻿import type { BaseType, Selection } from "d3-selection";
 
 import { animateBench, animateCosDown } from "../bench.ts";
 import { ViewWindowTransform } from "../../ViewWindowTransform.ts";

--- a/samples/benchmarks/path-recreate-dom/draw.ts
+++ b/samples/benchmarks/path-recreate-dom/draw.ts
@@ -1,4 +1,4 @@
-﻿import { BaseType, Selection } from "d3-selection";
+﻿import type { BaseType, Selection } from "d3-selection";
 
 import { animateBench, animateCosDown } from "../bench.ts";
 import { ViewWindowTransform } from "../../ViewWindowTransform.ts";

--- a/samples/benchmarks/path-segment-recreate-dom/draw.ts
+++ b/samples/benchmarks/path-segment-recreate-dom/draw.ts
@@ -1,4 +1,4 @@
-﻿import { BaseType, Selection } from "d3-selection";
+﻿import type { BaseType, Selection } from "d3-selection";
 
 import { animateBench } from "../bench.ts";
 import { ViewWindowTransform } from "../../ViewWindowTransform.ts";

--- a/samples/benchmarks/path-segment-recreate-dom/index.ts
+++ b/samples/benchmarks/path-segment-recreate-dom/index.ts
@@ -1,4 +1,5 @@
-import { Selection, select, selectAll } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select, selectAll } from "d3-selection";
 import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
 

--- a/samples/benchmarks/segment-tree-queries/draw.ts
+++ b/samples/benchmarks/segment-tree-queries/draw.ts
@@ -1,4 +1,4 @@
-import { BaseType, Selection } from "d3-selection";
+import type { BaseType, Selection } from "d3-selection";
 
 import { SegmentTree } from "segment-tree-rmq";
 import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";

--- a/samples/benchmarks/svg-path-recreation-d3/draw.ts
+++ b/samples/benchmarks/svg-path-recreation-d3/draw.ts
@@ -1,4 +1,4 @@
-﻿import { BaseType, Selection } from "d3-selection";
+﻿import type { BaseType, Selection } from "d3-selection";
 
 import { animateBench } from "../bench.ts";
 import { ViewWindowTransform } from "../../ViewWindowTransform.ts";

--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -1,5 +1,6 @@
 import { scaleLinear, scaleTime } from "d3-scale";
-import { ValueFn, BaseType, select, selectAll, Selection } from "d3-selection";
+import { select, selectAll } from "d3-selection";
+import type { ValueFn, BaseType, Selection } from "d3-selection";
 import type { D3ZoomEvent } from "d3-zoom";
 import type { ScaleLinear } from "d3-scale";
 import { line } from "d3-shape";

--- a/svg-time-series/src/axis.ts
+++ b/svg-time-series/src/axis.ts
@@ -26,7 +26,7 @@ function translateY<D>(scale0: PositionFn<D>, scale1: PositionFn<D>, d: D) {
   return "translate(0," + (isFinite(y) ? y : scale1(d)) + ")";
 }
 
-import { Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
 import type { ScaleContinuousNumeric, ScaleLinear, ScaleTime } from "d3-scale";
 
 type ScaleType = (

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,4 +1,5 @@
-import { scaleLinear, type ScaleLinear, type ScaleTime } from "d3-scale";
+import { scaleLinear } from "d3-scale";
+import type { ScaleLinear, ScaleTime } from "d3-scale";
 import type { Selection } from "d3-selection";
 import { SegmentTree } from "segment-tree-rmq";
 

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -3,9 +3,11 @@
  */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select, type Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart } from "../draw.ts";
+import type { IDataSource } from "../draw.ts";
 import type { ILegendController, LegendContext } from "./legend.ts";
 import "../../../test/setupDom.ts";
 import type { Matrix } from "../../../test/setupDom.ts";

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -3,13 +3,11 @@
  */
 /* eslint-disable @typescript-eslint/no-useless-constructor */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select, type Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import {
-  TimeSeriesChart,
-  type IDataSource,
-  type IZoomStateOptions,
-} from "../draw.ts";
+import { TimeSeriesChart } from "../draw.ts";
+import type { IDataSource, IZoomStateOptions } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 import "../../../test/setupDom.ts";
 import type { Matrix } from "../../../test/setupDom.ts";

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -3,9 +3,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select, type Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart } from "../draw.ts";
+import type { IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 import { Matrix } from "../../../test/setupDom.ts";
 

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -3,9 +3,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { select, type Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
-import { TimeSeriesChart, IDataSource } from "../draw.ts";
+import { TimeSeriesChart } from "../draw.ts";
+import type { IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
 import { Matrix } from "../../../test/setupDom.ts";
 

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -3,8 +3,10 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { JSDOM } from "jsdom";
-import { select, type Selection } from "d3-selection";
-import { ChartData, IDataSource } from "./data.ts";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import type { IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import * as domNode from "../utils/domNodeTransform.ts";
 import "../../../test/setupDom.ts";

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -19,8 +19,10 @@ vi.mock("../axis.ts", () => {
 });
 
 import { JSDOM } from "jsdom";
-import { select, type Selection } from "d3-selection";
-import { ChartData, type IDataSource } from "./data.ts";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import type { IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import "../../../test/setupDom.ts";

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -3,8 +3,10 @@
  */
 import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
-import { select, type Selection } from "d3-selection";
-import { ChartData, IDataSource } from "./data.ts";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import type { IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import "../../../test/setupDom.ts";
 

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi } from "vitest";
-import { select, type Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 import { SeriesManager } from "./series.ts";
 

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -1,13 +1,11 @@
-import { Selection } from "d3-selection";
-import { scaleTime, type ScaleTime, type ScaleLinear } from "d3-scale";
+import type { Selection } from "d3-selection";
+import { scaleTime } from "d3-scale";
+import type { ScaleTime, ScaleLinear } from "d3-scale";
 import type { Line } from "d3-shape";
 
 import { MyAxis, Orientation } from "../axis.ts";
-import {
-  AxisManager,
-  type AxisModel,
-  type AxisRenderState,
-} from "./axisManager.ts";
+import { AxisManager } from "./axisManager.ts";
+import type { AxisModel, AxisRenderState } from "./axisManager.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData } from "./data.ts";

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -2,10 +2,12 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from "vitest";
-import { select, Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { scaleLinear, scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
-import { ChartData, IDataSource } from "./data.ts";
+import { ChartData } from "./data.ts";
+import type { IDataSource } from "./data.ts";
 import { buildAxisTree } from "./axisManager.ts";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { JSDOM } from "jsdom";
-import { select, type Selection } from "d3-selection";
-import { ChartData, IDataSource } from "./data.ts";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import type { IDataSource } from "./data.ts";
 import { setupRender } from "./render.ts";
 import "../../../test/setupDom.ts";
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,4 +1,4 @@
-import { Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
 import type { ScaleTime } from "d3-scale";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -25,9 +25,11 @@ vi.mock("../axis.ts", () => {
   };
 });
 
-import { select, type Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { SeriesRenderer } from "./seriesRenderer.ts";
-import { TimeSeriesChart, type IDataSource } from "../draw.ts";
+import { TimeSeriesChart } from "../draw.ts";
+import type { IDataSource } from "../draw.ts";
 import "../../../test/setupDom.ts";
 
 describe("TimeSeriesChart.resize", () => {

--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -1,4 +1,4 @@
-import { Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
 import { line, type Line } from "d3-shape";
 
 import type { Series } from "./render.ts";

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -2,7 +2,8 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { select, Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
 
 interface MockZoomBehavior {

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -2,9 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { select, Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
-import { ZoomState, type D3ZoomEvent } from "./zoomState.ts";
+import { ZoomState } from "./zoomState.ts";
+import type { D3ZoomEvent } from "./zoomState.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -2,9 +2,11 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { select, Selection } from "d3-selection";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
-import { ZoomState, type D3ZoomEvent } from "./zoomState.ts";
+import { ZoomState } from "./zoomState.ts";
+import type { D3ZoomEvent } from "./zoomState.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,11 +1,6 @@
-import { Selection } from "d3-selection";
-import {
-  zoom as d3zoom,
-  D3ZoomEvent,
-  ZoomBehavior,
-  ZoomTransform,
-  zoomIdentity,
-} from "d3-zoom";
+import type { Selection } from "d3-selection";
+import { zoom as d3zoom, ZoomTransform, zoomIdentity } from "d3-zoom";
+import type { D3ZoomEvent, ZoomBehavior } from "d3-zoom";
 import { drawProc } from "../utils/drawProc.ts";
 import type { RenderState } from "./render.ts";
 

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,12 +1,14 @@
-import { Selection } from "d3-selection";
-import { D3ZoomEvent } from "d3-zoom";
+import type { Selection } from "d3-selection";
+import type { D3ZoomEvent } from "d3-zoom";
 
-import { ChartData, IDataSource } from "./chart/data.ts";
+import { ChartData } from "./chart/data.ts";
+import type { IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
 import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
-import { ZoomState, IZoomStateOptions } from "./chart/zoomState.ts";
+import { ZoomState } from "./chart/zoomState.ts";
+import type { IZoomStateOptions } from "./chart/zoomState.ts";
 
 export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";


### PR DESCRIPTION
## Summary
- refactor type-only imports across core, tests, and samples to use `import type`
- split mixed imports so values and types are imported separately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899147f39a0832ba832024d671b2b75