### PR TITLE
refactor: address eslint warnings

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -59,17 +59,21 @@ export class ChartData {
     this.seriesAxes = source.seriesAxes;
     if (this.seriesAxes.length !== this.seriesCount) {
       throw new Error(
-        `ChartData requires seriesAxes length to match seriesCount (${this.seriesCount})`,
+        `ChartData requires seriesAxes length to match seriesCount (${String(
+          this.seriesCount,
+        )})`,
       );
     }
     let axisIdx = 0;
     for (const axis of this.seriesAxes) {
       if (axis !== 0 && axis !== 1) {
         throw new Error(
-          `ChartData seriesAxes[${axisIdx}] must be 0 or 1; received ${axis}`,
+          `ChartData seriesAxes[${String(axisIdx)}] must be 0 or 1; received ${String(
+            axis,
+          )}`,
         );
       }
-      this.seriesByAxis[axis as 0 | 1].push(axisIdx);
+      this.seriesByAxis[axis].push(axisIdx);
       axisIdx++;
     }
     const initialData = Array.from({ length: source.length }).map((_, i) =>

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -66,14 +66,16 @@ export class TimeSeriesChart {
     };
     this.legendController.init(context);
 
-    this.zoomArea
-      .on("mousemove", mouseMoveHandler)
-      .on("mouseleave", () => this.legendController.clearHighlight());
+    this.zoomArea.on("mousemove", mouseMoveHandler).on("mouseleave", () => {
+      this.legendController.clearHighlight();
+    });
 
     this.zoomState = new ZoomState(
       this.zoomArea,
       this.state,
-      () => this.state.refresh(this.data),
+      () => {
+        this.state.refresh(this.data);
+      },
       (event) => {
         zoomHandler(event);
         this.legendController.refresh();


### PR DESCRIPTION
## Summary
- replace implicit void returns in draw handlers with explicit braces
- convert template literal numbers to strings and remove redundant type assertions in ChartData

## Testing
- `npm run lint --workspace=svg-time-series`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899188c94d8832ba0b0fd9cc5fac1ba