### PR TITLE
refactor: address lint warnings

### DIFF
--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -19,7 +19,7 @@ export class SegmentTree<T> {
       throw new Error("Data array must contain at least one element");
     }
     this.size = data.length;
-    this.tree = new Array(this.size << 1);
+    this.tree = new Array<T>(this.size << 1);
     this.op = op;
     this.identity = identity;
 

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -114,7 +114,9 @@ describe("Segment Tree Tests", () => {
     const identity = 0;
     const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(() => tree.update(-1, 5)).toThrow("Index is out of range");
+    expect(() => {
+      tree.update(-1, 5);
+    }).toThrow("Index is out of range");
   });
 
   it("should throw an error when updating with an index greater than or equal to the size", () => {
@@ -123,7 +125,9 @@ describe("Segment Tree Tests", () => {
     const identity = 0;
     const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(() => tree.update(3, 5)).toThrow("Index is out of range");
+    expect(() => {
+      tree.update(3, 5);
+    }).toThrow("Index is out of range");
   });
 
   it("should throw an error when updating with a non-integer index", () => {
@@ -132,7 +136,9 @@ describe("Segment Tree Tests", () => {
     const identity = 0;
     const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(() => tree.update(1.5, 5)).toThrow("Index must be an integer");
+    expect(() => {
+      tree.update(1.5, 5);
+    }).toThrow("Index must be an integer");
   });
 
   it("should throw an error for invalid ranges", () => {

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -15,13 +15,13 @@ export class ZoomState {
   private scheduleRefresh: () => void;
   private cancelRefresh: () => void;
   private scaleExtent: [number, number];
-  private validateScaleExtent(extent: [number, number]) {
+  private validateScaleExtent(extent: unknown) {
     if (!Array.isArray(extent) || extent.length !== 2) {
       throw new Error(
-        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${extent}`,
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${Array.isArray(extent) ? extent.join(",") : String(extent)}`,
       );
     }
-    const [min, max] = extent;
+    const [min, max] = extent as [number, number];
     if (
       typeof min !== "number" ||
       typeof max !== "number" ||
@@ -32,7 +32,7 @@ export class ZoomState {
       min >= max
     ) {
       throw new Error(
-        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${extent}]`,
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${extent.join(",")}]`,
       );
     }
   }

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -13,7 +13,7 @@ function createSegmentTree<T>(
   size: number,
   buildTuple: (index: number, elements: ReadonlyArray<T>) => IMinMax,
 ): SegmentTree<IMinMax> {
-  const data: IMinMax[] = new Array(size);
+  const data: IMinMax[] = new Array<IMinMax>(size);
   for (let i = 0; i < size; i++) {
     data[i] = buildTuple(i, elements);
   }
@@ -44,12 +44,12 @@ test("SegmentTree operations", () => {
   expect(() => tree.query(0, data.length)).toThrow("Range is not valid");
 
   // Test invalid update position
-  expect(() => tree.update(-1, { min: 0, max: 0 })).toThrow(
-    "Index is out of range",
-  );
-  expect(() => tree.update(5, { min: 0, max: 0 })).toThrow(
-    "Index is out of range",
-  );
+  expect(() => {
+    tree.update(-1, { min: 0, max: 0 });
+  }).toThrow("Index is out of range");
+  expect(() => {
+    tree.update(5, { min: 0, max: 0 });
+  }).toThrow("Index is out of range");
 });
 
 test("SegmentTree with IMinMax", () => {

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -1,4 +1,4 @@
-export function updateNode(n: SVGGraphicsElement, m: DOMMatrix | SVGMatrix) {
+export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
   const svgTransformList = n.transform.baseVal;
   const svg = (
     typeof SVGSVGElement !== "undefined" && n instanceof SVGSVGElement
@@ -6,7 +6,7 @@ export function updateNode(n: SVGGraphicsElement, m: DOMMatrix | SVGMatrix) {
       : n.ownerSVGElement
   )!;
 
-  function isSVGMatrix(matrix: DOMMatrix | SVGMatrix): matrix is SVGMatrix {
+  function isSVGMatrix(matrix: DOMMatrix): matrix is SVGMatrix {
     return matrix.constructor === svg.createSVGMatrix().constructor;
   }
 


### PR DESCRIPTION
## Summary
- use typed array allocation in SegmentTree implementation
- wrap arrow functions in tests to avoid confusing void expressions
- tighten DOM transform helpers and scale extent validation

## Testing
- `npm run lint --workspace=segment-tree-rmq`
- `npm run lint --workspace=svg-time-series`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68991af861f4832bb4619c29812d2916