### PR TITLE
chore: enable type-checked ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,9 +6,18 @@ import prettierConfig from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
 
 export default tsEslint.config(
+  { ignores: ["eslint.config.js"] },
+  {
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
   eslint.configs.recommended,
-  ...tsEslint.configs.recommended,
-  ...tsEslint.configs.strict,
+  ...tsEslint.configs.recommendedTypeChecked,
+  ...tsEslint.configs.strictTypeChecked,
   prettierConfig,
   {
     rules: {
@@ -22,11 +31,5 @@ export default tsEslint.config(
       "prefer-spread": "error",
     },
   },
-  {
-    files: ["**/*.test.ts"],
-    ...vitest.configs.recommended,
-    rules: {
-      "@typescript-eslint/no-explicit-any": "off",
-    },
-  },
+  { files: ["**/*.test.ts"], ...vitest.configs.recommended, ...tsEslint.configs.disableTypeChecked },
 );

--- a/lint-staged.config.cjs
+++ b/lint-staged.config.cjs
@@ -1,5 +1,8 @@
 module.exports = {
-  "*.{js,jsx,ts,tsx}": ["eslint --fix --max-warnings=0", "prettier --write"],
+  "*.{js,jsx,ts,tsx}": [
+    "eslint --fix --no-warn-ignored --max-warnings=0",
+    "prettier --write",
+  ],
   "*.{cjs,mjs,json,css,md}": ["prettier --write"],
   "*.{yml,yaml}": ["prettier --write"],
 };

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -85,7 +85,9 @@ export class AxisManager {
     for (const i of axisIndices) {
       if (i >= this.axes.length) {
         throw new Error(
-          `Series axis index ${i} out of bounds (max ${this.axes.length - 1})`,
+          `Series axis index ${String(i)} out of bounds (max ${String(
+            this.axes.length - 1,
+          )})`,
         );
       }
       const tree = buildAxisTree(data, i);

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -75,7 +75,9 @@ export function refreshRenderState(state: RenderState, data: ChartData): void {
     const t = state.axes.y[s.axisIdx]!.transform;
     updateNode(s.view, t.matrix);
   }
-  state.axisRenders.forEach((r) => r.axis.axisUp(r.g));
+  state.axisRenders.forEach((r) => {
+    r.axis.axisUp(r.g);
+  });
   state.axes.x.axis.axisUp(state.axes.x.g);
 }
 

--- a/svg-time-series/src/chart/slidingWindow.ts
+++ b/svg-time-series/src/chart/slidingWindow.ts
@@ -11,14 +11,18 @@ export class SlidingWindow {
     initialData.forEach((row, rowIdx) => {
       if (row.length !== seriesCount) {
         throw new Error(
-          `SlidingWindow requires row ${rowIdx} to have ${seriesCount} values, received ${row.length}`,
+          `SlidingWindow requires row ${String(rowIdx)} to have ${String(
+            seriesCount,
+          )} values, received ${String(row.length)}`,
         );
       }
       let valueIdx = 0;
       for (const val of row) {
         if (!Number.isFinite(val) && !Number.isNaN(val)) {
           throw new Error(
-            `SlidingWindow requires row ${rowIdx} series ${valueIdx} value to be a finite number or NaN`,
+            `SlidingWindow requires row ${String(rowIdx)} series ${String(
+              valueIdx,
+            )} value to be a finite number or NaN`,
           );
         }
         valueIdx++;
@@ -31,14 +35,18 @@ export class SlidingWindow {
   append(...values: number[]): void {
     if (values.length !== this.seriesCount) {
       throw new Error(
-        `SlidingWindow.append requires ${this.seriesCount} values, received ${values.length}`,
+        `SlidingWindow.append requires ${String(
+          this.seriesCount,
+        )} values, received ${String(values.length)}`,
       );
     }
     let valueIdx = 0;
     for (const val of values) {
       if (!Number.isFinite(val) && !Number.isNaN(val)) {
         throw new Error(
-          `SlidingWindow.append requires series ${valueIdx} value to be a finite number or NaN`,
+          `SlidingWindow.append requires series ${String(
+            valueIdx,
+          )} value to be a finite number or NaN`,
         );
       }
       valueIdx++;


### PR DESCRIPTION
## Summary
- use type-checked ESLint configs and project-aware parser options
- remove test override for `no-explicit-any` and adjust lint-staged to ignore config files
- fix new lint errors across axis helpers, render pipeline, and utilities

## Testing
- `npm run lint --workspace=svg-time-series`
- `npm run lint --workspace=segment-tree-rmq`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68991e82f82c832bb9e9250254ef917d