### PR TITLE
chore: tighten type configurations

### DIFF
--- a/segment-tree-rmq/tsconfig.json
+++ b/segment-tree-rmq/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist"
-  }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts", "bench/**"]
 }

--- a/svg-time-series/src/utils/drawProc.ts
+++ b/svg-time-series/src/utils/drawProc.ts
@@ -7,7 +7,7 @@ export function drawProc<F extends (...args: unknown[]) => void>(
   cancel: () => void;
 } {
   let requested = false;
-  let latestParams: Parameters<F>;
+  let latestParams: Parameters<F> | null = null;
   let timer: ReturnType<typeof runTimeout> | null = null;
 
   const wrapped = (...params: Parameters<F>) => {
@@ -17,7 +17,9 @@ export function drawProc<F extends (...args: unknown[]) => void>(
       timer = runTimeout(() => {
         requested = false;
         timer = null;
-        f(...latestParams);
+        if (latestParams) {
+          f(...latestParams);
+        }
       });
     }
   };
@@ -28,6 +30,7 @@ export function drawProc<F extends (...args: unknown[]) => void>(
       timer = null;
     }
     requested = false;
+    latestParams = null;
   };
 
   return { wrapped, cancel };

--- a/svg-time-series/tsconfig.json
+++ b/svg-time-series/tsconfig.json
@@ -1,10 +1,12 @@
 {
   "extends": "../tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "dist"
   },
-  "exclude": ["vite.config.ts", "**/*.test.ts", "**/*.bench.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "vite.config.ts", "**/*.test.ts", "**/*.bench.ts"]
 }


### PR DESCRIPTION
## Summary
- restrict TypeScript inputs to source folders and ignore build artifacts
- avoid stale parameter usage in drawProc by clearing last invocation

## Testing
- `npm run typecheck --workspaces --if-present`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689923beb164832b99502a97f0db472d