### PR TITLE
build(samples): fail typecheck on error

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit || true",
+    "typecheck": "tsc --noEmit",
     "test": "echo \"Error: no test specified\" && exit 1",
     "bench": "echo \"No benchmarks defined\""
   },


### PR DESCRIPTION
## Summary
- require samples typecheck script to fail on type errors

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6899ea3106a0832b896501856ab66574