### PR TITLE
refactor: centralize index validation for segment tree

### DIFF
--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -6,6 +6,15 @@ export class SegmentTree<T> {
   private op: Operator<T>;
   private identity: T;
 
+  private assertValidIndex(i: number): void {
+    if (!Number.isInteger(i)) {
+      throw new Error("Index must be an integer");
+    }
+    if (i < 0 || i >= this.size) {
+      throw new Error("Index is out of range");
+    }
+  }
+
   /**
    * Creates a new segment tree.
    *
@@ -32,13 +41,7 @@ export class SegmentTree<T> {
   }
 
   update(index: number, value: T): void {
-    if (!Number.isInteger(index)) {
-      throw new Error("Index must be an integer");
-    }
-    if (index < 0 || index >= this.size) {
-      throw new Error("Index is out of range");
-    }
-
+    this.assertValidIndex(index);
     let i = index + this.size;
     this.tree[i] = value;
     while (i > 1) {
@@ -48,13 +51,9 @@ export class SegmentTree<T> {
   }
 
   query(left: number, right: number): T {
-    if (!Number.isInteger(left)) {
-      throw new Error("Left index must be an integer");
-    }
-    if (!Number.isInteger(right)) {
-      throw new Error("Right index must be an integer");
-    }
-    if (left < 0 || right >= this.size || left > right) {
+    this.assertValidIndex(left);
+    this.assertValidIndex(right);
+    if (left > right) {
       throw new Error("Range is not valid");
     }
     left += this.size;

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -148,8 +148,8 @@ describe("Segment Tree Tests", () => {
     const tree = new SegmentTree(data, sumOperator, identity);
 
     expect(() => tree.query(3, 2)).toThrow("Range is not valid");
-    expect(() => tree.query(-1, 2)).toThrow("Range is not valid");
-    expect(() => tree.query(0, 5)).toThrow("Range is not valid");
+    expect(() => tree.query(-1, 2)).toThrow("Index is out of range");
+    expect(() => tree.query(0, 5)).toThrow("Index is out of range");
   });
 
   it("should throw an error when querying with non-integer indices", () => {
@@ -158,8 +158,8 @@ describe("Segment Tree Tests", () => {
     const identity = 0;
     const tree = new SegmentTree(data, sumOperator, identity);
 
-    expect(() => tree.query(1.2, 3)).toThrow("Left index must be an integer");
-    expect(() => tree.query(1, 2.8)).toThrow("Right index must be an integer");
+    expect(() => tree.query(1.2, 3)).toThrow("Index must be an integer");
+    expect(() => tree.query(1, 2.8)).toThrow("Index must be an integer");
   });
 
   it("should support min queries and updates", () => {

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -39,9 +39,11 @@ test("SegmentTree operations", () => {
   expect(tree.query(2, data.length - 1)).toEqual({ min: 4, max: 6 });
 
   // Test invalid range
-  expect(() => tree.query(-1, data.length - 1)).toThrow("Range is not valid");
+  expect(() => tree.query(-1, data.length - 1)).toThrow(
+    "Index is out of range",
+  );
   expect(() => tree.query(3, 2)).toThrow("Range is not valid");
-  expect(() => tree.query(0, data.length)).toThrow("Range is not valid");
+  expect(() => tree.query(0, data.length)).toThrow("Index is out of range");
 
   // Test invalid update position
   expect(() => {


### PR DESCRIPTION
## Summary
- add `assertValidIndex` helper to `SegmentTree` for shared index validation
- reuse helper in `update` and `query`
- update tests to cover shared validation and adjust expected error messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899f94f3264832bb11c312a51fb8683