### PR TITLE
feat: broaden eslint coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,14 +3,13 @@
 import tsEslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
+import globals from "globals";
+
+const disableTypeChecked = tsEslint.configs.disableTypeChecked;
 
 export default tsEslint.config(
   {
-    ignores: [
-      "eslint.config.js",
-      "**/dist/**",
-      "samples/competitors/**",
-    ],
+    ignores: ["**/dist/**"],
   },
   {
     languageOptions: {
@@ -45,5 +44,20 @@ export default tsEslint.config(
   { files: ["**/*.bench.ts", "**/bench/**/*.ts"], ...tsEslint.configs.disableTypeChecked },
   { files: ["samples/benchmarks/**"], ...tsEslint.configs.disableTypeChecked },
   { files: ["**/*.cjs", "**/*.mjs", "**/vite.config.ts"], ...tsEslint.configs.disableTypeChecked },
+  { files: ["eslint.config.js"], ...tsEslint.configs.disableTypeChecked },
+  {
+    files: ["samples/competitors/**"],
+    languageOptions: {
+      ...disableTypeChecked.languageOptions,
+      globals: { ...globals.browser, d3: "readonly" },
+    },
+    rules: {
+      ...disableTypeChecked.rules,
+      "prefer-const": "off",
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "prefer-spread": "off",
+    },
+  },
   { files: ["**/*.test.ts"], ...vitest.configs.recommended, ...tsEslint.configs.disableTypeChecked },
 );


### PR DESCRIPTION
## Summary
- lint the repo's own eslint configuration and samples/competitors
- include competitor samples with browser globals and relaxed rules

## Testing
- `npm run lint`
- `npm run typecheck --workspaces --if-present`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a03f6ca30832bb11da6c47d5b6c63