### PR TITLE
chore: enable lint typechecking for benchmark files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,9 @@ export default tsEslint.config(
       parserOptions: {
         project: [
           "./segment-tree-rmq/tsconfig.json",
+          "./segment-tree-rmq/tsconfig.bench.json",
           "./svg-time-series/tsconfig.json",
+          "./svg-time-series/tsconfig.bench.json",
           "./samples/tsconfig.json",
           "./samples/demos/tsconfig.json",
           "./samples/misc/tsconfig.json",
@@ -41,7 +43,6 @@ export default tsEslint.config(
     },
   },
   { files: ["test/**/*.ts"], ...tsEslint.configs.disableTypeChecked },
-  { files: ["**/*.bench.ts", "**/bench/**/*.ts"], ...tsEslint.configs.disableTypeChecked },
   { files: ["samples/benchmarks/**"], ...tsEslint.configs.disableTypeChecked },
   { files: ["**/*.cjs", "**/*.mjs", "**/vite.config.ts"], ...tsEslint.configs.disableTypeChecked },
   { files: ["eslint.config.js"], ...tsEslint.configs.disableTypeChecked },

--- a/segment-tree-rmq/tsconfig.bench.json
+++ b/segment-tree-rmq/tsconfig.bench.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["bench/**/*.ts"],
+  "exclude": ["dist", "**/*.test.ts"]
+}

--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -15,7 +15,7 @@ describe("renderPaths performance", () => {
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];
-    bench(`size ${size}`, () => {
+    bench(`size ${String(size)}`, () => {
       renderer.draw(data);
     });
   });

--- a/svg-time-series/tsconfig.bench.json
+++ b/svg-time-series/tsconfig.bench.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["bench/**/*.ts"],
+  "exclude": ["dist", "vite.config.ts", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- lint benchmark files by default
- add bench tsconfigs for segment-tree-rmq and svg-time-series packages
- fix benchmark template literal to satisfy strict lint rules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a142be71c832bbb6515233d5bc695