### PR TITLE
fix: enforce lint rules in competitor samples

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,10 +54,6 @@ export default tsEslint.config(
     },
     rules: {
       ...disableTypeChecked.rules,
-      "prefer-const": "off",
-      "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "prefer-spread": "off",
     },
   },
   { files: ["**/*.test.ts"], ...vitest.configs.recommended, ...tsEslint.configs.disableTypeChecked },

--- a/samples/competitors/d3-fixedaxis/index.js
+++ b/samples/competitors/d3-fixedaxis/index.js
@@ -22,13 +22,13 @@ function myAxis(orient, scale) {
     var values =
         tickValues == null
           ? scale.ticks
-            ? scale.ticks.apply(scale, tickArguments)
+            ? scale.ticks(...tickArguments)
             : scale.domain()
           : tickValues,
       format =
         tickFormat == null
           ? scale.tickFormat
-            ? scale.tickFormat.apply(scale, tickArguments)
+            ? scale.tickFormat(...tickArguments)
             : identity
           : tickFormat,
       spacing = Math.max(tickSizeInner, 0) + tickPadding,
@@ -152,13 +152,13 @@ function myAxis(orient, scale) {
     var values =
         tickValues == null
           ? scale.ticks
-            ? scale.ticks.apply(scale, tickArguments)
+            ? scale.ticks(...tickArguments)
             : scale.domain()
           : tickValues,
       format =
         tickFormat == null
           ? scale.tickFormat
-            ? scale.tickFormat.apply(scale, tickArguments)
+            ? scale.tickFormat(...tickArguments)
             : identity
           : tickFormat,
       spacing = Math.max(tickSizeInner, 0) + tickPadding,
@@ -184,27 +184,28 @@ function myAxis(orient, scale) {
         .enter()
         .append("path")
         .attr("class", "domain")
-        .attr("stroke", "#000")
-        .attr(
-          "d",
-          orient === left || orient == right
-            ? "M" +
-                k * tickSizeOuter +
-                "," +
-                range0 +
-                "H0.5V" +
-                range1 +
-                "H" +
-                k * tickSizeOuter
-            : "M" +
-                range0 +
-                "," +
-                k * tickSizeOuter +
-                "V0.5H" +
-                range1 +
-                "V" +
-                k * tickSizeOuter,
-        ),
+        .attr("stroke", "#000"),
+    );
+
+    path.attr(
+      "d",
+      orient === left || orient == right
+        ? "M" +
+            k * tickSizeOuter +
+            "," +
+            range0 +
+            "H0.5V" +
+            range1 +
+            "H" +
+            k * tickSizeOuter
+        : "M" +
+            range0 +
+            "," +
+            k * tickSizeOuter +
+            "V0.5H" +
+            range1 +
+            "V" +
+            k * tickSizeOuter,
     );
 
     tickEnter


### PR DESCRIPTION
## Summary
- remove unused rule overrides in ESLint config
- fix competitor sample to satisfy eslint after rule removal

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a1a30ca58832b8bef3dbc7b5266b5