### PR TITLE
refactor: extract zoom scheduler

### DIFF
--- a/svg-time-series/src/chart/zoomScheduler.test.ts
+++ b/svg-time-series/src/chart/zoomScheduler.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ZoomTransform } from "d3-zoom";
+import { ZoomScheduler } from "./zoomScheduler.ts";
+
+describe("ZoomScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("applies pending transform and clears state", () => {
+    const apply = vi.fn();
+    const refresh = vi.fn();
+    const zs = new ZoomScheduler(apply, refresh);
+
+    expect(zs.zoom({ x: 1, k: 2 } as unknown as ZoomTransform, {})).toBe(true);
+    vi.runAllTimers();
+    expect(apply).toHaveBeenCalledWith({ x: 1, k: 2 });
+    expect(zs.getCurrentTransform()).toBeNull();
+
+    zs.refresh();
+    vi.runAllTimers();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores unexpected transform while pending", () => {
+    const apply = vi.fn();
+    const refresh = vi.fn();
+    const zs = new ZoomScheduler(apply, refresh);
+
+    expect(zs.zoom({ x: 1, k: 2 } as unknown as ZoomTransform, null)).toBe(
+      true,
+    );
+    expect(apply).toHaveBeenCalledTimes(1);
+
+    expect(zs.zoom({ x: 5, k: 3 } as unknown as ZoomTransform, null)).toBe(
+      false,
+    );
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/svg-time-series/src/chart/zoomScheduler.ts
+++ b/svg-time-series/src/chart/zoomScheduler.ts
@@ -1,0 +1,67 @@
+import type { ZoomTransform } from "d3-zoom";
+import { drawProc } from "../utils/drawProc.ts";
+
+export const sameTransform = (a: ZoomTransform, b: ZoomTransform): boolean =>
+  a.k === b.k && a.x === b.x && a.y === b.y;
+
+export class ZoomScheduler {
+  private currentPanZoomTransformState: ZoomTransform | null = null;
+  private pendingZoomBehaviorTransform = false;
+  private scheduleRefresh: () => void;
+  private cancelRefresh: () => void;
+
+  constructor(
+    private applyTransform: (transform: ZoomTransform) => void,
+    private refreshChart: () => void,
+  ) {
+    const { wrapped, cancel } = drawProc(() => {
+      if (this.currentPanZoomTransformState != null) {
+        this.applyTransform(this.currentPanZoomTransformState);
+        this.currentPanZoomTransformState = null;
+      } else {
+        this.refreshChart();
+      }
+    });
+    this.scheduleRefresh = wrapped;
+    this.cancelRefresh = cancel;
+  }
+
+  public zoom(transform: ZoomTransform, sourceEvent: unknown): boolean {
+    const prevTransform = this.currentPanZoomTransformState;
+    this.currentPanZoomTransformState = transform;
+    if (sourceEvent) {
+      this.pendingZoomBehaviorTransform = true;
+      this.scheduleRefresh();
+    } else if (!this.pendingZoomBehaviorTransform) {
+      this.pendingZoomBehaviorTransform = true;
+      this.applyTransform(this.currentPanZoomTransformState);
+    } else if (
+      prevTransform !== null &&
+      !sameTransform(transform, prevTransform)
+    ) {
+      this.currentPanZoomTransformState = prevTransform;
+      return false;
+    } else {
+      this.pendingZoomBehaviorTransform = false;
+      this.refreshChart();
+      this.currentPanZoomTransformState = null;
+    }
+    return true;
+  }
+
+  public refresh() {
+    this.scheduleRefresh();
+  }
+
+  public destroy() {
+    this.cancelRefresh();
+  }
+
+  public getCurrentTransform(): ZoomTransform | null {
+    return this.currentPanZoomTransformState;
+  }
+
+  public isPending(): boolean {
+    return this.pendingZoomBehaviorTransform;
+  }
+}

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -6,6 +6,7 @@ import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
+import { ZoomScheduler } from "./zoomScheduler.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;
@@ -78,10 +79,10 @@ describe("ZoomState programmatic transforms", () => {
     expect(transformSpy).toHaveBeenCalledTimes(2);
     expect(refresh).toHaveBeenCalledTimes(1);
     interface ZoomStateInternal {
-      currentPanZoomTransformState: unknown;
+      zoomScheduler: ZoomScheduler;
     }
     expect(
-      (zs as unknown as ZoomStateInternal).currentPanZoomTransformState,
+      (zs as unknown as ZoomStateInternal).zoomScheduler.getCurrentTransform(),
     ).toBeNull();
   });
 });

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -7,6 +7,7 @@ import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
 import type { D3ZoomEvent } from "./zoomState.ts";
+import { ZoomScheduler } from "./zoomScheduler.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;
@@ -293,14 +294,12 @@ describe("ZoomState", () => {
 
     vi.runAllTimers();
 
-    expect(
-      (zs1 as unknown as { pendingZoomBehaviorTransform: boolean })
-        .pendingZoomBehaviorTransform,
-    ).toBe(false);
-    expect(
-      (zs1 as unknown as { currentPanZoomTransformState: unknown })
-        .currentPanZoomTransformState,
-    ).toBeNull();
+    interface ZoomStateInternal {
+      zoomScheduler: ZoomScheduler;
+    }
+    const zs1Internal = zs1 as unknown as ZoomStateInternal;
+    expect(zs1Internal.zoomScheduler.isPending()).toBe(false);
+    expect(zs1Internal.zoomScheduler.getCurrentTransform()).toBeNull();
   });
 
   it("programmatic zoom does not reapply transform on subsequent refresh", () => {
@@ -409,9 +408,11 @@ describe("ZoomState", () => {
     expect(y.onZoomPan).toHaveBeenCalledWith(
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
+    interface ZoomStateInternal {
+      zoomScheduler: ZoomScheduler;
+    }
     expect(
-      (zs as unknown as { currentPanZoomTransformState: unknown })
-        .currentPanZoomTransformState,
+      (zs as unknown as ZoomStateInternal).zoomScheduler.getCurrentTransform(),
     ).toBeNull();
     expect(refresh).toHaveBeenCalledTimes(1);
   });

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -7,6 +7,7 @@ import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
 import type { D3ZoomEvent } from "./zoomState.ts";
+import { ZoomScheduler } from "./zoomScheduler.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;
@@ -80,10 +81,10 @@ describe("ZoomState transform state", () => {
 
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 1, k: 2 });
     interface ZoomStateInternal {
-      currentPanZoomTransformState: unknown;
+      zoomScheduler: ZoomScheduler;
     }
     expect(
-      (zs as unknown as ZoomStateInternal).currentPanZoomTransformState,
+      (zs as unknown as ZoomStateInternal).zoomScheduler.getCurrentTransform(),
     ).toBeNull();
 
     transformSpy.mockClear();


### PR DESCRIPTION
## Summary
- create `ZoomScheduler` to manage deferred zoom transforms and refresh scheduling
- use `ZoomScheduler` inside `ZoomState` and expose `ZoomState.validateScaleExtent`
- add standalone tests for the scheduler and update existing tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a1e18c27c832b9507db6e4d0aa0b5