### PR TITLE
fix: clamp zoom transform to scale extent

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
+import { zoomTransform } from "d3-zoom";
 import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
 import type { D3ZoomEvent } from "./zoomState.ts";
@@ -14,11 +15,26 @@ interface MockZoomBehavior {
   translateExtent: vi.Mock;
   on: vi.Mock;
   transform: vi.Mock;
+  scaleTo: vi.Mock;
   triggerZoom: (transform: unknown) => void;
   _zoomHandler?: (event: unknown) => void;
 }
 
 vi.mock("d3-zoom", () => {
+  const transforms = new Map<Element, unknown>();
+  const zoomTransformFn = (node: Element) =>
+    (transforms.get(node) as { k: number; x?: number; y?: number }) || {
+      k: 1,
+      x: 0,
+      y: 0,
+    };
+  const getNode = (s: unknown): Element =>
+    typeof (s as Selection<Element, unknown, HTMLElement, unknown>).node ===
+    "function"
+      ? ((
+          s as Selection<Element, unknown, HTMLElement, unknown>
+        ).node() as Element)
+      : (s as Element);
   return {
     zoom: () => {
       const behavior = vi.fn() as unknown as MockZoomBehavior;
@@ -34,8 +50,20 @@ vi.mock("d3-zoom", () => {
         );
       behavior.transform = vi
         .fn<(s: unknown, transform: unknown) => void>()
-        .mockImplementation((_s, transform) => {
+        .mockImplementation((s, transform) => {
+          const node = getNode(s);
+          transforms.set(node, transform);
           behavior._zoomHandler?.({ transform });
+          return behavior;
+        });
+      behavior.scaleTo = vi
+        .fn<(s: unknown, k: number) => void>()
+        .mockImplementation((s, k) => {
+          const node = getNode(s);
+          const current = zoomTransformFn(node);
+          const newTransform = { ...current, k };
+          transforms.set(node, newTransform);
+          behavior._zoomHandler?.({ transform: newTransform });
           return behavior;
         });
       behavior.triggerZoom = (transform: unknown) => {
@@ -44,6 +72,7 @@ vi.mock("d3-zoom", () => {
       return behavior;
     },
     zoomIdentity: { k: 1, x: 0, y: 0 },
+    zoomTransform: zoomTransformFn,
   };
 });
 
@@ -490,10 +519,9 @@ describe("ZoomState", () => {
   it("updates scale extent at runtime", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      transforms: [y],
+      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
     } as unknown as RenderState;
     const zs = new ZoomState(
@@ -514,6 +542,54 @@ describe("ZoomState", () => {
     expect(scaleSpy).toHaveBeenCalledWith([2, 80]);
   });
 
+  it("clamps existing transform to new scale extent", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
+      axisRenders: [],
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      state,
+      vi.fn(),
+    );
+
+    zs.zoomBehavior.transform(rect, { k: 10, x: 0, y: 0 });
+    const scaleSpy = zs.zoomBehavior.scaleTo as unknown as vi.Mock;
+    scaleSpy.mockClear();
+
+    zs.setScaleExtent([1, 5]);
+
+    expect(scaleSpy).toHaveBeenCalledWith(rect, 5);
+    expect(zoomTransform(rect.node()!)).toMatchObject({ k: 5 });
+  });
+
+  it("clamps existing transform to new minimum", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
+      axisRenders: [],
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      state,
+      vi.fn(),
+    );
+
+    zs.zoomBehavior.transform(rect, { k: 0.2, x: 0, y: 0 });
+    const scaleSpy = zs.zoomBehavior.scaleTo as unknown as vi.Mock;
+    scaleSpy.mockClear();
+
+    zs.setScaleExtent([0.5, 5]);
+
+    expect(scaleSpy).toHaveBeenCalledWith(rect, 0.5);
+    expect(zoomTransform(rect.node()!)).toMatchObject({ k: 0.5 });
+  });
+
   it.each([
     [1, 10],
     [0.5, 20],
@@ -522,6 +598,7 @@ describe("ZoomState", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
+      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
     } as unknown as RenderState;
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,5 +1,10 @@
 import type { Selection } from "d3-selection";
-import { zoom as d3zoom, ZoomTransform, zoomIdentity } from "d3-zoom";
+import {
+  zoom as d3zoom,
+  ZoomTransform,
+  zoomIdentity,
+  zoomTransform,
+} from "d3-zoom";
 import type { D3ZoomEvent, ZoomBehavior } from "d3-zoom";
 import { drawProc } from "../utils/drawProc.ts";
 import type { RenderState } from "./render.ts";
@@ -113,6 +118,12 @@ export class ZoomState {
     this.validateScaleExtent(extent);
     this.scaleExtent = extent;
     this.zoomBehavior.scaleExtent(extent);
+    const current = zoomTransform(this.zoomArea.node()!);
+    const [min, max] = extent;
+    const clampedK = Math.max(min, Math.min(max, current.k));
+    if (clampedK !== current.k) {
+      this.zoomBehavior.scaleTo(this.zoomArea, clampedK);
+    }
   };
 
   public updateExtents = (dimensions: { width: number; height: number }) => {


### PR DESCRIPTION
## Summary
- clamp zoom transform to new scale extent if outside range
- test clamping behavior when updating scale extent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a21d44f70832ba335d2ea82101fec