### PR TITLE
test: fix some type errors in charts

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -9,7 +9,7 @@ describe("ChartData", () => {
     timeStep: 1,
     length: data.length,
     seriesCount: data[0]?.length ?? 0,
-    getSeries: (i, seriesIdx) => data[i][seriesIdx]!,
+    getSeries: (i, seriesIdx) => data[i]![seriesIdx]!,
     seriesAxes,
   });
 
@@ -450,7 +450,7 @@ describe("ChartData", () => {
         timeStep: 1,
         length: 2,
         seriesCount: 1,
-        getSeries: (i) => [0, 1][i],
+        getSeries: (i) => [0, 1][i]!,
         seriesAxes: [0],
       };
       const cd = new ChartData(source);
@@ -467,7 +467,7 @@ describe("ChartData", () => {
         timeStep: 1,
         length: 1,
         seriesCount: 1,
-        getSeries: (i) => [0][i],
+        getSeries: (i) => [0][i]!,
         seriesAxes: [0],
       };
       const cd = new ChartData(source);

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -2,7 +2,15 @@
  * @vitest-environment jsdom
  */
 /* eslint-disable @typescript-eslint/no-useless-constructor */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
@@ -20,7 +28,7 @@ vi.mock("../utils/domNodeTransform.ts", () => ({
 }));
 
 let currentDataLength = 0;
-const transformInstances: Array<{ onZoomPan: vi.Mock }> = [];
+const transformInstances: Array<{ onZoomPan: Mock }> = [];
 vi.mock("../ViewportTransform.ts", () => ({
   ViewportTransform: class {
     constructor() {
@@ -49,10 +57,10 @@ vi.mock("../axis.ts", () => ({
   },
 }));
 
-let zoomReset: vi.Mock;
-let legendRefresh: vi.Mock;
+let zoomReset: Mock;
+let legendRefresh: Mock;
 let zoomOptions: unknown;
-let zoomSetScaleExtent: vi.Mock;
+let zoomSetScaleExtent: Mock;
 vi.mock("../../../samples/LegendController.ts", () => ({
   LegendController: class {
     refresh = vi.fn();

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -2,7 +2,15 @@
  * @vitest-environment jsdom
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  vi,
+  type Mock,
+} from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import { AR1Basis } from "../math/affine.ts";
@@ -21,7 +29,7 @@ vi.mock("../utils/domNodeTransform.ts", () => ({
 }));
 
 let currentDataLength = 0;
-const transformInstances: Array<{ onZoomPan: vi.Mock }> = [];
+const transformInstances: Array<{ onZoomPan: Mock }> = [];
 vi.mock("../ViewportTransform.ts", () => ({
   ViewportTransform: class {
     constructor() {
@@ -38,7 +46,7 @@ vi.mock("../ViewportTransform.ts", () => ({
   },
 }));
 
-const axisInstances: Array<{ axisUpCalls: number; axisUp: vi.Mock }> = [];
+const axisInstances: Array<{ axisUpCalls: number; axisUp: Mock }> = [];
 vi.mock("../axis.ts", () => ({
   Orientation: { Bottom: 0, Right: 1 },
   MyAxis: class {

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -103,7 +103,7 @@ class Point {
 }
 
 const globalObj = globalThis as unknown as Record<string, unknown>;
-globalObj.DOMMatrix = Matrix;
+globalObj["DOMMatrix"] = Matrix;
 globalObj.DOMPoint = Point;
 if (typeof SVGSVGElement !== "undefined") {
   (


### PR DESCRIPTION
## Summary
- use non-null assertions to satisfy data source types in chart tests
- replace `vi.Mock` with Vitest `Mock` type and fix related declarations
- handle DOMMatrix export via bracket notation in DOM setup

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2584a210832bb735e3ccb77ba162