### PR TITLE
refactor: create series factory

### DIFF
--- a/svg-time-series/bench/renderPaths.bench.ts
+++ b/svg-time-series/bench/renderPaths.bench.ts
@@ -4,14 +4,13 @@
 import { bench, describe } from "vitest";
 import { select } from "d3-selection";
 import { SeriesRenderer } from "../src/chart/seriesRenderer.ts";
-import { SeriesManager } from "../src/chart/series.ts";
+import { createSeries } from "../src/chart/series.ts";
 import { sizes, datasets } from "./timeSeriesData.ts";
 
 describe("renderPaths performance", () => {
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   const renderer = new SeriesRenderer();
-  const manager = new SeriesManager(select(svg), [0, 1]);
-  renderer.series = manager.series;
+  renderer.series = createSeries(select(svg), [0, 1]);
 
   sizes.forEach((size, idx) => {
     const data = datasets[idx];

--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -5,14 +5,14 @@ import { describe, it, expect, vi } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import { SeriesRenderer } from "./seriesRenderer.ts";
-import { SeriesManager } from "./series.ts";
+import { createSeries } from "./series.ts";
 
 describe("SeriesRenderer", () => {
   describe("draw", () => {
     it("skips segments for NaN values", () => {
       const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
       const renderer = new SeriesRenderer();
-      const manager = new SeriesManager(
+      renderer.series = createSeries(
         select(svg) as unknown as Selection<
           SVGSVGElement,
           unknown,
@@ -21,7 +21,6 @@ describe("SeriesRenderer", () => {
         >,
         [0, 1],
       );
-      renderer.series = manager.series;
       const data: Array<[number, number]> = [
         [0, 0],
         [NaN, NaN],
@@ -40,9 +39,9 @@ describe("SeriesRenderer", () => {
         "svg",
       ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
       const renderer = new SeriesRenderer();
-      const manager = new SeriesManager(svgSelection, [0]);
-      const [series] = manager.series;
-      renderer.series = manager.series;
+      const seriesList = createSeries(svgSelection, [0]);
+      const [series] = seriesList;
+      renderer.series = seriesList;
       const pathNode = series.path;
       const spy = vi.spyOn(pathNode, "setAttribute");
 
@@ -57,13 +56,12 @@ describe("SeriesRenderer", () => {
   });
 });
 
-describe("SeriesManager", () => {
+describe("createSeries", () => {
   it("creates a view and path", () => {
     const svgSelection = select(document.createElement("div")).append(
       "svg",
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
-    const manager = new SeriesManager(svgSelection, [0]);
-    const [series] = manager.series;
+    const [series] = createSeries(svgSelection, [0]);
 
     expect(series.view.tagName).toBe("g");
     expect(series.path.tagName).toBe("path");

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -11,7 +11,7 @@ import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 import type { ChartData } from "./data.ts";
 import { createDimensions } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
-import { SeriesManager } from "./series.ts";
+import { createSeries } from "./series.ts";
 
 function createYAxis(
   orientation: Orientation,
@@ -118,10 +118,9 @@ export function setupRender(
     a.transform.onReferenceViewWindowResize(referenceBasis);
   }
 
-  const seriesManager = new SeriesManager(svg, data.seriesAxes);
+  const series = createSeries(svg, data.seriesAxes);
   const seriesRenderer = new SeriesRenderer();
-  seriesRenderer.series = seriesManager.series;
-  const { series } = seriesManager;
+  seriesRenderer.series = series;
   const xAxis = new MyAxis(Orientation.Bottom, xScale)
     .ticks(4)
     .setTickSize(height)

--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -4,23 +4,19 @@ import { line, type Line } from "d3-shape";
 import type { Series } from "./render.ts";
 import { createSeriesNodes } from "./render/utils.ts";
 
-export class SeriesManager {
-  public readonly series: Series[];
+function createLine(seriesIdx: number): Line<number[]> {
+  return line<number[]>()
+    .defined((d) => !isNaN(d[seriesIdx]!))
+    .x((_, i) => i)
+    .y((d) => d[seriesIdx]!);
+}
 
-  constructor(
-    svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
-    seriesAxes: number[],
-  ) {
-    this.series = seriesAxes.map((axisIdx, i) => {
-      const { view, path } = createSeriesNodes(svg);
-      return { axisIdx, view, path, line: this.createLine(i) };
-    });
-  }
-
-  private createLine(seriesIdx: number): Line<number[]> {
-    return line<number[]>()
-      .defined((d) => !isNaN(d[seriesIdx]!))
-      .x((_, i) => i)
-      .y((d) => d[seriesIdx]!);
-  }
+export function createSeries(
+  svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
+  seriesAxes: number[],
+): Series[] {
+  return seriesAxes.map((axisIdx, i) => {
+    const { view, path } = createSeriesNodes(svg);
+    return { axisIdx, view, path, line: createLine(i) };
+  });
 }


### PR DESCRIPTION
## Summary
- add `createSeries` function for generating line render data
- update renderer setup to use new series factory
- adjust tests to call `createSeries`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a25f448b8832b99d2ec83a7784845