### PR TITLE
Fix twenty TypeScript errors in tests

### DIFF
--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -109,13 +109,23 @@ function createChart(data: Array<[number]>) {
     length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
+    getSeries: (i) => data[i]![0],
   };
   const legendController = new LegendController(
-    select(legend) as Selection<HTMLElement, unknown, null, undefined>,
+    select(legend) as unknown as Selection<
+      HTMLElement,
+      unknown,
+      HTMLElement,
+      unknown
+    >,
   );
   const chart = new TimeSeriesChart(
-    select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
+    select(svgEl) as unknown as Selection<
+      SVGSVGElement,
+      unknown,
+      HTMLElement,
+      unknown
+    >,
     source,
     legendController,
     () => {},
@@ -152,9 +162,9 @@ describe("chart interaction single-axis", () => {
     const { zoom } = createChart([[0], [1]]);
     vi.runAllTimers();
 
-    const xAxis = axisInstances[0];
+    const xAxis = axisInstances[0]!;
     const yAxis = axisInstances[1];
-    const mtNy = transformInstances[0];
+    const mtNy = transformInstances[0]!;
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -22,7 +22,7 @@ function createSvg() {
   const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  return select(div).select("svg") as Selection<
+  return select(div).select("svg") as unknown as Selection<
     SVGSVGElement,
     unknown,
     HTMLElement,
@@ -40,7 +40,7 @@ describe("RenderState.refresh integration", () => {
       seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
-        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+        seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
@@ -49,15 +49,15 @@ describe("RenderState.refresh integration", () => {
       .mockImplementation(() => {});
 
     const xBefore = state.axes.x.scale.domain().slice();
-    const yNyBefore = state.axes.y[0].scale.domain().slice();
-    const ySfBefore = state.axes.y[1].scale.domain().slice();
+    const yNyBefore = state.axes.y[0]!.scale.domain().slice();
+    const ySfBefore = state.axes.y[1]!.scale.domain().slice();
 
     data.append(100, 200);
     state.refresh(data);
 
     const xAfter = state.axes.x.scale.domain();
-    const yNyAfter = state.axes.y[0].scale.domain();
-    const ySfAfter = state.axes.y[1].scale.domain();
+    const yNyAfter = state.axes.y[0]!.scale.domain();
+    const ySfAfter = state.axes.y[1]!.scale.domain();
 
     expect(xAfter).not.toEqual(xBefore);
     expect(yNyAfter).not.toEqual(yNyBefore);
@@ -70,10 +70,10 @@ describe("RenderState.refresh integration", () => {
       (state.axes.x.axis as unknown as AxisWithScale1).scale1.domain(),
     ).toEqual(xAfter);
     expect(
-      (state.axisRenders[0].axis as unknown as AxisWithScale1).scale1.domain(),
+      (state.axisRenders[0]!.axis as unknown as AxisWithScale1).scale1.domain(),
     ).toEqual(yNyAfter);
     expect(
-      (state.axisRenders[1].axis as unknown as AxisWithScale1).scale1.domain(),
+      (state.axisRenders[1]!.axis as unknown as AxisWithScale1).scale1.domain(),
     ).toEqual(ySfAfter);
 
     expect(updateNodeSpy).toHaveBeenCalledTimes(state.series.length);

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -38,7 +38,7 @@ function createSvg() {
   const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  return select(div).select("svg") as Selection<
+  return select(div).select("svg") as unknown as Selection<
     SVGSVGElement,
     unknown,
     HTMLElement,
@@ -55,7 +55,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
+      getSeries: (i) => [1, 2, 3][i]!,
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
@@ -65,12 +65,12 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.series.length).toBe(1);
-    expect(state.axes.y[state.series[0].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[0]!.axisIdx]!.scale.domain()).toEqual([
       1, 3,
     ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      const t = state.axes.y[s.axisIdx].transform;
+      const t = state.axes.y[s.axisIdx]!.transform;
       expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });


### PR DESCRIPTION
## Summary
- use non-null assertions and explicit casts to address TypeScript issues in chart tests
- clean up sample legend controller usage in interaction test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2e631f18832bb7640c28f427d23d