### PR TITLE
Fix initial TypeScript errors in tests

### DIFF
--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -88,11 +88,16 @@ function createChart(data: Array<[number]>) {
     length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
+    getSeries: (i) => data[i]![0]!,
   };
   const legendController = new StubLegendController();
   const chart = new TimeSeriesChart(
-    select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
+    select(svgEl) as unknown as Selection<
+      SVGSVGElement,
+      unknown,
+      HTMLElement,
+      unknown
+    >,
     source,
     legendController,
     () => {},

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -163,15 +163,13 @@ describe("chart interaction single-axis", () => {
     vi.runAllTimers();
 
     const xAxis = axisInstances[0]!;
-    const yAxis = axisInstances[1];
+    const yAxis = axisInstances[1]!;
     const mtNy = transformInstances[0]!;
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
 
-    zoom({ transform: { x: 10, k: 2 } } as unknown as {
-      transform: { x: number; k: number };
-    });
+    zoom({ transform: { x: 10, k: 2 } } as Parameters<typeof zoom>[0]);
     vi.runAllTimers();
     vi.runAllTimers();
 

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -83,7 +83,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
@@ -92,15 +92,15 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.axes.y[state.series[0].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[0]!.axisIdx]!.scale.domain()).toEqual([
       1, 3,
     ]);
-    expect(state.axes.y[state.series[1].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[1]!.axisIdx]!.scale.domain()).toEqual([
       10, 30,
     ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      const t = state.axes.y[s.axisIdx].transform;
+      const t = state.axes.y[s.axisIdx]!.transform;
       expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });
@@ -113,7 +113,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 0],
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
@@ -121,7 +121,7 @@ describe("RenderState.refresh", () => {
     state.refresh(data);
 
     expect(state.axes.y).toHaveLength(1);
-    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y[0]!.scale.domain()).toEqual([1, 30]);
   });
 
   it("refreshes after data changes", () => {
@@ -132,7 +132,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
     const data1 = new ChartData(source1);
     const state = setupRender(svg, data1);
@@ -143,7 +143,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, s) => (s === 0 ? [4, 5, 6][i] : [40, 50, 60][i]),
+      getSeries: (i, s) => (s === 0 ? [4, 5, 6][i]! : [40, 50, 60][i]!),
     };
     const data2 = new ChartData(source2);
     const updateNodeMock = vi.mocked(updateNode);
@@ -151,8 +151,8 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data2);
 
-    expect(state.axes.y[0].scale.domain()).toEqual([4, 6]);
-    expect(state.axes.y[1].scale.domain()).toEqual([40, 60]);
+    expect(state.axes.y[0]!.scale.domain()).toEqual([4, 6]);
+    expect(state.axes.y[1]!.scale.domain()).toEqual([40, 60]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
   });
 
@@ -164,17 +164,17 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
+      getSeries: (i) => [1, 2, 3][i]!,
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
 
-    expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 1, max: 3 });
+    expect(state.axes.y[0]!.tree.query(0, 2)).toEqual({ min: 1, max: 3 });
 
     data.append(4);
     state.refresh(data);
 
-    expect(state.axes.y[0].tree.query(0, 2)).toEqual({ min: 2, max: 4 });
+    expect(state.axes.y[0]!.tree.query(0, 2)).toEqual({ min: 2, max: 4 });
   });
 
   it("throws when series is all Infinity", () => {


### PR DESCRIPTION
## Summary
- resolve first batch of TypeScript issues across tests
- document remaining error count and revert test type checking

## Testing
- `npm run typecheck`
- `vitest run`


------
https://chatgpt.com/codex/tasks/task_e_689a34198fe8832b98ee6f7dc1a03408