### PR TITLE
test: fix type errors in unit tests

### DIFF
--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -83,7 +83,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
@@ -92,15 +92,15 @@ describe("RenderState.refresh", () => {
 
     state.refresh(data);
 
-    expect(state.axes.y[state.series[0].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[0]!.axisIdx]!.scale.domain()).toEqual([
       1, 3,
     ]);
-    expect(state.axes.y[state.series[1].axisIdx].scale.domain()).toEqual([
+    expect(state.axes.y[state.series[1]!.axisIdx]!.scale.domain()).toEqual([
       10, 30,
     ]);
     expect(updateNodeMock).toHaveBeenCalledTimes(state.series.length);
     state.series.forEach((s, i) => {
-      const t = state.axes.y[s.axisIdx].transform;
+      const t = state.axes.y[s.axisIdx]!.transform;
       expect(updateNodeMock).toHaveBeenNthCalledWith(i + 1, s.view, t.matrix);
     });
   });
@@ -113,7 +113,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 0],
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
@@ -132,7 +132,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i] : [10, 20, 30][i]),
+      getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
     const data1 = new ChartData(source1);
     const state = setupRender(svg, data1);
@@ -143,7 +143,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 2,
       seriesAxes: [0, 1],
-      getSeries: (i, s) => (s === 0 ? [4, 5, 6][i] : [40, 50, 60][i]),
+      getSeries: (i, s) => (s === 0 ? [4, 5, 6][i]! : [40, 50, 60][i]!),
     };
     const data2 = new ChartData(source2);
     const updateNodeMock = vi.mocked(updateNode);
@@ -164,7 +164,7 @@ describe("RenderState.refresh", () => {
       length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
+      getSeries: (i) => [1, 2, 3][i]!,
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -23,8 +23,8 @@ function createSegmentTree<T>(
 test("SegmentTree operations", () => {
   const data = [1, 3, 2, 5, 4];
   const buildTuple = (index: number, elements: readonly number[]): IMinMax => ({
-    min: elements[index],
-    max: elements[index],
+    min: elements[index]!,
+    max: elements[index]!,
   });
 
   const tree = createSegmentTree(data, data.length, buildTuple);
@@ -63,7 +63,7 @@ test("SegmentTree with IMinMax", () => {
     { min: 4, max: 7 },
   ];
   const buildTuple = (index: number, elements: readonly IMinMax[]): IMinMax =>
-    elements[index];
+    elements[index]!;
 
   const tree = createSegmentTree(data, data.length, buildTuple);
 

--- a/svg-time-series/src/utils/domMatrix.test.ts
+++ b/svg-time-series/src/utils/domMatrix.test.ts
@@ -9,13 +9,19 @@ import { Matrix } from "../../../test/setupDom.ts";
 
 describe("applyAR1ToMatrix helpers", () => {
   it("translates and scales along X axis", () => {
-    const matrix = applyAR1ToMatrixX(new AR1([2, 3]), new Matrix());
+    const matrix = applyAR1ToMatrixX(
+      new AR1([2, 3]),
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(matrix.a).toBeCloseTo(2);
     expect(matrix.e).toBeCloseTo(3);
   });
 
   it("translates and scales along Y axis", () => {
-    const matrix = applyAR1ToMatrixY(new AR1([4, 5]), new Matrix());
+    const matrix = applyAR1ToMatrixY(
+      new AR1([4, 5]),
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(matrix.d).toBeCloseTo(4);
     expect(matrix.f).toBeCloseTo(5);
   });
@@ -24,7 +30,10 @@ describe("applyAR1ToMatrix helpers", () => {
 describe("applyDirectProductToMatrix", () => {
   it("combines independent AR1 transforms", () => {
     const dp = new DirectProduct(new AR1([2, 3]), new AR1([4, 5]));
-    const matrix = applyDirectProductToMatrix(dp, new Matrix());
+    const matrix = applyDirectProductToMatrix(
+      dp,
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(matrix.a).toBeCloseTo(2);
     expect(matrix.d).toBeCloseTo(4);
     expect(matrix.e).toBeCloseTo(3);

--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -62,7 +62,7 @@ describe("updateNode", () => {
   it("converts DOMMatrix to SVGMatrix", () => {
     const node = createNode();
     const domMatrix = new Matrix().translate(5, 6);
-    updateNode(node, domMatrix);
+    updateNode(node, domMatrix as unknown as DOMMatrix);
     const last = node.transform.baseVal.last as FakeSVGMatrix;
     expect(last).toBeInstanceOf(FakeSVGMatrix);
     expect(last.e).toBeCloseTo(5);

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -42,7 +42,7 @@ describe("AR1 and AR1Basis", () => {
 
 describe("DirectProduct", () => {
   it("applies independent transforms on axes", () => {
-    const identity = new Matrix();
+    const identity = new Matrix() as unknown as DOMMatrix;
     const b1 = new DirectProductBasis([0, 0], [1, 1]);
     const b2 = new DirectProductBasis([10, 10], [20, 30]);
     const dp = betweenTBasesDirectProduct(b1, b2);
@@ -72,11 +72,17 @@ describe("DirectProductBasis utilities", () => {
 
 describe("viewZoomTransform helpers", () => {
   it("applies AR1 transforms along X and Y axes", () => {
-    const mx = applyAR1ToMatrixX(new AR1([2, 3]), new Matrix());
+    const mx = applyAR1ToMatrixX(
+      new AR1([2, 3]),
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(mx.a).toBeCloseTo(2);
     expect(mx.e).toBeCloseTo(3);
 
-    const my = applyAR1ToMatrixY(new AR1([3, 4]), new Matrix());
+    const my = applyAR1ToMatrixY(
+      new AR1([3, 4]),
+      new Matrix() as unknown as DOMMatrix,
+    );
     expect(my.d).toBeCloseTo(3);
     expect(my.f).toBeCloseTo(4);
   });
@@ -91,9 +97,11 @@ describe("viewZoomTransform helpers", () => {
     };
     const node = {
       transform: { baseVal },
-      ownerSVGElement: { createSVGMatrix: () => new Matrix() },
+      ownerSVGElement: {
+        createSVGMatrix: () => new Matrix() as unknown as DOMMatrix,
+      },
     } as unknown as SVGGraphicsElement;
-    const matrix = new Matrix(1, 0, 0, 1, 2, 3);
+    const matrix = new Matrix(1, 0, 0, 1, 2, 3) as unknown as DOMMatrix;
 
     updateNode(node, matrix);
     expect(calls[0]).toBe(matrix);


### PR DESCRIPTION
## Summary
- add non-null assertions in segment tree tests
- cast test matrices to DOMMatrix
- guard chart refresh tests against undefined data

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a381b365c832b892131366a99a353