### PR TITLE
feat(chart): validate positive integer lengths and series counts

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -13,16 +13,44 @@ describe("ChartData", () => {
     seriesAxes,
   });
 
-  it("throws if constructed with empty data", () => {
-    const source: IDataSource = {
+  it("throws when length is not a positive integer", () => {
+    const base: IDataSource = {
       startTime: 0,
       timeStep: 1,
-      length: 0,
+      length: 1,
       seriesCount: 1,
       getSeries: () => 0,
       seriesAxes: [0],
     };
-    expect(() => new ChartData(source)).toThrow(/non-empty data array/);
+    expect(() => new ChartData({ ...base, length: 0 })).toThrow(
+      /length.*positive integer/,
+    );
+    expect(() => new ChartData({ ...base, length: -1 })).toThrow(
+      /length.*positive integer/,
+    );
+    expect(() => new ChartData({ ...base, length: 1.5 })).toThrow(
+      /length.*positive integer/,
+    );
+  });
+
+  it("throws when seriesCount is not a positive integer", () => {
+    const base: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 1,
+      seriesCount: 1,
+      getSeries: () => 0,
+      seriesAxes: [0],
+    };
+    expect(() => new ChartData({ ...base, seriesCount: 0 })).toThrow(
+      /seriesCount.*positive integer/,
+    );
+    expect(() => new ChartData({ ...base, seriesCount: -1 })).toThrow(
+      /seriesCount.*positive integer/,
+    );
+    expect(() => new ChartData({ ...base, seriesCount: 1.5 })).toThrow(
+      /seriesCount.*positive integer/,
+    );
   });
 
   it("throws when startTime is not finite", () => {

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -26,11 +26,11 @@ export interface IDataSource {
 }
 
 function validateSource(source: IDataSource): void {
-  if (source.length === 0) {
-    throw new Error("ChartData requires a non-empty data array");
+  if (!Number.isInteger(source.length) || source.length <= 0) {
+    throw new Error("ChartData requires length to be a positive integer");
   }
-  if (source.seriesCount < 1) {
-    throw new Error("ChartData requires at least one series");
+  if (!Number.isInteger(source.seriesCount) || source.seriesCount <= 0) {
+    throw new Error("ChartData requires seriesCount to be a positive integer");
   }
   if (!Number.isFinite(source.startTime)) {
     throw new Error("ChartData requires startTime to be a finite number");


### PR DESCRIPTION
## Summary
- ensure `validateSource` enforces positive integer `length` and `seriesCount`
- add tests covering invalid lengths and series counts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3bc85e10832bba00ff067a2411cb