### PR TITLE
refactor: iterate over seriesByAxis in updateScales

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -71,14 +71,10 @@ export class AxisManager {
 
   updateScales(bIndex: AR1Basis, data: ChartData): void {
     updateScaleX(this.x, bIndex, data);
-    const axisIndices: number[] = [];
-    for (const idx of data.seriesAxes) {
-      if (!axisIndices.includes(idx)) {
-        axisIndices.push(idx);
+    for (const [i, idxs] of data.seriesByAxis.entries()) {
+      if (idxs.length === 0) {
+        continue;
       }
-    }
-
-    for (const i of axisIndices) {
       if (i >= this.axes.length) {
         throw new Error(
           `Series axis index ${String(i)} out of bounds (max ${String(

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -6,10 +6,34 @@ import {
   betweenTBasesAR1,
 } from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
-import type { ChartData } from "./data.ts";
+import { ChartData } from "./data.ts";
 import "../../../test/setupDom.ts";
 
 describe("updateScales", () => {
+  it("updates domains for two axes using ChartData", () => {
+    const axisManager = new AxisManager();
+    axisManager.setXAxis(scaleTime().range([0, 1]));
+    const axes = axisManager.create(2);
+    axes.forEach((a) => a.scale.range([0, 1]));
+
+    const source = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      seriesCount: 2,
+      seriesAxes: [0, 1],
+      getSeries: (i: number, seriesIdx: number) =>
+        seriesIdx === 0 ? [1, 3][i]! : [10, 30][i]!,
+    };
+    const data = new ChartData(source);
+
+    const bIndexVisible = new AR1Basis(0, 1);
+    axisManager.updateScales(bIndexVisible, data);
+
+    expect(axes[0].scale.domain()).toEqual([1, 3]);
+    expect(axes[1].scale.domain()).toEqual([10, 30]);
+  });
+
   it("updates domains for multiple axes", () => {
     const axisManager = new AxisManager();
     axisManager.setXAxis(scaleTime().range([0, 1]));


### PR DESCRIPTION
## Summary
- update AxisManager.updateScales to iterate over precomputed seriesByAxis arrays
- remove redundant dedupe of seriesAxes
- add test exercising updateScales with two axes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3f391d9c832bb3e5a69c5891c332