### PR TITLE
fix: clamp zoom translations to updated extents

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -22,13 +22,29 @@ interface MockZoomBehavior {
 }
 
 vi.mock("d3-zoom", () => {
-  const transforms = new Map<Element, unknown>();
-  const zoomTransformFn = (node: Element) =>
-    (transforms.get(node) as { k: number; x?: number; y?: number }) || {
-      k: 1,
-      x: 0,
-      y: 0,
+  const transforms = new Map<Element, ReturnType<typeof createTransform>>();
+  function createTransform(k = 1, x = 0, y = 0) {
+    return {
+      k,
+      x,
+      y,
+      translate(dx: number, dy: number) {
+        return createTransform(
+          this.k,
+          this.x + this.k * dx,
+          this.y + this.k * dy,
+        );
+      },
+      invertX(x: number) {
+        return (x - this.x) / this.k;
+      },
+      invertY(y: number) {
+        return (y - this.y) / this.k;
+      },
     };
+  }
+  const zoomTransformFn = (node: Element) =>
+    transforms.get(node) || createTransform();
   const getNode = (s: unknown): Element =>
     typeof (s as Selection<Element, unknown, HTMLElement, unknown>).node ===
     "function"
@@ -72,7 +88,7 @@ vi.mock("d3-zoom", () => {
       };
       return behavior;
     },
-    zoomIdentity: { k: 1, x: 0, y: 0 },
+    zoomIdentity: createTransform(),
     zoomTransform: zoomTransformFn,
   };
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,11 +1,6 @@
 import type { Selection } from "d3-selection";
-import {
-  zoom as d3zoom,
-  ZoomTransform,
-  zoomIdentity,
-  zoomTransform,
-} from "d3-zoom";
-import type { D3ZoomEvent, ZoomBehavior } from "d3-zoom";
+import { zoom as d3zoom, zoomIdentity, zoomTransform } from "d3-zoom";
+import type { D3ZoomEvent, ZoomBehavior, ZoomTransform } from "d3-zoom";
 import { ZoomScheduler, sameTransform } from "./zoomScheduler.ts";
 import type { RenderState } from "./render.ts";
 
@@ -104,6 +99,17 @@ export class ZoomState {
       [0, 0],
       [dimensions.width, dimensions.height],
     ]);
+    const current = zoomTransform(this.zoomArea.node()!);
+    const x0 = current.invertX(0);
+    const x1 = current.invertX(dimensions.width) - dimensions.width;
+    const y0 = current.invertY(0);
+    const y1 = current.invertY(dimensions.height) - dimensions.height;
+    const tx = x1 > x0 ? (x0 + x1) / 2 : Math.min(0, x0) || Math.max(0, x1);
+    const ty = y1 > y0 ? (y0 + y1) / 2 : Math.min(0, y0) || Math.max(0, y1);
+    if (tx !== 0 || ty !== 0) {
+      const constrained = current.translate(tx, ty);
+      this.zoomBehavior.transform(this.zoomArea, constrained);
+    }
   };
 
   public reset = () => {

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -1,0 +1,133 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import { zoomIdentity, zoomTransform } from "d3-zoom";
+import type { RenderState } from "./render.ts";
+import { ZoomState } from "./zoomState.ts";
+
+interface MockZoomBehavior {
+  (_s: unknown): void;
+  scaleExtent: vi.Mock;
+  translateExtent: vi.Mock;
+  on: vi.Mock;
+  transform: vi.Mock;
+  triggerZoom: (transform: unknown) => void;
+  _zoomHandler?: (event: unknown) => void;
+}
+
+vi.mock("d3-zoom", () => {
+  interface Transform {
+    k: number;
+    x: number;
+    y: number;
+    translate(dx: number, dy: number): Transform;
+    scale(k2: number): Transform;
+    invertX(x: number): number;
+    invertY(y: number): number;
+  }
+  const transforms = new Map<Element, Transform>();
+  function createTransform(k = 1, x = 0, y = 0): Transform {
+    return {
+      k,
+      x,
+      y,
+      translate(dx: number, dy: number) {
+        return createTransform(
+          this.k,
+          this.x + this.k * dx,
+          this.y + this.k * dy,
+        );
+      },
+      scale(k2: number) {
+        return createTransform(this.k * k2, this.x, this.y);
+      },
+      invertX(x: number) {
+        return (x - this.x) / this.k;
+      },
+      invertY(y: number) {
+        return (y - this.y) / this.k;
+      },
+    };
+  }
+  const zoomTransformFn = (node: Element): Transform =>
+    transforms.get(node) || createTransform();
+  const getNode = (s: unknown): Element =>
+    typeof (s as Selection<Element, unknown, HTMLElement, unknown>).node ===
+    "function"
+      ? ((
+          s as Selection<Element, unknown, HTMLElement, unknown>
+        ).node() as Element)
+      : (s as Element);
+  return {
+    zoom: () => {
+      const behavior = vi.fn() as unknown as MockZoomBehavior;
+      behavior.scaleExtent = vi.fn().mockReturnValue(behavior);
+      behavior.translateExtent = vi.fn().mockReturnValue(behavior);
+      behavior.on = vi
+        .fn()
+        .mockImplementation(
+          (_event: string, handler: (event: unknown) => void) => {
+            behavior._zoomHandler = handler;
+            return behavior;
+          },
+        );
+      behavior.transform = vi
+        .fn()
+        .mockImplementation((s: unknown, transform: Transform) => {
+          const node = getNode(s);
+          transforms.set(node, transform);
+          behavior._zoomHandler?.({ transform });
+          return behavior;
+        });
+      behavior.triggerZoom = (transform: unknown) => {
+        behavior._zoomHandler?.({ transform });
+      };
+      return behavior;
+    },
+    zoomIdentity: createTransform(),
+    zoomTransform: zoomTransformFn,
+  };
+});
+
+describe("ZoomState.updateExtents clamp", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("clamps existing translation to new bounds", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 100, height: 100 },
+      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
+      axisRenders: [],
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      state,
+      vi.fn(),
+    );
+
+    const initial = zoomIdentity.translate(-120, -80).scale(2);
+    zs.zoomBehavior.transform(rect, initial);
+    const transformSpy = zs.zoomBehavior.transform as unknown as vi.Mock;
+    transformSpy.mockClear();
+
+    zs.updateExtents({ width: 50, height: 50 });
+
+    expect(transformSpy).toHaveBeenCalledWith(
+      rect,
+      expect.objectContaining({ x: -50, y: -50, k: 2 }),
+    );
+    expect(transformSpy).toHaveBeenCalledTimes(2);
+    expect(zoomTransform(rect.node()!)).toMatchObject({ x: -50, y: -50, k: 2 });
+  });
+});


### PR DESCRIPTION
## Summary
- clamp current transform within new translate extents when chart size changes
- test translation clamping after updating extents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3be48448832b93ebff65f5c658c7