### PR TITLE
test: fix initial TypeScript errors

### DIFF
--- a/svg-time-series/src/chart/render.test.ts
+++ b/svg-time-series/src/chart/render.test.ts
@@ -29,7 +29,7 @@ describe("SeriesRenderer", () => {
 
       renderer.draw(data);
 
-      const d = select(renderer.series[0].path).attr("d");
+      const d = select(renderer.series[0]!.path).attr("d");
       expect(d).not.toContain("NaN");
       expect(d.match(/M/g)?.length).toBe(2);
     });
@@ -42,7 +42,7 @@ describe("SeriesRenderer", () => {
       const seriesList = createSeries(svgSelection, [0]);
       const [series] = seriesList;
       renderer.series = seriesList;
-      const pathNode = series.path;
+      const pathNode = series!.path;
       const spy = vi.spyOn(pathNode, "setAttribute");
 
       renderer.draw([[0], [1]]);
@@ -63,7 +63,7 @@ describe("createSeries", () => {
     ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
     const [series] = createSeries(svgSelection, [0]);
 
-    expect(series.view.tagName).toBe("g");
-    expect(series.path.tagName).toBe("path");
+    expect(series!.view.tagName).toBe("g");
+    expect(series!.path.tagName).toBe("path");
   });
 });

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -66,7 +66,7 @@ describe("updateScaleX", () => {
     length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
+    getSeries: (i) => data[i]![0]!,
   });
 
   it("adjusts domain based on visible index range", () => {
@@ -74,8 +74,8 @@ describe("updateScaleX", () => {
     const x = scaleTime().range([0, 100]);
     updateScaleX(x, new AR1Basis(0, 2), cd);
     const [d0, d1] = x.domain();
-    expect(d0.getTime()).toBe(0);
-    expect(d1.getTime()).toBe(2);
+    expect(d0!.getTime()).toBe(0);
+    expect(d1!.getTime()).toBe(2);
   });
 });
 
@@ -86,7 +86,7 @@ describe("updateScaleY", () => {
     length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i][0],
+    getSeries: (i) => data[i]![0]!,
   });
 
   it("sets domain from visible data bounds", () => {

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -18,7 +18,7 @@ function createSvg() {
   const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  return select(div).select("svg") as Selection<
+  return select(div).select("svg") as unknown as Selection<
     SVGSVGElement,
     unknown,
     HTMLElement,
@@ -36,12 +36,12 @@ describe("setupRender Y-axis modes", () => {
       seriesCount: 2,
       seriesAxes: [0, 0],
       getSeries: (i, seriesIdx) =>
-        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+        seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
     expect(state.axes.y).toHaveLength(1);
-    expect(state.axes.y[0].scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y[0]!.scale.domain()).toEqual([1, 30]);
   });
 
   it("separates scales when series use different axes", () => {
@@ -53,11 +53,11 @@ describe("setupRender Y-axis modes", () => {
       seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
-        seriesIdx === 0 ? [1, 2, 3][i] : [10, 20, 30][i],
+        seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
-    expect(state.axes.y[0].scale.domain()).toEqual([1, 3]);
-    expect(state.axes.y[1].scale.domain()).toEqual([10, 30]);
+    expect(state.axes.y[0]!.scale.domain()).toEqual([1, 3]);
+    expect(state.axes.y[1]!.scale.domain()).toEqual([10, 30]);
   });
 });

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -48,7 +48,7 @@ describe("TimeSeriesChart.resize", () => {
       length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
+      getSeries: (i) => [1, 2, 3][i]!,
     };
 
     const legend = {
@@ -60,7 +60,12 @@ describe("TimeSeriesChart.resize", () => {
     };
 
     const chart = new TimeSeriesChart(
-      select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
+      select(svgEl) as unknown as Selection<
+        SVGSVGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       source,
       legend,
     );
@@ -89,7 +94,7 @@ describe("TimeSeriesChart.resize", () => {
       length: 3,
       seriesCount: 1,
       seriesAxes: [0],
-      getSeries: (i) => [1, 2, 3][i],
+      getSeries: (i) => [1, 2, 3][i]!,
     };
 
     const legend = {
@@ -101,7 +106,12 @@ describe("TimeSeriesChart.resize", () => {
     };
 
     const chart = new TimeSeriesChart(
-      select(svgEl) as Selection<SVGSVGElement, unknown, null, undefined>,
+      select(svgEl) as unknown as Selection<
+        SVGSVGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       source,
       legend,
     );


### PR DESCRIPTION
## Summary
- assert non-null series elements in chart render tests
- tighten chart utility tests with explicit non-null assertions
- stabilize Y-axis and resize tests with safer selections

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a412f011c832b95af67714182bd6c