### PR TITLE
fix: respect visible index window in Y-scale update

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -172,7 +172,7 @@ export class ChartData {
     tree: SegmentTree<IMinMax>,
   ): DirectProductBasis {
     const bAxisVisible = this.bAxisVisible(bIndexVisible, tree);
-    return DirectProductBasis.fromProjections(this.bIndexFull, bAxisVisible);
+    return DirectProductBasis.fromProjections(bIndexVisible, bAxisVisible);
   }
 
   combinedAxisDp(

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
-import { scaleLinear, scaleTime } from "d3-scale";
+import { scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData } from "./data.ts";
 import type { IDataSource } from "./data.ts";
@@ -89,13 +89,11 @@ describe("updateScaleY", () => {
     getSeries: (i) => data[i]![0]!,
   });
 
-  it("sets domain from visible data bounds", () => {
-    const cd = new ChartData(makeSource([[10], [20], [40]]));
-    const y = scaleLinear().range([100, 0]);
+  it("respects the supplied index window", () => {
+    const cd = new ChartData(makeSource([[10], [20], [40], [5]]));
     const tree = buildAxisTree(cd, 0);
-    const dp = cd.updateScaleY(new AR1Basis(0, 2), tree);
-    expect(dp.y().toArr()).toEqual([10, 40]);
-    y.domain(dp.y().toArr());
-    expect(y.domain()).toEqual([10, 40]);
+    const dp = cd.updateScaleY(new AR1Basis(1, 2), tree);
+    expect(dp.x().toArr()).toEqual([1, 2]);
+    expect(dp.y().toArr()).toEqual([20, 40]);
   });
 });


### PR DESCRIPTION
## Summary
- ensure ChartData.updateScaleY derives direct product basis from the visible index window
- test that Y-scale updates honor the supplied index window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4e71ccac832baa74a294d09ba1e0