### PR TITLE
Fix a subset of test type errors

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
+import type { Selection } from "d3-selection";
 
 import { LegendController } from "./LegendController.ts";
 import { ChartData, IDataSource } from "../svg-time-series/src/chart/data.ts";
@@ -26,13 +27,12 @@ function createSvgAndLegend() {
   const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  const svg = select<HTMLDivElement, unknown>(div).select<
-    SVGSVGElement,
-    unknown
-  >("svg");
-  const legendDiv = select<HTMLElement, unknown, HTMLElement, unknown>(
+  const svg = select<HTMLDivElement, unknown>(div).select<SVGSVGElement>(
+    "svg",
+  ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
+  const legendDiv = select(
     dom.window.document.getElementById("l") as HTMLDivElement,
-  );
+  ) as unknown as Selection<HTMLElement, unknown, HTMLElement, unknown>;
   return { svg, legendDiv };
 }
 
@@ -56,7 +56,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path,
-        transform: state.axes.y[s.axisIdx].transform,
+        transform: state.axes.y[s.axisIdx]!.transform,
       })),
     });
 
@@ -66,11 +66,11 @@ describe("LegendController", () => {
 
     lc.highlightIndex(1);
 
-    const lastCall = updateSpy.mock.calls[updateSpy.mock.calls.length - 1];
+    const lastCall = updateSpy.mock.calls.at(-1)!;
     const matrix = lastCall[1] as DOMMatrix;
     const modelPoint = new DOMPoint(1, data.getPoint(1).values[0]);
     const expected = modelPoint.matrixTransform(
-      state.axes.y[0].transform.matrix,
+      state.axes.y[0]!.transform.matrix,
     );
     expect(matrix.e).toBeCloseTo(expected.x);
     expect(matrix.f).toBeCloseTo(expected.y);
@@ -107,7 +107,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path,
-        transform: state.axes.y[s.axisIdx].transform,
+        transform: state.axes.y[s.axisIdx]!.transform,
       })),
     });
 
@@ -147,7 +147,7 @@ describe("LegendController", () => {
       length: data.length,
       series: state.series.map((s) => ({
         path: s.path,
-        transform: state.axes.y[s.axisIdx].transform,
+        transform: state.axes.y[s.axisIdx]!.transform,
       })),
     });
 

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
@@ -11,10 +12,10 @@ import { ZoomScheduler } from "./zoomScheduler.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;
-  scaleExtent: vi.Mock;
-  translateExtent: vi.Mock;
-  on: vi.Mock;
-  transform: vi.Mock;
+  scaleExtent: Mock;
+  translateExtent: Mock;
+  on: Mock;
+  transform: Mock;
   triggerZoom: (transform: unknown) => void;
   _zoomHandler?: (event: unknown) => void;
 }
@@ -70,7 +71,7 @@ describe("ZoomState transform state", () => {
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as vi.Mock;
+    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
 
     const first = {
       transform: { x: 1, k: 2 },

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import { zoomIdentity, zoomTransform } from "d3-zoom";
@@ -10,10 +11,10 @@ import { ZoomState } from "./zoomState.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;
-  scaleExtent: vi.Mock;
-  translateExtent: vi.Mock;
-  on: vi.Mock;
-  transform: vi.Mock;
+  scaleExtent: Mock;
+  translateExtent: Mock;
+  on: Mock;
+  transform: Mock;
   triggerZoom: (transform: unknown) => void;
   _zoomHandler?: (event: unknown) => void;
 }
@@ -118,7 +119,7 @@ describe("ZoomState.updateExtents clamp", () => {
 
     const initial = zoomIdentity.translate(-120, -80).scale(2);
     zs.zoomBehavior.transform(rect, initial);
-    const transformSpy = zs.zoomBehavior.transform as unknown as vi.Mock;
+    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
     transformSpy.mockClear();
 
     zs.updateExtents({ width: 50, height: 50 });


### PR DESCRIPTION
## Summary
- adjust sample legend test selection logic and non-null handling
- use explicit `Mock` type from Vitest in zoom state tests

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4c62f7d8832baa84e7a30c034653