### PR TITLE
fix: reset ZoomScheduler state on destroy

### DIFF
--- a/svg-time-series/src/chart/zoomScheduler.test.ts
+++ b/svg-time-series/src/chart/zoomScheduler.test.ts
@@ -46,4 +46,26 @@ describe("ZoomScheduler", () => {
     );
     expect(apply).toHaveBeenCalledTimes(1);
   });
+
+  it("clears state on destroy and supports subsequent zooms", () => {
+    const apply = vi.fn();
+    const refresh = vi.fn();
+    const zs = new ZoomScheduler(apply, refresh);
+
+    expect(zs.zoom({ x: 1, k: 2 } as unknown as ZoomTransform, {})).toBe(true);
+    expect(zs.getCurrentTransform()).toEqual({ x: 1, k: 2 });
+    expect(zs.isPending()).toBe(true);
+
+    zs.destroy();
+    expect(zs.getCurrentTransform()).toBeNull();
+    expect(zs.isPending()).toBe(false);
+
+    vi.runAllTimers();
+    expect(apply).not.toHaveBeenCalled();
+    expect(refresh).not.toHaveBeenCalled();
+
+    expect(zs.zoom({ x: 5, k: 3 } as unknown as ZoomTransform, {})).toBe(true);
+    vi.runAllTimers();
+    expect(apply).toHaveBeenCalledWith({ x: 5, k: 3 });
+  });
 });

--- a/svg-time-series/src/chart/zoomScheduler.ts
+++ b/svg-time-series/src/chart/zoomScheduler.ts
@@ -55,6 +55,8 @@ export class ZoomScheduler {
 
   public destroy() {
     this.cancelRefresh();
+    this.currentPanZoomTransformState = null;
+    this.pendingZoomBehaviorTransform = false;
   }
 
   public getCurrentTransform(): ZoomTransform | null {


### PR DESCRIPTION
## Summary
- ensure ZoomScheduler.destroy resets internal state
- test ZoomScheduler destroy behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4e54f4bc832b9ef3c5fffc1ff262