### PR TITLE
Expose ChartData.clampIndex for shared bounds checking

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -151,7 +151,11 @@ export class ChartData {
     return this.clampIndex(idx);
   }
 
-  private clampIndex(idx: number): number {
+  /**
+   * Clamp a raw index to the valid data range.
+   * Exposed for shared bounds checking across components.
+   */
+  public clampIndex(idx: number): number {
     return Math.min(Math.max(idx, 0), this.window.length - 1);
   }
   bAxisVisible(bIndexVisible: AR1Basis, tree: SegmentTree<IMinMax>): AR1Basis {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -169,7 +169,7 @@ export class TimeSeriesChart {
 
   public onHover = (x: number) => {
     let idx = this.state.axes.y[0]!.transform.fromScreenToModelX(x);
-    idx = Math.min(Math.max(idx, 0), this.data.length - 1);
+    idx = this.data.clampIndex(idx);
     this.legendController.highlightIndex(idx);
   };
 


### PR DESCRIPTION
## Summary
- expose `ChartData.clampIndex` so other components can clamp indices
- reuse `ChartData.clampIndex` in `TimeSeriesChart.onHover` to ensure consistent bounds checking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a53323ae0832b96f2a2de96808ca3