### PR TITLE
refactor: centralize chart refresh logic

### DIFF
--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -69,16 +69,23 @@ describe("TimeSeriesChart.resize", () => {
       source,
       legend,
     );
+    interface ChartInternal {
+      zoomState: { refresh: Mock };
+    }
+    const chartInternal = chart as unknown as ChartInternal;
+    const zoomRefreshSpy = vi.spyOn(chartInternal.zoomState, "refresh");
 
     renderSpy.mockClear();
     axisInstances.forEach((a) => a.axisUp.mockClear());
     legend.refresh.mockClear();
+    zoomRefreshSpy.mockClear();
 
     chart.resize({ width: 200, height: 150 });
 
     axisInstances.forEach((a) => expect(a.axisUp).toHaveBeenCalled());
     expect(renderSpy).toHaveBeenCalled();
     expect(legend.refresh).toHaveBeenCalled();
+    expect(zoomRefreshSpy).toHaveBeenCalled();
   });
 
   it("uses explicit dimensions for zoom extents and axes", () => {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -163,8 +163,7 @@ export class TimeSeriesChart {
     }
 
     this.state.refresh(this.data);
-    this.state.seriesRenderer.draw(this.data.data);
-    this.legendController.refresh();
+    this.refreshAll();
   };
 
   public onHover = (x: number) => {
@@ -174,6 +173,10 @@ export class TimeSeriesChart {
   };
 
   private drawNewData = () => {
+    this.refreshAll();
+  };
+
+  private refreshAll = () => {
     this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
     this.legendController.refresh();


### PR DESCRIPTION
## Summary
- factor out `refreshAll` helper to redraw series, refresh zoom, and update legend
- reuse helper in `resize` and `drawNewData` to avoid repeated code and ensure zoom refresh on resize
- test that chart resizing triggers zoom-state refresh

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a55d23920832b9d8c123877551164