### PR TITLE
fix: make axis g optional and cleanup disposal

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -29,7 +29,7 @@ function createYAxis(
 
 interface AxisData {
   axis: MyAxis;
-  g: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+  g?: Selection<SVGGElement, unknown, HTMLElement, unknown> | undefined;
 }
 
 interface AxisDataX extends AxisData {
@@ -78,7 +78,7 @@ export function refreshRenderState(state: RenderState, data: ChartData): void {
   state.axisRenders.forEach((r) => {
     r.axis.axisUp(r.g);
   });
-  state.axes.x.axis.axisUp(state.axes.x.g);
+  state.axes.x.axis.axisUp(state.axes.x.g!);
 }
 
 export function setupRender(

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -14,12 +14,6 @@ export type { IMinMax, IDataSource } from "./chart/data.ts";
 export type { ILegendController } from "./chart/legend.ts";
 export type { IZoomStateOptions } from "./chart/zoomState.ts";
 
-interface AxisWithG {
-  g?:
-    | Selection<SVGGElement, unknown, null, undefined>
-    | Selection<SVGGElement, unknown, HTMLElement, unknown>;
-}
-
 export interface IPublicInteraction {
   zoom: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
   onHover: (x: number) => void;
@@ -115,8 +109,10 @@ export class TimeSeriesChart {
     }
     this.state.series.length = 0;
     const axisX = this.state.axes.x;
-    axisX.g.remove();
-    delete (axisX as AxisWithG).g;
+    if (axisX.g) {
+      axisX.g.remove();
+      axisX.g = undefined;
+    }
 
     for (const r of this.state.axisRenders) {
       r.g.remove();


### PR DESCRIPTION
## Summary
- make AxisData.g optional
- streamline axis disposal without casting or delete

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a562bd5d0832bbe4493975fb3ebcb