### PR TITLE
fix: refine scale extent validation

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -16,12 +16,18 @@ export class ZoomState {
   private scaleExtent: [number, number];
 
   public static validateScaleExtent(extent: unknown) {
-    if (!Array.isArray(extent) || extent.length !== 2) {
+    if (!Array.isArray(extent)) {
       throw new Error(
-        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${Array.isArray(extent) ? extent.join(",") : String(extent)}`,
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${String(extent)}`,
       );
     }
-    const [min, max] = extent as [number, number];
+    const arr = extent as [number, number];
+    if (extent.length !== 2) {
+      throw new Error(
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${arr.join(",")}`,
+      );
+    }
+    const [min, max] = arr;
     if (
       typeof min !== "number" ||
       typeof max !== "number" ||
@@ -32,7 +38,7 @@ export class ZoomState {
       min >= max
     ) {
       throw new Error(
-        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${extent.join(",")}]`,
+        `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: [${arr.join(",")}]`,
       );
     }
   }

--- a/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
+++ b/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { ZoomState } from "./zoomState.ts";
+
+describe("ZoomState.validateScaleExtent", () => {
+  it("rejects non-array inputs", () => {
+    expect(() => ZoomState.validateScaleExtent(5 as unknown)).toThrow(
+      /Received: 5/,
+    );
+  });
+
+  it("rejects arrays without exactly two elements", () => {
+    expect(() => ZoomState.validateScaleExtent([1] as unknown)).toThrow(
+      /Received: 1/,
+    );
+    expect(() => ZoomState.validateScaleExtent([1, 2, 3] as unknown)).toThrow(
+      /Received: 1,2,3/,
+    );
+  });
+
+  it("rejects non-positive numbers", () => {
+    expect(() => ZoomState.validateScaleExtent([0, 2])).toThrow(
+      /Received: \[0,2\]/,
+    );
+  });
+
+  it.each([
+    [2, 1],
+    [1, 1],
+  ])("rejects when min >= max %j", (a, b) => {
+    expect(() => ZoomState.validateScaleExtent([a, b])).toThrow(
+      new RegExp(`Received: \\[${a},${b}\\]`),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refine scaleExtent validation to use typed array after array check and improve error messages
- add tests covering invalid scale extent inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a5ab886b8832b83bffd24b1090992