### PR TITLE
Enable type checking for tests

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "echo \"Error: no test specified\" && exit 1",
     "bench": "echo \"No benchmarks defined\""
   },

--- a/samples/tsconfig.test.json
+++ b/samples/tsconfig.test.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["*.ts", "../test/**/*.ts"],
+  "exclude": [
+    "misc/**",
+    "demos/**",
+    "benchmarks/**",
+    "competitors/**",
+    "unused/**"
+  ],
+  "compilerOptions": {
+    "rootDir": ".."
+  }
+}

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "bench": "npm run bench:segment-tree",
     "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts --run"
   }

--- a/segment-tree-rmq/tsconfig.test.json
+++ b/segment-tree-rmq/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["src/**/*.ts", "../test/**/*.ts"],
+  "exclude": ["dist", "bench/**"]
+}

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -35,7 +35,7 @@
     "prepare": "npm run build",
     "build": "tsc && vite build",
     "lint": "eslint src",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",
     "bench": "vitest bench bench/*.bench.ts"
   }

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -150,10 +150,10 @@ describe("TimeSeriesChart.resize", () => {
 
     expect(updateSpy).toHaveBeenCalledWith({ width: 250, height: 120 });
     expect(chartInternal.state.dimensions).toEqual({ width: 250, height: 120 });
-    const arg = resizeSpy.mock.calls[0][0];
+    const arg = resizeSpy.mock.calls.at(0)![0];
     expect(arg.x().toArr()).toEqual([0, 250]);
     expect(arg.y().toArr()).toEqual([120, 0]);
     expect(chartInternal.state.axes.x.scale.range()).toEqual([0, 250]);
-    expect(chartInternal.state.axes.y[0].scale.range()).toEqual([120, 0]);
+    expect(chartInternal.state.axes.y[0]!.scale.range()).toEqual([120, 0]);
   });
 });

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -30,8 +30,8 @@ describe("updateScales", () => {
     const bIndexVisible = new AR1Basis(0, 1);
     axisManager.updateScales(bIndexVisible, data);
 
-    expect(axes[0].scale.domain()).toEqual([1, 3]);
-    expect(axes[1].scale.domain()).toEqual([10, 30]);
+    expect(axes[0]!.scale.domain()).toEqual([1, 3]);
+    expect(axes[1]!.scale.domain()).toEqual([10, 30]);
   });
 
   it("updates domains for multiple axes", () => {
@@ -66,9 +66,9 @@ describe("updateScales", () => {
     const bIndexVisible = new AR1Basis(0, 1);
     axisManager.updateScales(bIndexVisible, data as unknown as ChartData);
 
-    expect(axes[0].scale.domain()).toEqual([1, 3]);
-    expect(axes[1].scale.domain()).toEqual([10, 30]);
-    expect(axes[2].scale.domain()).toEqual([-5, 5]);
+    expect(axes[0]!.scale.domain()).toEqual([1, 3]);
+    expect(axes[1]!.scale.domain()).toEqual([10, 30]);
+    expect(axes[2]!.scale.domain()).toEqual([-5, 5]);
   });
 
   it("throws when a series references an out-of-range axis index", () => {

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -7,7 +7,7 @@ import { select } from "d3-selection";
 import type { RenderState } from "./render.ts";
 
 interface MockZoomBehavior {
-  (selection: Selection<unknown, unknown, unknown, unknown>): void;
+  (selection: Selection<Element, unknown, Element, unknown>): void;
   _handler?: (event: unknown) => void;
   scaleExtent: () => MockZoomBehavior;
   translateExtent: () => MockZoomBehavior;
@@ -19,7 +19,7 @@ vi.mock("d3-zoom", () => {
   return {
     zoom: () => {
       const behavior: MockZoomBehavior = (
-        selection: Selection<unknown, unknown, unknown, unknown>,
+        selection: Selection<Element, unknown, Element, unknown>,
       ) => {
         selection.on("wheel.zoom", (event: Event) =>
           behavior._handler?.(event),
@@ -57,8 +57,8 @@ describe("ZoomState.destroy", () => {
       width: { baseVal: { value: number } };
       height: { baseVal: { value: number } };
     };
-    svg.width = { baseVal: { value: 10 } };
-    svg.height = { baseVal: { value: 10 } };
+    svg.width = { baseVal: { value: 10 } } as unknown as SVGAnimatedLength;
+    svg.height = { baseVal: { value: 10 } } as unknown as SVGAnimatedLength;
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
@@ -71,7 +71,12 @@ describe("ZoomState.destroy", () => {
     const refresh = vi.fn();
     const zoomCb = vi.fn();
     const zs = new ZoomState(
-      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       state,
       refresh,
       zoomCb,
@@ -96,8 +101,8 @@ describe("ZoomState.destroy", () => {
       width: { baseVal: { value: number } };
       height: { baseVal: { value: number } };
     };
-    svg.width = { baseVal: { value: 10 } };
-    svg.height = { baseVal: { value: 10 } };
+    svg.width = { baseVal: { value: 10 } } as unknown as SVGAnimatedLength;
+    svg.height = { baseVal: { value: 10 } } as unknown as SVGAnimatedLength;
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
@@ -109,7 +114,12 @@ describe("ZoomState.destroy", () => {
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
-      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       state,
       refresh,
     );

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -1,19 +1,28 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
+import type { ZoomTransform } from "d3-zoom";
 import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
 import { ZoomScheduler } from "./zoomScheduler.ts";
 
 interface MockZoomBehavior {
   (_s: unknown): void;
-  scaleExtent: vi.Mock;
-  translateExtent: vi.Mock;
-  on: vi.Mock;
-  transform: vi.Mock;
+  scaleExtent: Mock;
+  translateExtent: Mock;
+  on: Mock;
+  transform: Mock;
   triggerZoom: (transform: unknown) => void;
   _zoomHandler?: (event: unknown) => void;
 }
@@ -66,13 +75,18 @@ describe("ZoomState programmatic transforms", () => {
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
-      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       state,
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as vi.Mock;
-    const initial = { x: 1, y: 2, k: 3 };
+    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const initial = { x: 1, y: 2, k: 3 } as unknown as ZoomTransform;
     zs.zoomBehavior.transform(rect, initial);
     vi.runAllTimers();
 

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -77,7 +77,7 @@ vi.mock("d3-zoom", () => {
         .fn<(s: unknown, transform: unknown) => void>()
         .mockImplementation((s, transform) => {
           const node = getNode(s);
-          transforms.set(node, transform);
+          transforms.set(node, transform as ReturnType<typeof createTransform>);
           behavior._zoomHandler?.({ transform });
           return behavior;
         });
@@ -150,7 +150,7 @@ describe("ZoomState", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
-    const internalEvent = zoomCb.mock.calls[1][0];
+    const internalEvent = zoomCb.mock.calls.at(1)![0];
     expect(internalEvent).toMatchObject({ transform: { x: 5, k: 2 } });
     expect(internalEvent.sourceEvent).toBeUndefined();
   });
@@ -197,7 +197,7 @@ describe("ZoomState", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
-    const internalEvent = zoomCb.mock.calls[1][0];
+    const internalEvent = zoomCb.mock.calls.at(1)![0];
     expect(internalEvent).toMatchObject({ transform: { x: 2, k: 3 } });
     expect(internalEvent.sourceEvent).toBeUndefined();
   });

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -66,7 +66,12 @@ describe("ZoomState transform state", () => {
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
-      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       state,
       refresh,
     );

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -112,7 +112,12 @@ describe("ZoomState.updateExtents clamp", () => {
       axisRenders: [],
     } as unknown as RenderState;
     const zs = new ZoomState(
-      rect as Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
       state,
       vi.fn(),
     );

--- a/svg-time-series/tsconfig.test.json
+++ b/svg-time-series/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["src/**/*.ts", "../test/**/*.ts"],
+  "exclude": ["dist", "vite.config.ts", "**/*.bench.ts"]
+}


### PR DESCRIPTION
## Summary
- type check test files across workspaces with dedicated tsconfig and scripts
- fix assorted test type errors with explicit casts and assertions

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a5dde7ae0832bbd24fac4c4794f74