### PR TITLE
chore: simplify tsconfig structure

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ const disableTypeChecked = tsEslint.configs.disableTypeChecked;
 
 export default tsEslint.config(
   {
-    ignores: ["**/dist/**"],
+    ignores: ["**/dist/**", "samples/unused/**"],
   },
   {
     languageOptions: {

--- a/samples/demos/tsconfig.json
+++ b/samples/demos/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["*.ts"],
-  "exclude": []
+  "include": ["*.ts"]
 }

--- a/samples/misc/tsconfig.json
+++ b/samples/misc/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["**/*.ts"],
-  "exclude": []
+  "include": ["**/*.ts"]
 }

--- a/samples/tsconfig.json
+++ b/samples/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../tsconfig.base.json",
-  "exclude": [
-    "**/*.test.ts",
-    "misc/**",
-    "demos/**",
-    "benchmarks/**",
-    "competitors/**"
-  ]
+  "include": ["*.ts"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/samples/tsconfig.json
+++ b/samples/tsconfig.json
@@ -1,10 +1,5 @@
 {
   "extends": "../tsconfig.base.json",
-  "compilerOptions": {
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedIndexedAccess": true,
-    "noPropertyAccessFromIndexSignature": true
-  },
   "exclude": [
     "**/*.test.ts",
     "misc/**",

--- a/samples/tsconfig.test.json
+++ b/samples/tsconfig.test.json
@@ -1,14 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "include": ["*.ts", "../test/**/*.ts"],
-  "exclude": [
-    "misc/**",
-    "demos/**",
-    "benchmarks/**",
-    "competitors/**",
-    "unused/**"
-  ],
-  "compilerOptions": {
-    "rootDir": ".."
-  }
+  "extends": "../tsconfig.base.json",
+  "include": ["*.ts", "../test/**/*.ts"]
 }

--- a/segment-tree-rmq/tsconfig.bench.json
+++ b/segment-tree-rmq/tsconfig.bench.json
@@ -1,8 +1,5 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
+  "extends": "../tsconfig.base.json",
   "include": ["bench/**/*.ts"],
-  "exclude": ["dist", "**/*.test.ts"]
+  "exclude": ["**/*.test.ts"]
 }

--- a/segment-tree-rmq/tsconfig.json
+++ b/segment-tree-rmq/tsconfig.json
@@ -8,5 +8,5 @@
     "declarationDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "**/*.test.ts", "bench/**"]
+  "exclude": ["**/*.test.ts"]
 }

--- a/segment-tree-rmq/tsconfig.test.json
+++ b/segment-tree-rmq/tsconfig.test.json
@@ -1,8 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": ".."
-  },
-  "include": ["src/**/*.ts", "../test/**/*.ts"],
-  "exclude": ["dist", "bench/**"]
+  "extends": "../tsconfig.base.json",
+  "include": ["src/**/*.ts", "../test/**/*.ts"]
 }

--- a/svg-time-series/tsconfig.bench.json
+++ b/svg-time-series/tsconfig.bench.json
@@ -1,8 +1,5 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "."
-  },
+  "extends": "../tsconfig.base.json",
   "include": ["bench/**/*.ts"],
-  "exclude": ["dist", "vite.config.ts", "**/*.test.ts"]
+  "exclude": ["**/*.test.ts"]
 }

--- a/svg-time-series/tsconfig.json
+++ b/svg-time-series/tsconfig.json
@@ -8,5 +8,5 @@
     "declarationDir": "dist"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["dist", "vite.config.ts", "**/*.test.ts", "**/*.bench.ts"]
+  "exclude": ["**/*.test.ts", "**/*.bench.ts"]
 }

--- a/svg-time-series/tsconfig.test.json
+++ b/svg-time-series/tsconfig.test.json
@@ -1,8 +1,5 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": ".."
-  },
+  "extends": "../tsconfig.base.json",
   "include": ["src/**/*.ts", "../test/**/*.ts"],
-  "exclude": ["dist", "vite.config.ts", "**/*.bench.ts"]
+  "exclude": ["**/*.bench.ts"]
 }


### PR DESCRIPTION
## Summary
- streamline tsconfig.test and tsconfig.bench files to rely on base config
- drop redundant excludes and compilerOptions across tsconfigs

## Testing
- `npm run format`
- `git commit -am "chore: simplify tsconfig structure"`


------
https://chatgpt.com/codex/tasks/task_e_689a63c058bc832b81a3075473091142