### PR TITLE
refactor: simplify seriesAxes validation

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -48,8 +48,7 @@ function validateSource(source: IDataSource): void {
       )})`,
     );
   }
-  let axisIdx = 0;
-  for (const axis of source.seriesAxes) {
+  source.seriesAxes.forEach((axis, axisIdx) => {
     if (axis !== 0 && axis !== 1) {
       throw new Error(
         `ChartData seriesAxes[${String(axisIdx)}] must be 0 or 1; received ${String(
@@ -57,8 +56,7 @@ function validateSource(source: IDataSource): void {
         )}`,
       );
     }
-    axisIdx++;
-  }
+  });
 }
 
 export class ChartData {


### PR DESCRIPTION
## Summary
- refactor ChartData seriesAxes validation to use forEach instead of manual counter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a633e57ac832ba0fc65b9c8b7739b