### PR TITLE
refactor: eliminate forward ZoomState declaration in test

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -327,45 +327,37 @@ describe("ZoomState", () => {
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
     } as unknown as RenderState;
-    // eslint-disable-next-line prefer-const
-    let zs2: ZoomState;
-    const zs1 = new ZoomState(
+    const createZoomState = (
+      rect: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+      forward: () => ZoomState,
+    ) =>
+      new ZoomState(rect, state, vi.fn(), (event) => {
+        if (event.sourceEvent) {
+          const forwarded = {
+            ...event,
+            sourceEvent: null,
+          } as D3ZoomEvent<SVGRectElement, unknown>;
+          forward().zoom(forwarded);
+        }
+      });
+
+    const zs1 = createZoomState(
       rect1 as unknown as Selection<
         SVGRectElement,
         unknown,
         HTMLElement,
         unknown
       >,
-      state,
-      vi.fn(),
-      (event) => {
-        if (event.sourceEvent) {
-          const forwarded = {
-            ...event,
-            sourceEvent: null,
-          } as D3ZoomEvent<SVGRectElement, unknown>;
-          zs2.zoom(forwarded);
-        }
-      },
+      () => zs2,
     );
-    zs2 = new ZoomState(
+    const zs2 = createZoomState(
       rect2 as unknown as Selection<
         SVGRectElement,
         unknown,
         HTMLElement,
         unknown
       >,
-      state,
-      vi.fn(),
-      (event) => {
-        if (event.sourceEvent) {
-          const forwarded = {
-            ...event,
-            sourceEvent: null,
-          } as D3ZoomEvent<SVGRectElement, unknown>;
-          zs1.zoom(forwarded);
-        }
-      },
+      () => zs1,
     );
 
     const event1 = {


### PR DESCRIPTION
## Summary
- use helper to construct linked ZoomState instances without forward declaration
- remove prefer-const eslint disable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2dde5448832b93fda5092b13598b