### PR TITLE
test: clean up reset zoom interaction mock constructors

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-useless-constructor */
 import {
   describe,
   it,
@@ -47,7 +46,6 @@ vi.mock("../ViewportTransform.ts", () => ({
 vi.mock("../axis.ts", () => ({
   Orientation: { Bottom: 0, Right: 1 },
   MyAxis: class {
-    constructor() {}
     setScale = vi.fn(() => this);
     axis = vi.fn();
     axisUp = vi.fn();


### PR DESCRIPTION
## Summary
- remove no-useless-constructor eslint disable
- drop empty constructor from MyAxis mock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2dd3a404832ba583076f3bb5d7e4