### PR TITLE
chore: refine unused variable linting

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,7 +34,10 @@ export default tsEslint.config(
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-empty-object-type": "error",
-      "@typescript-eslint/no-unused-vars": "error",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
       "@typescript-eslint/no-unsafe-function-type": "error",
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/no-useless-constructor": "error",

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -1,7 +1,6 @@
 /**
  * @vitest-environment jsdom
  */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";


### PR DESCRIPTION
## Summary
- enforce error for unused variables but ignore names prefixed with `_`
- drop redundant ESLint disable from hoverClamp interaction test

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2dc95854832b80b93dce23a7e8db