### PR TITLE
test: fix type-check violations in tests

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -27,7 +27,8 @@ function createSvgAndLegend() {
   const div = dom.window.document.getElementById("c") as HTMLDivElement;
   Object.defineProperty(div, "clientWidth", { value: 100 });
   Object.defineProperty(div, "clientHeight", { value: 100 });
-  const svg = select<HTMLDivElement, unknown>(div).select<SVGSVGElement>(
+
+  const svg = select<HTMLDivElement, unknown>(div).select(
     "svg",
   ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
   const legendDiv = select(
@@ -49,7 +50,10 @@ describe("LegendController", () => {
     };
     const data = new ChartData(source);
     const state = setupRender(svg, data);
-    select(state.series[0]!.path as SVGPathElement).attr("stroke", "green");
+    select<SVGPathElement, unknown>(state.series[0]!.path).attr(
+      "stroke",
+      "green",
+    );
     const lc = new LegendController(legendDiv);
     lc.init({
       getPoint: data.getPoint.bind(data),
@@ -67,7 +71,7 @@ describe("LegendController", () => {
     lc.highlightIndex(1);
 
     const lastCall = updateSpy.mock.calls.at(-1)!;
-    const matrix = lastCall[1] as DOMMatrix;
+    const matrix = lastCall[1]!;
     const modelPoint = new DOMPoint(1, data.getPoint(1).values[0]);
     const expected = modelPoint.matrixTransform(
       state.axes.y[0]!.transform.matrix,
@@ -100,7 +104,10 @@ describe("LegendController", () => {
       return [timestamp, ...values] as [number, ...number[]];
     }) as unknown as typeof data.getPoint;
     const state = setupRender(svg, data);
-    select(state.series[0]!.path as SVGPathElement).attr("stroke", "green");
+    select<SVGPathElement, unknown>(state.series[0]!.path).attr(
+      "stroke",
+      "green",
+    );
     const lc = new LegendController(legendDiv);
     lc.init({
       getPoint: data.getPoint.bind(data),
@@ -140,7 +147,10 @@ describe("LegendController", () => {
       return { timestamp } as { timestamp: number } & Record<string, unknown>;
     }) as unknown as typeof data.getPoint;
     const state = setupRender(svg, data);
-    select(state.series[0]!.path as SVGPathElement).attr("stroke", "green");
+    select<SVGPathElement, unknown>(state.series[0]!.path).attr(
+      "stroke",
+      "green",
+    );
     const lc = new LegendController(legendDiv);
     lc.init({
       getPoint: data.getPoint.bind(data),

--- a/svg-time-series/src/axis.test.ts
+++ b/svg-time-series/src/axis.test.ts
@@ -10,8 +10,8 @@ function createGroup() {
   const dom = new JSDOM(`<svg xmlns="${NS}"></svg>`, {
     contentType: "image/svg+xml",
   });
-  const svg = dom.window.document.querySelector("svg") as SVGSVGElement;
-  const g = dom.window.document.createElementNS(NS, "g") as SVGGElement;
+  const svg = dom.window.document.querySelector<SVGSVGElement>("svg")!;
+  const g = dom.window.document.createElementNS(NS, "g");
   svg.appendChild(g);
   return { g };
 }

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -278,9 +278,9 @@ describe("ChartData", () => {
       [0, 1],
     );
     const cd = new ChartData(source);
-    expect(() => cd.append(undefined as unknown as number, 2)).toThrow(
-      /series 0/,
-    );
+    expect(() => {
+      cd.append(undefined as unknown as number, 2);
+    }).toThrow(/series 0/);
   });
 
   it("throws when sf is invalid", () => {
@@ -292,9 +292,9 @@ describe("ChartData", () => {
       [0, 1],
     );
     const cd = new ChartData(source);
-    expect(() => cd.append(2, undefined as unknown as number)).toThrow(
-      /series 1/,
-    );
+    expect(() => {
+      cd.append(2, undefined as unknown as number);
+    }).toThrow(/series 1/);
   });
 
   it("computes visible temperature bounds", () => {
@@ -499,7 +499,9 @@ describe("ChartData", () => {
         seriesAxes: [0],
       };
       const cd = new ChartData(source);
-      expect(() => cd.append(1)).not.toThrow();
+      expect(() => {
+        cd.append(1);
+      }).not.toThrow();
       expect(cd.data).toEqual([[1]]);
     });
 

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -80,7 +80,9 @@ vi.mock("./zoomState.ts", () => ({
     private zoomCallback: (e: unknown) => void;
     reset = vi.fn(() => {
       const identity = { x: 0, k: 1 };
-      this.state.axes.y.forEach((a) => a.transform.onZoomPan(identity));
+      this.state.axes.y.forEach((a) => {
+        a.transform.onZoomPan(identity);
+      });
       this.refreshChart();
       this.zoomCallback({ transform: identity, sourceEvent: null });
     });

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -192,7 +192,7 @@ describe("chart interaction single-axis", () => {
       legend.querySelector(".chart-legend__green_value")!.textContent,
     ).toBe("30");
 
-    const circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    const circle = svgEl.querySelector<SVGCircleElement>("circle")!;
     const transform = nodeTransforms.get(circle)!;
     expect(transform.tx).toBe(1);
     expect(transform.ty).toBe(30);
@@ -213,7 +213,7 @@ describe("chart interaction single-axis", () => {
       legend.querySelector(".chart-legend__green_value")!.textContent,
     ).toBe("50");
 
-    const circle = svgEl.querySelector("circle")! as SVGCircleElement;
+    const circle = svgEl.querySelector<SVGCircleElement>("circle")!;
     const transform = nodeTransforms.get(circle)!;
     expect(transform.tx).toBe(1);
     expect(transform.ty).toBe(50);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -255,7 +255,7 @@ describe("chart interaction", () => {
       [10, 20],
       [30, 40],
     ];
-    const formatter = vi.fn((ts: number) => `ts:${ts}`);
+    const formatter = vi.fn((ts: number) => `ts:${String(ts)}`);
     const { onHover, legend } = createChart(data, formatter);
     vi.runAllTimers();
 

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -82,7 +82,9 @@ describe("TimeSeriesChart.resize", () => {
 
     chart.resize({ width: 200, height: 150 });
 
-    axisInstances.forEach((a) => expect(a.axisUp).toHaveBeenCalled());
+    axisInstances.forEach((a) => {
+      expect(a.axisUp).toHaveBeenCalled();
+    });
     expect(renderSpy).toHaveBeenCalled();
     expect(legend.refresh).toHaveBeenCalled();
     expect(zoomRefreshSpy).toHaveBeenCalled();
@@ -150,9 +152,15 @@ describe("TimeSeriesChart.resize", () => {
 
     expect(updateSpy).toHaveBeenCalledWith({ width: 250, height: 120 });
     expect(chartInternal.state.dimensions).toEqual({ width: 250, height: 120 });
-    const arg = resizeSpy.mock.calls.at(0)![0];
+
+    interface AxisRange {
+      x(): { toArr(): [number, number] };
+      y(): { toArr(): [number, number] };
+    }
+    const arg = resizeSpy.mock.calls.at(0)![0] as unknown as AxisRange;
     expect(arg.x().toArr()).toEqual([0, 250]);
     expect(arg.y().toArr()).toEqual([120, 0]);
+
     expect(chartInternal.state.axes.x.scale.range()).toEqual([0, 250]);
     expect(chartInternal.state.axes.y[0]!.scale.range()).toEqual([120, 0]);
   });

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -100,8 +100,8 @@ describe("updateScales", () => {
     };
 
     const bIndexVisible = new AR1Basis(0, 1);
-    expect(() =>
-      axisManager.updateScales(bIndexVisible, data as unknown as ChartData),
-    ).toThrow(/axis index 2/i);
+    expect(() => {
+      axisManager.updateScales(bIndexVisible, data as unknown as ChartData);
+    }).toThrow(/axis index 2/i);
   });
 });


### PR DESCRIPTION
## Summary
- clean up test utilities to use typed DOM queries and safer D3 selections
- wrap void-returning lambdas with blocks and tighten types to avoid unsafe any usage
- stringify numeric template values to satisfy `restrict-template-expressions`

## Testing
- `npx eslint .` *(with tests type-checked, 28 remaining errors)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2f9e8c70832bae264e67aeb7f5a3