### PR TITLE
chore: enable import rules for tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -114,13 +114,8 @@ export default tsEslint.config(
     files: ["**/*.test.ts"],
     ...vitest.configs.recommended,
     ...tsEslint.configs.disableTypeChecked,
-      rules: {
-        ...disableTypeChecked.rules,
-        "import/no-unresolved": "off",
-        "import/order": "off",
-        "import/default": "off",
-        "import/no-named-as-default-member": "off",
-        "import/no-named-as-default": "off",
-      },
+    rules: {
+      ...disableTypeChecked.rules,
+    },
   },
 );


### PR DESCRIPTION
## Summary
- enable import plugin rules for test files by removing overrides in ESLint config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b6d36ea40832b80f0ef8167434248