### PR TITLE
refactor: extract isSVGMatrix guard

### DIFF
--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Matrix } from "../setupDom.ts";
-import { updateNode } from "./domNodeTransform.ts";
+import { updateNode, isSVGMatrix } from "./domNodeTransform.ts";
 
 class FakeSVGMatrix {
   constructor(
@@ -67,5 +67,29 @@ describe("updateNode", () => {
     expect(last).toBeInstanceOf(FakeSVGMatrix);
     expect(last.e).toBeCloseTo(5);
     expect(last.f).toBeCloseTo(6);
+  });
+});
+
+describe("isSVGMatrix", () => {
+  it("returns true for SVGMatrix", () => {
+    const svg = new FakeSVGSVGElement();
+    const matrix = svg.createSVGMatrix();
+    expect(
+      isSVGMatrix(
+        matrix as unknown as DOMMatrix,
+        svg as unknown as SVGSVGElement,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for DOMMatrix", () => {
+    const svg = new FakeSVGSVGElement();
+    const domMatrix = new Matrix();
+    expect(
+      isSVGMatrix(
+        domMatrix as unknown as DOMMatrix,
+        svg as unknown as SVGSVGElement,
+      ),
+    ).toBe(false);
   });
 });

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -1,3 +1,10 @@
+export function isSVGMatrix(
+  matrix: DOMMatrix,
+  svg: SVGSVGElement,
+): matrix is SVGMatrix {
+  return matrix.constructor === svg.createSVGMatrix().constructor;
+}
+
 export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
   const svgTransformList = n.transform.baseVal;
   const svg = (
@@ -6,12 +13,8 @@ export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
       : n.ownerSVGElement
   )!;
 
-  function isSVGMatrix(matrix: DOMMatrix): matrix is SVGMatrix {
-    return matrix.constructor === svg.createSVGMatrix().constructor;
-  }
-
   let matrix: SVGMatrix;
-  if (isSVGMatrix(m)) {
+  if (isSVGMatrix(m, svg)) {
     matrix = m;
   } else {
     const sm = svg.createSVGMatrix();


### PR DESCRIPTION
## Summary
- extract `isSVGMatrix` into a reusable helper and use in `updateNode`
- test `isSVGMatrix` to distinguish DOMMatrix from SVGMatrix

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b7617cd7c832baa789299fe7d6a93