### PR TITLE
Enable import rules for competitor samples

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -60,11 +60,6 @@ export default tsEslint.config(
     ...tsEslint.configs.disableTypeChecked,
     rules: {
       ...disableTypeChecked.rules,
-      "import/no-unresolved": "off",
-      "import/order": "off",
-      "import/default": "off",
-      "import/no-named-as-default-member": "off",
-      "import/no-named-as-default": "off",
     },
   },
     {
@@ -103,11 +98,6 @@ export default tsEslint.config(
     },
     rules: {
       ...disableTypeChecked.rules,
-      "import/no-unresolved": "off",
-      "import/order": "off",
-      "import/default": "off",
-      "import/no-named-as-default-member": "off",
-      "import/no-named-as-default": "off",
     },
   },
   {

--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -7,12 +7,13 @@ import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import type { Selection } from "d3-selection";
 
-import { LegendController } from "./LegendController.ts";
 import type { IDataSource } from "../svg-time-series/src/chart/data.ts";
 import { ChartData } from "../svg-time-series/src/chart/data.ts";
 import { setupRender } from "../svg-time-series/src/chart/render.ts";
 import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
 import "../test/setupDom.ts";
+
+import { LegendController } from "./LegendController.ts";
 
 function createSvgAndLegend() {
   const dom = new JSDOM(

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -1,9 +1,10 @@
-import { TimeSeriesChart } from "svg-time-series";
-import type { IDataSource } from "svg-time-series";
-import { LegendController } from "../../LegendController.ts";
-import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
+import type { IDataSource } from "svg-time-series";
+import { TimeSeriesChart } from "svg-time-series";
+
+import { LegendController } from "../../LegendController.ts";
+import { measure, measureOnce, onCsv, animateBench } from "../bench.ts";
 
 onCsv((data: [number, number][]) => {
   const svg = select(".chart-drawing svg") as Selection<

--- a/samples/benchmarks/demo2-without-grid/common.ts
+++ b/samples/benchmarks/demo2-without-grid/common.ts
@@ -1,7 +1,8 @@
-import * as draw from "./draw.ts";
-import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
 import type { D3ZoomEvent } from "d3-zoom";
 import { select, selectAll } from "d3-selection";
+
+import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
+import * as draw from "./draw.ts";
 
 function buildSegmentTreeTuple(
   index: number,

--- a/samples/benchmarks/demo2-without-grid/draw.ts
+++ b/samples/benchmarks/demo2-without-grid/draw.ts
@@ -1,14 +1,15 @@
-import type { D3ZoomEvent } from "d3-zoom";
 import { zoom } from "d3-zoom";
+import type { D3ZoomEvent } from "d3-zoom";
 import { SegmentTree } from "segment-tree-rmq";
-import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
 import { timeout as runTimeout } from "d3-timer";
-import type { Selection } from "d3-selection";
 import { selectAll } from "d3-selection";
+import type { Selection } from "d3-selection";
 import { scaleLinear, scaleOrdinal, scaleTime } from "d3-scale";
 import type { ScaleLinear, ScaleOrdinal, ScaleTime } from "d3-scale";
 import { line } from "d3-shape";
 import type { Line } from "d3-shape";
+
+import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
 
 interface IChartData {
   name: string;

--- a/samples/benchmarks/demo2-without-grid/index.ts
+++ b/samples/benchmarks/demo2-without-grid/index.ts
@@ -1,7 +1,8 @@
-import { measure, measureOnce } from "../bench.ts";
-import * as common from "./common.ts";
 import { csv } from "d3-request";
 import { select, selectAll } from "d3-selection";
+
+import { measure, measureOnce } from "../bench.ts";
+import * as common from "./common.ts";
 
 const resize: {
   interval: number;

--- a/samples/benchmarks/viewing-pipeline-transformations/draw.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/draw.ts
@@ -1,5 +1,6 @@
-﻿import * as VWTransform from "../../ViewWindowTransform.ts";
 import type { Selection } from "d3-selection";
+
+import * as VWTransform from "../../ViewWindowTransform.ts";
 
 export class TimeSeriesChart {
   private SVGNode: SVGSVGElement;

--- a/samples/benchmarks/viewing-pipeline-transformations/drawModelCS.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/drawModelCS.ts
@@ -1,5 +1,6 @@
-﻿import * as VWTransform from "../../ViewWindowTransform.ts";
 import type { Selection } from "d3-selection";
+
+import * as VWTransform from "../../ViewWindowTransform.ts";
 
 export class TimeSeriesChartModelCS {
   private SVGNode: SVGSVGElement;

--- a/samples/benchmarks/viewing-pipeline-transformations/index.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/index.ts
@@ -1,8 +1,7 @@
 import { csv } from "d3-request";
 
-import d3shape from "d3-shape";
-
-import d3selection from "d3-selection";
+import { line } from "d3-shape";
+import { select, selectAll, type Selection } from "d3-selection";
 import * as draw from "./draw.ts";
 import * as drawModelCS from "./drawModelCS.ts";
 
@@ -19,16 +18,10 @@ csv("../../demos/ny-vs-sf.csv")
     }
 
     const onPath = (
-      path: d3selection.Selection<
-        SVGPathElement,
-        number[],
-        SVGGElement,
-        unknown
-      >,
+      path: Selection<SVGPathElement, number[], SVGGElement, unknown>,
     ) => {
       path.attr("d", (cityIdx: number) =>
-        d3shape
-          .line<number[]>()
+        line<number[]>()
           .defined((d: number[]) => !!d[cityIdx])
           .x((d: number[], i: number) => i)
           .y((d: number[]) => d[cityIdx])
@@ -37,16 +30,10 @@ csv("../../demos/ny-vs-sf.csv")
     };
 
     const onPathModel = (
-      path: d3selection.Selection<
-        SVGPathElement,
-        number[],
-        SVGGElement,
-        unknown
-      >,
+      path: Selection<SVGPathElement, number[], SVGGElement, unknown>,
     ) => {
       path.attr("d", (cityIdx: number) =>
-        d3shape
-          .line()
+        line()
           .defined((d: number[]) => !!d[cityIdx])
           .x((d: number[], i: number) => calcDate(i, startDate, 86400000))
           .y((d: number[]) => d[cityIdx])
@@ -54,19 +41,12 @@ csv("../../demos/ny-vs-sf.csv")
       );
     };
 
-    d3selection.selectAll("svg#default").each(function () {
-      new draw.TimeSeriesChart(
-        d3selection.select(this),
-        0,
-        1,
-        [0, 1],
-        onPath,
-        data.length,
-      );
+    selectAll("svg#default").each(function () {
+      new draw.TimeSeriesChart(select(this), 0, 1, [0, 1], onPath, data.length);
     });
-    d3selection.selectAll("svg#model").each(function () {
+    selectAll("svg#model").each(function () {
       new drawModelCS.TimeSeriesChartModelCS(
-        d3selection.select(this),
+        select(this),
         startDate,
         86400000,
         [0, 1],

--- a/samples/competitors/d3-plotly/dom-d3-plotly.ts
+++ b/samples/competitors/d3-plotly/dom-d3-plotly.ts
@@ -1,5 +1,6 @@
-﻿import * as common from "../../misc/common.ts";
-import Plotly from "plotly.js";
+import { newPlot } from "plotly.js";
+
+import * as common from "../../misc/common.ts";
 
 function generateData() {
   return Array.from({ length: 10 }, (_, i) => {
@@ -20,8 +21,7 @@ const layout = {
   xaxis: { showgrid: false, showticklabels: false },
 };
 async function render() {
-  Plotly.newPlot(container, generateData(), layout, { staticPlot: true }).then(
-    () => window.requestAnimationFrame(() => console.log(Date.now() - start)),
-  );
+  await newPlot(container, generateData(), layout, { staticPlot: true });
+  window.requestAnimationFrame(() => console.log(Date.now() - start));
 }
 window.requestAnimationFrame(render);

--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -1,8 +1,9 @@
 import { select } from "d3-selection";
 import { range } from "d3-array";
-import { measure, measureOnce } from "../../benchmarks/bench.ts";
 import { zoom } from "d3-zoom";
 import type { D3ZoomEvent, ZoomTransform } from "d3-zoom";
+
+import { measure, measureOnce } from "../../benchmarks/bench.ts";
 import { betweenBasesAR1 } from "../../../svg-time-series/src/math/affine.ts";
 import {
   applyAR1ToMatrixX,

--- a/samples/misc/demo2-bug-60/index.ts
+++ b/samples/misc/demo2-bug-60/index.ts
@@ -1,16 +1,15 @@
 import { scaleLinear, scaleTime } from "d3-scale";
+import type { ScaleLinear } from "d3-scale";
 import { select, selectAll } from "d3-selection";
 import type { ValueFn, BaseType, Selection } from "d3-selection";
+import { zoomIdentity, zoom as d3zoom } from "d3-zoom";
 import type { D3ZoomEvent } from "d3-zoom";
-import type { ScaleLinear } from "d3-scale";
 import { line } from "d3-shape";
 import { timeout as runTimeout, timer as runTimer } from "d3-timer";
-import { zoomIdentity, zoom as d3zoom } from "d3-zoom";
+import { SegmentTree } from "segment-tree-rmq";
 
 import { MyAxis, Orientation } from "../../../svg-time-series/src/axis.ts";
 import { ViewportTransform } from "../../../svg-time-series/src/ViewportTransform.ts";
-import { updateNode } from "../../../svg-time-series/src/utils/domNodeTransform.ts";
-import { SegmentTree } from "segment-tree-rmq";
 import type { IMinMax } from "../../../svg-time-series/src/chart/data.ts";
 import type { AR1 } from "../../../svg-time-series/src/math/affine.ts";
 import {
@@ -20,6 +19,7 @@ import {
   bPlaceholder,
   bUnit,
 } from "../../../svg-time-series/src/math/affine.ts";
+import { updateNode } from "../../../svg-time-series/src/utils/domNodeTransform.ts";
 import { onCsv } from "../../demos/common.ts";
 
 function buildSegmentTreeTuple(index: number, elements: number[][]): IMinMax {


### PR DESCRIPTION
## Summary
- enable eslint import rules for samples/competitors
- reorder sample imports to satisfy lint

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b739f7870832b857f5df40e3ca96a