### PR TITLE
Add render state destroy helper and streamline chart disposal

### DIFF
--- a/svg-time-series/src/chart/render.destroy.test.ts
+++ b/svg-time-series/src/chart/render.destroy.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import { ChartData } from "./data.ts";
+import type { IDataSource } from "./data.ts";
+import { setupRender } from "./render.ts";
+import "../setupDom.ts";
+
+function createSvg(): Selection<SVGSVGElement, unknown, HTMLElement, unknown> {
+  const parent = document.createElement("div");
+  Object.defineProperty(parent, "clientWidth", { value: 100 });
+  Object.defineProperty(parent, "clientHeight", { value: 100 });
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  parent.appendChild(svg);
+  return select(svg) as unknown as Selection<
+    SVGSVGElement,
+    unknown,
+    HTMLElement,
+    unknown
+  >;
+}
+
+describe("RenderState.destroy", () => {
+  it("removes DOM elements and clears arrays", () => {
+    const svg = createSvg();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      seriesCount: 1,
+      seriesAxes: [0],
+      getSeries: (i, _s) => [1, 2][i]!,
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg, data);
+
+    expect(svg.selectAll("path").nodes().length).toBeGreaterThan(0);
+    expect(svg.selectAll("g.axis").nodes().length).toBeGreaterThan(0);
+
+    state.destroy();
+
+    expect(svg.selectAll("path").nodes().length).toBe(0);
+    expect(svg.selectAll("g.axis").nodes().length).toBe(0);
+    expect(state.series.length).toBe(0);
+    expect(state.axisRenders.length).toBe(0);
+    expect(state.axes.y.length).toBe(0);
+    expect(state.axes.x.g).toBeUndefined();
+  });
+});

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -64,6 +64,7 @@ export interface RenderState {
   series: Series[];
   seriesRenderer: SeriesRenderer;
   refresh: (data: ChartData) => void;
+  destroy: () => void;
 }
 
 export function refreshRenderState(state: RenderState, data: ChartData): void {
@@ -81,6 +82,26 @@ export function refreshRenderState(state: RenderState, data: ChartData): void {
     r.axis.axisUp(r.g);
   });
   state.axes.x.axis.axisUp(state.axes.x.g!);
+}
+
+function destroyRenderState(state: RenderState): void {
+  for (const s of state.series) {
+    s.path.remove();
+    s.view.remove();
+  }
+  state.series.length = 0;
+
+  const axisX = state.axes.x;
+  if (axisX.g) {
+    axisX.g.remove();
+    axisX.g = undefined;
+  }
+
+  for (const r of state.axisRenders) {
+    r.g.remove();
+  }
+  state.axisRenders.length = 0;
+  state.axes.y.length = 0;
 }
 
 export function setupRender(
@@ -156,6 +177,7 @@ export function setupRender(
     seriesRenderer,
   } as RenderState;
   state.refresh = refreshRenderState.bind(null, state);
+  state.destroy = destroyRenderState.bind(null, state);
 
   return state;
 }

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -102,23 +102,7 @@ export class TimeSeriesChart {
     this.zoomArea.on("mousemove", null).on("mouseleave", null);
     this.zoomArea.remove();
     this.legendController.destroy();
-
-    for (const s of this.state.series) {
-      s.path.remove();
-      s.view.remove();
-    }
-    this.state.series.length = 0;
-    const axisX = this.state.axes.x;
-    if (axisX.g) {
-      axisX.g.remove();
-      axisX.g = undefined;
-    }
-
-    for (const r of this.state.axisRenders) {
-      r.g.remove();
-    }
-    this.state.axisRenders.length = 0;
-    this.state.axes.y.length = 0;
+    this.state.destroy();
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {


### PR DESCRIPTION
## Summary
- add a destroy helper on render state to remove series and axis nodes
- simplify chart dispose to delegate cleanup to render state
- cover render state cleanup with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7a86ee34832b8aeafbcd4a46c87d