### PR TITLE
refactor: centralize cleanup in chart dispose

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -98,27 +98,11 @@ export class TimeSeriesChart {
   }
 
   public dispose() {
-    this.zoomState.destroy();
-    this.zoomArea.on("mousemove", null).on("mouseleave", null);
+    this.clearEventListeners();
     this.zoomArea.remove();
     this.legendController.destroy();
-
-    for (const s of this.state.series) {
-      s.path.remove();
-      s.view.remove();
-    }
-    this.state.series.length = 0;
-    const axisX = this.state.axes.x;
-    if (axisX.g) {
-      axisX.g.remove();
-      axisX.g = undefined;
-    }
-
-    for (const r of this.state.axisRenders) {
-      r.g.remove();
-    }
-    this.state.axisRenders.length = 0;
-    this.state.axes.y.length = 0;
+    this.clearSeries();
+    this.removeAxes();
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
@@ -168,13 +152,40 @@ export class TimeSeriesChart {
     this.legendController.highlightIndex(idx);
   };
 
-  private drawNewData = () => {
+  private drawNewData(): void {
     this.refreshAll();
-  };
+  }
 
-  private refreshAll = () => {
+  private refreshAll(): void {
     this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
     this.legendController.refresh();
-  };
+  }
+
+  private clearEventListeners(): void {
+    this.zoomState.destroy();
+    this.zoomArea.on("mousemove", null).on("mouseleave", null);
+  }
+
+  private clearSeries(): void {
+    for (const s of this.state.series) {
+      s.path.remove();
+      s.view.remove();
+    }
+    this.state.series.length = 0;
+  }
+
+  private removeAxes(): void {
+    const axisX = this.state.axes.x;
+    if (axisX.g) {
+      axisX.g.remove();
+      axisX.g = undefined;
+    }
+
+    for (const r of this.state.axisRenders) {
+      r.g.remove();
+    }
+    this.state.axisRenders.length = 0;
+    this.state.axes.y.length = 0;
+  }
 }


### PR DESCRIPTION
## Summary
- factor repetitive cleanup into `clearEventListeners`, `clearSeries`, and `removeAxes`
- convert internal arrow functions `drawNewData` and `refreshAll` to private methods
- ensure event listeners and state references are cleared to avoid leaks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7bb89840832b9068f3ffdc91d264