### PR TITLE
refactor: centralize resize logic

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -5,8 +5,7 @@ import type { Line } from "d3-shape";
 
 import { MyAxis, Orientation } from "../axis.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
-import type { AR1Basis } from "../math/affine.ts";
-import { DirectProductBasis, bPlaceholder } from "../math/affine.ts";
+import { AR1Basis, DirectProductBasis, bPlaceholder } from "../math/affine.ts";
 
 import { AxisManager } from "./axisManager.ts";
 import type { AxisModel, AxisRenderState } from "./axisManager.ts";
@@ -14,6 +13,7 @@ import type { ChartData } from "./data.ts";
 import { createDimensions } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 import { createSeries } from "./series.ts";
+import type { ZoomState } from "./zoomState.ts";
 
 function createYAxis(
   orientation: Orientation,
@@ -64,6 +64,7 @@ export interface RenderState {
   series: Series[];
   seriesRenderer: SeriesRenderer;
   refresh: (data: ChartData) => void;
+  resize: (dimensions: Dimensions, zoomState: ZoomState) => void;
   destroy: () => void;
 }
 
@@ -102,6 +103,30 @@ function destroyRenderState(state: RenderState): void {
   }
   state.axisRenders.length = 0;
   state.axes.y.length = 0;
+}
+
+function resizeRenderState(
+  state: RenderState,
+  dimensions: Dimensions,
+  zoomState: ZoomState,
+): void {
+  const { width, height } = dimensions;
+  const bScreenXVisible = new AR1Basis(0, width);
+  const bScreenYVisible = new AR1Basis(height, 0);
+  const bScreenVisible = DirectProductBasis.fromProjections(
+    bScreenXVisible,
+    bScreenYVisible,
+  );
+
+  state.axes.x.scale.range([0, width]);
+  state.screenXBasis = bScreenXVisible;
+
+  zoomState.updateExtents(dimensions);
+
+  for (const a of state.axes.y) {
+    a.transform.onViewPortResize(bScreenVisible);
+    a.scale.range([height, 0]);
+  }
 }
 
 export function setupRender(
@@ -177,6 +202,7 @@ export function setupRender(
     seriesRenderer,
   } as RenderState;
   state.refresh = refreshRenderState.bind(null, state);
+  state.resize = resizeRenderState.bind(null, state);
   state.destroy = destroyRenderState.bind(null, state);
 
   return state;

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -5,7 +5,6 @@ import { ChartData } from "./chart/data.ts";
 import type { IDataSource } from "./chart/data.ts";
 import { setupRender } from "./chart/render.ts";
 import type { RenderState } from "./chart/render.ts";
-import { AR1Basis, DirectProductBasis } from "./math/affine.ts";
 import type { ILegendController, LegendContext } from "./chart/legend.ts";
 import { ZoomState } from "./chart/zoomState.ts";
 import type { IZoomStateOptions } from "./chart/zoomState.ts";
@@ -120,28 +119,7 @@ export class TimeSeriesChart {
   public resize = (dimensions: { width: number; height: number }) => {
     const { width, height } = dimensions;
     this.svg.attr("width", width).attr("height", height);
-
-    const bScreenXVisible = new AR1Basis(0, width);
-    const bScreenYVisible = new AR1Basis(height, 0);
-    const bScreenVisible = DirectProductBasis.fromProjections(
-      bScreenXVisible,
-      bScreenYVisible,
-    );
-
-    this.state.axes.x.scale.range([0, width]);
-    this.state.screenXBasis = bScreenXVisible;
-
-    this.state.dimensions.width = width;
-    this.state.dimensions.height = height;
-
-    this.zoomArea.attr("width", width).attr("height", height);
-    this.zoomState.updateExtents({ width, height });
-
-    for (const a of this.state.axes.y) {
-      a.transform.onViewPortResize(bScreenVisible);
-      a.scale.range([height, 0]);
-    }
-
+    this.state.resize(dimensions, this.zoomState);
     this.state.refresh(this.data);
     this.refreshAll();
   };


### PR DESCRIPTION
## Summary
- add `resize` function to chart `RenderState`
- delegate `TimeSeriesChart.resize` to state helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7f2f9214832b8d247112cd1f16ac