### PR TITLE
refactor: extract axis helpers

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest";
 import { AR1Basis } from "../math/affine.ts";
 import type { IDataSource } from "./data.ts";
 import { ChartData } from "./data.ts";
-import { buildAxisTree } from "./axisManager.ts";
 
 describe("ChartData", () => {
   const makeSource = (data: number[][], seriesAxes: number[]): IDataSource => ({
@@ -264,8 +263,8 @@ describe("ChartData", () => {
     ]);
     expect(cd.getPoint(0).timestamp).toBe(3);
     expect(cd.getPoint(1).timestamp).toBe(4);
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
     expect(tree0.query(0, 1)).toEqual({ min: 3, max: 4 });
     expect(tree1.query(0, 1)).toEqual({ min: 3, max: 4 });
   });
@@ -310,8 +309,8 @@ describe("ChartData", () => {
       ),
     );
     const range = new AR1Basis(0, 2);
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
     expect(cd.bAxisVisible(range, tree0).toArr()).toEqual([10, 50]);
     expect(cd.bAxisVisible(range, tree1).toArr()).toEqual([20, 60]);
   });
@@ -327,8 +326,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const fractionalRange = new AR1Basis(0.49, 1.49);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([10, 50]);
@@ -346,8 +345,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const fractionalRange = new AR1Basis(1.1, 1.7);
     expect(cd.bAxisVisible(fractionalRange, tree0).toArr()).toEqual([30, 50]);
@@ -365,8 +364,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const outOfRange = new AR1Basis(-0.5, 3.5);
     expect(() => cd.bAxisVisible(outOfRange, tree0)).not.toThrow();
@@ -386,8 +385,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const leftRange = new AR1Basis(-5, -1);
     expect(() => cd.bAxisVisible(leftRange, tree0)).not.toThrow();
@@ -407,8 +406,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
 
     const rightRange = new AR1Basis(5, 10);
     expect(() => cd.bAxisVisible(rightRange, tree0)).not.toThrow();
@@ -428,8 +427,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const tree0 = buildAxisTree(cd, 0);
-    const tree1 = buildAxisTree(cd, 1);
+    const tree0 = cd.buildAxisTree(0);
+    const tree1 = cd.buildAxisTree(1);
     const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
     expect(combined.toArr()).toEqual([-3, 10]);
     expect(dp.x().toArr()).toEqual([0, 2]);
@@ -468,7 +467,7 @@ describe("ChartData", () => {
 
   it("ignores NaN values when building axis tree", () => {
     const cd = new ChartData(makeSource([[1], [NaN], [3]], [0]));
-    const tree = buildAxisTree(cd, 0);
+    const tree = cd.buildAxisTree(0);
     expect(tree.query(0, 2)).toEqual({ min: 1, max: 3 });
   });
 
@@ -486,7 +485,7 @@ describe("ChartData", () => {
       expect(cd.data).toEqual([[0], [1]]);
       cd.append(2);
       expect(cd.data).toEqual([[1], [2]]);
-      const tree0 = buildAxisTree(cd, 0);
+      const tree0 = cd.buildAxisTree(0);
       expect(tree0.query(0, 1)).toEqual({ min: 1, max: 2 });
     });
 
@@ -523,8 +522,8 @@ describe("ChartData", () => {
         [0, 0, 0, 1, 1],
       ),
     );
-    let tree0 = buildAxisTree(cd, 0);
-    let tree1 = buildAxisTree(cd, 1);
+    let tree0 = cd.buildAxisTree(0);
+    let tree1 = cd.buildAxisTree(1);
     expect(tree0.query(0, 1)).toEqual({ min: 0, max: 20 });
     expect(tree1.query(0, 1)).toEqual({ min: 100, max: 220 });
 
@@ -533,8 +532,8 @@ describe("ChartData", () => {
       [1, 20, 15, 110, 220],
       [2, 30, 25, 130, 230],
     ]);
-    tree0 = buildAxisTree(cd, 0);
-    tree1 = buildAxisTree(cd, 1);
+    tree0 = cd.buildAxisTree(0);
+    tree1 = cd.buildAxisTree(1);
     expect(tree0.query(0, 1)).toEqual({ min: 1, max: 30 });
     expect(tree1.query(0, 1)).toEqual({ min: 110, max: 230 });
     expect(cd.getPoint(1)).toEqual({

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,4 +1,4 @@
-import type { SegmentTree } from "segment-tree-rmq";
+import { SegmentTree } from "segment-tree-rmq";
 
 import type { AR1 } from "../math/affine.ts";
 import {
@@ -25,6 +25,18 @@ export interface IDataSource {
   readonly seriesAxes: number[];
   getSeries(index: number, seriesIdx: number): number;
 }
+
+function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
+  return {
+    min: Math.min(fst.min, snd.min),
+    max: Math.max(fst.max, snd.max),
+  } as const;
+}
+
+const minMaxIdentity: IMinMax = {
+  min: Infinity,
+  max: -Infinity,
+};
 
 function validateSource(source: IDataSource): void {
   if (!Number.isInteger(source.length) || source.length <= 0) {
@@ -154,6 +166,19 @@ export class ChartData {
    */
   public clampIndex(idx: number): number {
     return Math.min(Math.max(idx, 0), this.window.length - 1);
+  }
+
+  buildAxisTree(axis: number): SegmentTree<IMinMax> {
+    const idxs = this.seriesByAxis[axis] ?? [];
+    const arr = this.data.map((row) =>
+      idxs
+        .map((j) => {
+          const v = row[j]!;
+          return Number.isFinite(v) ? { min: v, max: v } : minMaxIdentity;
+        })
+        .reduce(buildMinMax, minMaxIdentity),
+    );
+    return new SegmentTree(arr, buildMinMax, minMaxIdentity);
   }
   bAxisVisible(bIndexVisible: AR1Basis, tree: SegmentTree<IMinMax>): AR1Basis {
     const [minIdxX, maxIdxX] = bIndexVisible.toArr();

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -8,7 +8,6 @@ import { scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData } from "./data.ts";
 import type { IDataSource } from "./data.ts";
-import { buildAxisTree } from "./axisManager.ts";
 import { createDimensions, updateScaleX } from "./render/utils.ts";
 
 describe("createDimensions", () => {
@@ -91,7 +90,7 @@ describe("updateScaleY", () => {
 
   it("respects the supplied index window", () => {
     const cd = new ChartData(makeSource([[10], [20], [40], [5]]));
-    const tree = buildAxisTree(cd, 0);
+    const tree = cd.buildAxisTree(0);
     const dp = cd.updateScaleY(new AR1Basis(1, 2), tree);
     expect(dp.x().toArr()).toEqual([1, 2]);
     expect(dp.y().toArr()).toEqual([20, 40]);

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -48,6 +48,26 @@ describe("updateScales", () => {
         [3, 30, 5, 25],
       ],
       bIndexFull: new AR1Basis(0, 1),
+      buildAxisTree(axis: number) {
+        const idxs = this.seriesByAxis[axis] ?? [];
+        return {
+          query: (start: number, end: number) => {
+            let min = Infinity;
+            let max = -Infinity;
+            for (let i = start; i <= end; i++) {
+              const row = this.data[i]!;
+              for (const j of idxs) {
+                const v = row[j]!;
+                if (Number.isFinite(v)) {
+                  min = Math.min(min, v);
+                  max = Math.max(max, v);
+                }
+              }
+            }
+            return { min, max };
+          },
+        };
+      },
       indexToTime() {
         return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
       },
@@ -84,6 +104,26 @@ describe("updateScales", () => {
         [1, 20, 5],
       ],
       bIndexFull: new AR1Basis(0, 1),
+      buildAxisTree(axis: number) {
+        const idxs = this.seriesByAxis[axis] ?? [];
+        return {
+          query: (start: number, end: number) => {
+            let min = Infinity;
+            let max = -Infinity;
+            for (let i = start; i <= end; i++) {
+              const row = this.data[i]!;
+              for (const j of idxs) {
+                const v = row[j]!;
+                if (Number.isFinite(v)) {
+                  min = Math.min(min, v);
+                  max = Math.max(max, v);
+                }
+              }
+            }
+            return { min, max };
+          },
+        };
+      },
       indexToTime() {
         return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
       },


### PR DESCRIPTION
## Summary
- add `buildAxisTree` to `ChartData` for per-axis segment trees
- introduce `AxisModel.updateAxisTransform` and delegate `AxisManager.updateScales`
- update tests to use new helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7a99e518832b8ade2e4e18324cb9