### PR TITLE
feat: add dedicated x transform

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -75,6 +75,7 @@ vi.mock("./zoomState.ts", () => ({
   ZoomState: class {
     private state: {
       axes: { y: Array<{ transform: { onZoomPan: (t: unknown) => void } }> };
+      xTransform: { onZoomPan: (t: unknown) => void };
     };
     private refreshChart: () => void;
     private zoomCallback: (e: unknown) => void;
@@ -83,6 +84,7 @@ vi.mock("./zoomState.ts", () => ({
       this.state.axes.y.forEach((a) => {
         a.transform.onZoomPan(identity);
       });
+      this.state.xTransform.onZoomPan(identity);
       this.refreshChart();
       this.zoomCallback({ transform: identity, sourceEvent: null });
     });
@@ -94,6 +96,7 @@ vi.mock("./zoomState.ts", () => ({
       _zoomArea: unknown,
       state: {
         axes: { y: Array<{ transform: { onZoomPan: (t: unknown) => void } }> };
+        xTransform: { onZoomPan: (t: unknown) => void };
       },
       refreshChart: () => void,
       zoomCallback: (e: unknown) => void,

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -165,6 +165,7 @@ describe("chart interaction single-axis", () => {
     const xAxis = axisInstances[0]!;
     const yAxis = axisInstances[1]!;
     const mtNy = transformInstances[0]!;
+    const mtX = transformInstances[1]!;
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
@@ -174,7 +175,8 @@ describe("chart interaction single-axis", () => {
     vi.runAllTimers();
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
-    expect(transformInstances.length).toBe(1);
+    expect(mtX.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(transformInstances.length).toBe(2);
     expect(updateNodeCalls).toBeGreaterThan(callCount);
     expect(xAxis.axisUpCalls).toBeGreaterThanOrEqual(xCalls);
     expect(yAxis.axisUpCalls).toBeGreaterThanOrEqual(yCalls);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -175,6 +175,7 @@ describe("chart interaction", () => {
     const yAxis = axisInstances[1]!;
     const mtNy = transformInstances[0]!;
     const mtSf = transformInstances[1]!;
+    const mtX = transformInstances[2]!;
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
@@ -188,6 +189,7 @@ describe("chart interaction", () => {
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(mtSf.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(mtX.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(updateNodeCalls).toBeGreaterThan(callCount);
     expect(xAxis.axisUpCalls).toBeGreaterThanOrEqual(xCalls);
     expect(yAxis.axisUpCalls).toBeGreaterThanOrEqual(yCalls);

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -67,6 +67,7 @@ describe("ZoomState.destroy", () => {
         y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -111,6 +112,7 @@ describe("ZoomState.destroy", () => {
         y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -72,6 +72,7 @@ describe("ZoomState programmatic transforms", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -123,6 +123,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }, { transform: y2 }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -166,6 +167,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -213,6 +215,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -263,6 +266,7 @@ describe("ZoomState", () => {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs2 = new ZoomState(
       rect2 as unknown as Selection<
@@ -326,6 +330,7 @@ describe("ZoomState", () => {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const createZoomState = (
       rect: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -393,6 +398,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -434,6 +440,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -475,6 +482,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -523,6 +531,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -566,6 +575,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -600,6 +610,7 @@ describe("ZoomState", () => {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -631,6 +642,7 @@ describe("ZoomState", () => {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -664,6 +676,7 @@ describe("ZoomState", () => {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -700,6 +713,7 @@ describe("ZoomState", () => {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -732,6 +746,7 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -755,6 +770,7 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -792,6 +808,7 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
 
     expect(
@@ -817,6 +834,7 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
 
     expect(

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -63,6 +63,7 @@ describe("ZoomState transform state", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -73,6 +73,7 @@ export class ZoomState {
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.state.axes.y.forEach((a) => a.transform.onZoomPan(event.transform));
+    this.state.xTransform.onZoomPan(event.transform);
     if (!this.zoomScheduler.zoom(event.transform, event.sourceEvent)) {
       return;
     }

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -110,6 +110,7 @@ describe("ZoomState.updateExtents clamp", () => {
       dimensions: { width: 100, height: 100 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -157,13 +157,14 @@ export class TimeSeriesChart {
       a.transform.onViewPortResize(bScreenVisible);
       a.scale.range([height, 0]);
     }
+    this.state.xTransform.onViewPortResize(bScreenVisible);
 
     this.state.refresh(this.data);
     this.refreshAll();
   };
 
   public onHover = (x: number) => {
-    let idx = this.state.axes.y[0]!.transform.fromScreenToModelX(x);
+    let idx = this.state.xTransform.fromScreenToModelX(x);
     idx = this.data.clampIndex(idx);
     this.legendController.highlightIndex(idx);
   };


### PR DESCRIPTION
## Summary
- add xTransform to render state for horizontal viewport mapping
- use xTransform for hover and zoom interactions instead of first Y axis
- update tests for new transform handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b7b7304dc832baf7d6f390c6c6c29