### PR TITLE
refactor: centralize chart cleanup

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -99,10 +99,11 @@ export class TimeSeriesChart {
 
   public dispose() {
     this.zoomState.destroy();
-    this.zoomArea.on("mousemove", null).on("mouseleave", null);
+    this.clearEventListeners();
+    this.clearSeries();
+    this.removeAxes();
     this.zoomArea.remove();
     this.legendController.destroy();
-    this.state.destroy();
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
@@ -152,13 +153,38 @@ export class TimeSeriesChart {
     this.legendController.highlightIndex(idx);
   };
 
-  private drawNewData = () => {
+  private drawNewData(): void {
     this.refreshAll();
-  };
+  }
 
-  private refreshAll = () => {
+  private refreshAll(): void {
     this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
     this.legendController.refresh();
-  };
+  }
+
+  private clearEventListeners(): void {
+    this.zoomArea.on("mousemove", null).on("mouseleave", null);
+  }
+
+  private clearSeries(): void {
+    for (const s of this.state.series) {
+      s.path.remove();
+      s.view.remove();
+    }
+    this.state.series.length = 0;
+  }
+
+  private removeAxes(): void {
+    const axisX = this.state.axes.x;
+    if (axisX.g) {
+      axisX.g.remove();
+      axisX.g = undefined;
+    }
+    for (const r of this.state.axisRenders) {
+      r.g.remove();
+    }
+    this.state.axisRenders.length = 0;
+    this.state.axes.y.length = 0;
+  }
 }


### PR DESCRIPTION
## Summary
- centralize chart cleanup into dedicated helpers to remove listeners, series, and axes
- convert internal arrow functions to private methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bb2f86540832b86516a0cdc8e4533