### PR TITLE
feat: add dedicated x transform

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -75,11 +75,13 @@ vi.mock("./zoomState.ts", () => ({
   ZoomState: class {
     private state: {
       axes: { y: Array<{ transform: { onZoomPan: (t: unknown) => void } }> };
+      xTransform: { onZoomPan: (t: unknown) => void };
     };
     private refreshChart: () => void;
     private zoomCallback: (e: unknown) => void;
     reset = vi.fn(() => {
       const identity = { x: 0, k: 1 };
+      this.state.xTransform.onZoomPan(identity);
       this.state.axes.y.forEach((a) => {
         a.transform.onZoomPan(identity);
       });
@@ -94,6 +96,7 @@ vi.mock("./zoomState.ts", () => ({
       _zoomArea: unknown,
       state: {
         axes: { y: Array<{ transform: { onZoomPan: (t: unknown) => void } }> };
+        xTransform: { onZoomPan: (t: unknown) => void };
       },
       refreshChart: () => void,
       zoomCallback: (e: unknown) => void,

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -165,6 +165,7 @@ describe("chart interaction single-axis", () => {
     const xAxis = axisInstances[0]!;
     const yAxis = axisInstances[1]!;
     const mtNy = transformInstances[0]!;
+    const mtX = transformInstances[1]!;
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
@@ -174,7 +175,8 @@ describe("chart interaction single-axis", () => {
     vi.runAllTimers();
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
-    expect(transformInstances.length).toBe(1);
+    expect(mtX.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(transformInstances.length).toBe(2);
     expect(updateNodeCalls).toBeGreaterThan(callCount);
     expect(xAxis.axisUpCalls).toBeGreaterThanOrEqual(xCalls);
     expect(yAxis.axisUpCalls).toBeGreaterThanOrEqual(yCalls);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -175,6 +175,7 @@ describe("chart interaction", () => {
     const yAxis = axisInstances[1]!;
     const mtNy = transformInstances[0]!;
     const mtSf = transformInstances[1]!;
+    const mtX = transformInstances[2]!;
     const xCalls = xAxis.axisUpCalls;
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
@@ -188,6 +189,7 @@ describe("chart interaction", () => {
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(mtSf.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
+    expect(mtX.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
     expect(updateNodeCalls).toBeGreaterThan(callCount);
     expect(xAxis.axisUpCalls).toBeGreaterThanOrEqual(xCalls);
     expect(yAxis.axisUpCalls).toBeGreaterThanOrEqual(yCalls);

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -67,6 +67,7 @@ describe("ZoomState.destroy", () => {
         y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -111,6 +112,7 @@ describe("ZoomState.destroy", () => {
         y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
       },
       axisRenders: [],
+      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -65,6 +65,7 @@ describe("ZoomState programmatic transforms", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -72,6 +73,7 @@ describe("ZoomState programmatic transforms", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -91,6 +93,8 @@ describe("ZoomState programmatic transforms", () => {
     vi.runAllTimers();
 
     expect(transformSpy).toHaveBeenCalledTimes(2);
+    expect(x.onZoomPan).toHaveBeenCalledWith(initial);
+    expect(y.onZoomPan).toHaveBeenCalledWith(initial);
     expect(refresh).toHaveBeenCalledTimes(1);
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -116,6 +116,7 @@ describe("ZoomState", () => {
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const y2 = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -123,6 +124,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }, { transform: y2 }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -145,6 +147,7 @@ describe("ZoomState", () => {
     zs.zoom(event);
     vi.runAllTimers();
 
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
     expect(y.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
     expect(y2.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
     expect(refresh).toHaveBeenCalledTimes(1);
@@ -159,6 +162,7 @@ describe("ZoomState", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -166,6 +170,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -194,6 +199,8 @@ describe("ZoomState", () => {
       x: 2,
       k: 3,
     });
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 2, k: 3 });
+    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 2, k: 3 });
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
@@ -206,6 +213,7 @@ describe("ZoomState", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -213,6 +221,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -251,6 +260,10 @@ describe("ZoomState", () => {
       x: 5,
       k: 4,
     });
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 3, k: 2 });
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 4 });
+    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 3, k: 2 });
+    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 4 });
     expect(refresh).toHaveBeenCalledTimes(2);
   });
 
@@ -259,10 +272,12 @@ describe("ZoomState", () => {
     const rect1 = select(svg1).append("rect");
     const svg2 = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect2 = select(svg2).append("rect");
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const zs2 = new ZoomState(
       rect2 as unknown as Selection<
@@ -315,6 +330,8 @@ describe("ZoomState", () => {
       x: 5,
       k: 4,
     });
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 2 });
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 4 });
   });
 
   it("does not leave source chart stuck after target chart zoom", () => {
@@ -322,10 +339,12 @@ describe("ZoomState", () => {
     const rect1 = select(svg1).append("rect");
     const svg2 = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect2 = select(svg2).append("rect");
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const createZoomState = (
       rect: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -380,12 +399,14 @@ describe("ZoomState", () => {
     const zs1Internal = zs1 as unknown as ZoomStateInternal;
     expect(zs1Internal.zoomScheduler.isPending()).toBe(false);
     expect(zs1Internal.zoomScheduler.getCurrentTransform()).toBeNull();
+    expect(x.onZoomPan).toHaveBeenCalled();
   });
 
   it("programmatic zoom does not reapply transform on subsequent refresh", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -393,6 +414,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -412,6 +434,8 @@ describe("ZoomState", () => {
       transform: { x: 4, k: 5 },
     } as unknown as D3ZoomEvent<SVGRectElement, unknown>);
     vi.runAllTimers();
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 4, k: 5 });
+    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 4, k: 5 });
 
     transformSpy.mockClear();
     refresh.mockClear();
@@ -427,6 +451,7 @@ describe("ZoomState", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -434,6 +459,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -452,6 +478,8 @@ describe("ZoomState", () => {
       sourceEvent: {},
     } as unknown as D3ZoomEvent<SVGRectElement, unknown>);
     vi.runAllTimers();
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 1 });
+    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 1 });
 
     const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
     transformSpy.mockClear();
@@ -468,6 +496,7 @@ describe("ZoomState", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -475,6 +504,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -491,6 +521,7 @@ describe("ZoomState", () => {
     const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
     transformSpy.mockClear();
     y.onZoomPan.mockClear();
+    x.onZoomPan.mockClear();
     refresh.mockClear();
 
     zs.reset();
@@ -500,9 +531,9 @@ describe("ZoomState", () => {
       rect,
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
-    expect(y.onZoomPan).toHaveBeenCalledWith(
-      expect.objectContaining({ k: 1, x: 0, y: 0 }),
-    );
+    const identity = expect.objectContaining({ k: 1, x: 0, y: 0 });
+    expect(x.onZoomPan).toHaveBeenCalledWith(identity);
+    expect(y.onZoomPan).toHaveBeenCalledWith(identity);
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;
     }
@@ -516,6 +547,7 @@ describe("ZoomState", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -523,6 +555,7 @@ describe("ZoomState", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -596,10 +629,12 @@ describe("ZoomState", () => {
   it("updates scale extent at runtime", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -627,10 +662,12 @@ describe("ZoomState", () => {
   it("clamps existing transform to new scale extent", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -648,6 +685,7 @@ describe("ZoomState", () => {
       x: 0,
       y: 0,
     } as unknown as ZoomTransform);
+    expect(x.onZoomPan).toHaveBeenCalledWith({ k: 10, x: 0, y: 0 });
     const scaleSpy = zs.zoomBehavior.scaleTo as unknown as Mock;
     scaleSpy.mockClear();
 
@@ -660,10 +698,12 @@ describe("ZoomState", () => {
   it("clamps existing transform to new minimum", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
+    const x2 = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x2,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -681,6 +721,7 @@ describe("ZoomState", () => {
       x: 0,
       y: 0,
     } as unknown as ZoomTransform);
+    expect(x2.onZoomPan).toHaveBeenCalledWith({ k: 0.2, x: 0, y: 0 });
     const scaleSpy = zs.zoomBehavior.scaleTo as unknown as Mock;
     scaleSpy.mockClear();
 
@@ -696,10 +737,12 @@ describe("ZoomState", () => {
   ])("accepts valid scale extent %j", (min, max) => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -56,6 +56,7 @@ describe("ZoomState transform state", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
       axes: {
@@ -63,6 +64,7 @@ describe("ZoomState transform state", () => {
         y: [{ transform: y }],
       },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -86,6 +88,8 @@ describe("ZoomState transform state", () => {
     vi.runAllTimers();
 
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 1, k: 2 });
+    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 2 });
+    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 2 });
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;
     }
@@ -114,5 +118,7 @@ describe("ZoomState transform state", () => {
 
     expect(transformSpy).toHaveBeenCalledTimes(1);
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 5, k: 3 });
+    expect(x.onZoomPan).toHaveBeenLastCalledWith({ x: 5, k: 3 });
+    expect(y.onZoomPan).toHaveBeenLastCalledWith({ x: 5, k: 3 });
   });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -72,6 +72,7 @@ export class ZoomState {
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
+    this.state.xTransform.onZoomPan(event.transform);
     this.state.axes.y.forEach((a) => a.transform.onZoomPan(event.transform));
     if (!this.zoomScheduler.zoom(event.transform, event.sourceEvent)) {
       return;

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -106,10 +106,12 @@ describe("ZoomState.updateExtents clamp", () => {
   it("clamps existing translation to new bounds", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
+    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 100, height: 100 },
       axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
+      xTransform: x,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -125,6 +127,7 @@ describe("ZoomState.updateExtents clamp", () => {
     const initial = zoomIdentity.translate(-120, -80).scale(2);
     zs.zoomBehavior.transform(rect, initial);
     const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    expect(x.onZoomPan).toHaveBeenCalledWith(initial);
     transformSpy.mockClear();
 
     zs.updateExtents({ width: 50, height: 50 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -125,7 +125,7 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    let idx = this.state.axes.y[0]!.transform.fromScreenToModelX(x);
+    let idx = this.state.xTransform.fromScreenToModelX(x);
     idx = this.data.clampIndex(idx);
     this.legendController.highlightIndex(idx);
   };


### PR DESCRIPTION
## Summary
- compute and expose an `xTransform` alongside Y-axis transforms
- use this horizontal transform for zoom and hover interactions
- update tests for new transform API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb4a69a90832b99ceb9727bccfb56