### PR TITLE
fix: lint mjs files as ES modules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,20 @@ import globals from "globals";
 import importPlugin from "eslint-plugin-import";
 
 const disableTypeChecked = tsEslint.configs.disableTypeChecked;
+const nodeOverride = {
+  languageOptions: {
+    ...disableTypeChecked.languageOptions,
+    globals: globals.node,
+  },
+  rules: {
+    ...disableTypeChecked.rules,
+    "import/no-unresolved": "off",
+    "import/order": "off",
+    "import/default": "off",
+    "import/no-named-as-default-member": "off",
+    "import/no-named-as-default": "off",
+  },
+};
 
 export default tsEslint.config(
   {
@@ -65,19 +79,19 @@ export default tsEslint.config(
     },
   },
     {
-      files: ["**/*.cjs", "**/*.mjs", "**/vite.config.ts"],
+      files: ["**/*.cjs", "**/vite.config.ts"],
+      ...nodeOverride,
       languageOptions: {
-        ...disableTypeChecked.languageOptions,
+        ...nodeOverride.languageOptions,
         sourceType: "commonjs",
-        globals: globals.node,
       },
-      rules: {
-        ...disableTypeChecked.rules,
-        "import/no-unresolved": "off",
-        "import/order": "off",
-        "import/default": "off",
-        "import/no-named-as-default-member": "off",
-        "import/no-named-as-default": "off",
+    },
+    {
+      files: ["**/*.mjs"],
+      ...nodeOverride,
+      languageOptions: {
+        ...nodeOverride.languageOptions,
+        sourceType: "module",
       },
     },
   {


### PR DESCRIPTION
## Summary
- lint `.mjs` files as ES modules instead of CommonJS
- keep CommonJS override for `.cjs` and Vite config files
- share node override config between `.cjs` and `.mjs` files to avoid duplication

## Testing
- `npm run lint`
- `git commit` (pre-commit: lint, typecheck, vitest)


------
https://chatgpt.com/codex/tasks/task_e_689bb90cf930832b83d0fed74d5f21bc