### PR TITLE
chore: resolve lint issues in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -119,13 +119,5 @@ export default tsEslint.config(
   {
     files: ["**/*.test.ts"],
     ...vitest.configs.recommended,
-    rules: {
-      "@typescript-eslint/no-confusing-void-expression": "off",
-      "@typescript-eslint/unbound-method": "off",
-      "@typescript-eslint/no-unnecessary-type-assertion": "off",
-      "@typescript-eslint/no-unsafe-assignment": "off",
-      "@typescript-eslint/no-unsafe-member-access": "off",
-      "@typescript-eslint/restrict-template-expressions": "off",
-    },
   },
 );

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -87,9 +87,10 @@ function createChart(data: Array<[number]>) {
     length: data.length,
     seriesCount: 1,
     seriesAxes: [0],
-    getSeries: (i) => data[i]![0]!,
+    getSeries: (i) => data[i]![0],
   };
   const legendController = new StubLegendController();
+
   const chart = new TimeSeriesChart(
     select(svgEl) as unknown as Selection<
       SVGSVGElement,

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -87,7 +87,7 @@ describe("ZoomState programmatic transforms", () => {
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     const initial = { x: 1, y: 2, k: 3 } as unknown as ZoomTransform;
     zs.zoomBehavior.transform(rect, initial);
     vi.runAllTimers();

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -153,7 +153,10 @@ describe("ZoomState", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
-    const internalEvent = zoomCb.mock.calls.at(1)![0];
+    const internalEvent = zoomCb.mock.calls.at(1)![0] as {
+      transform: { x: number; k: number };
+      sourceEvent?: unknown;
+    };
     expect(internalEvent).toMatchObject({ transform: { x: 5, k: 2 } });
     expect(internalEvent.sourceEvent).toBeUndefined();
   });
@@ -186,7 +189,7 @@ describe("ZoomState", () => {
       zoomCb,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     transformSpy.mockClear();
     const event = {
       transform: { x: 2, k: 3 },
@@ -204,7 +207,10 @@ describe("ZoomState", () => {
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
-    const internalEvent = zoomCb.mock.calls.at(1)![0];
+    const internalEvent = zoomCb.mock.calls.at(1)![0] as {
+      transform: { x: number; k: number };
+      sourceEvent?: unknown;
+    };
     expect(internalEvent).toMatchObject({ transform: { x: 2, k: 3 } });
     expect(internalEvent.sourceEvent).toBeUndefined();
   });
@@ -235,7 +241,7 @@ describe("ZoomState", () => {
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     transformSpy.mockClear();
 
     const forwarded = {
@@ -307,7 +313,7 @@ describe("ZoomState", () => {
       },
     );
 
-    const transformSpy = zs2.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs2.zoomBehavior, "transform");
     transformSpy.mockClear();
 
     const event1 = {
@@ -428,7 +434,7 @@ describe("ZoomState", () => {
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
 
     zs.zoom({
       transform: { x: 4, k: 5 },
@@ -481,7 +487,7 @@ describe("ZoomState", () => {
     expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 1 });
     expect(y.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 1 });
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     transformSpy.mockClear();
     refresh.mockClear();
 
@@ -518,7 +524,7 @@ describe("ZoomState", () => {
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     transformSpy.mockClear();
     y.onZoomPan.mockClear();
     x.onZoomPan.mockClear();
@@ -531,7 +537,7 @@ describe("ZoomState", () => {
       rect,
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
-    const identity = expect.objectContaining({ k: 1, x: 0, y: 0 });
+    const identity = expect.objectContaining({ k: 1, x: 0, y: 0 }) as unknown;
     expect(x.onZoomPan).toHaveBeenCalledWith(identity);
     expect(y.onZoomPan).toHaveBeenCalledWith(identity);
     interface ZoomStateInternal {
@@ -686,7 +692,7 @@ describe("ZoomState", () => {
       y: 0,
     } as unknown as ZoomTransform);
     expect(x.onZoomPan).toHaveBeenCalledWith({ k: 10, x: 0, y: 0 });
-    const scaleSpy = zs.zoomBehavior.scaleTo as unknown as Mock;
+    const scaleSpy = vi.spyOn(zs.zoomBehavior, "scaleTo");
     scaleSpy.mockClear();
 
     zs.setScaleExtent([1, 5]);
@@ -722,7 +728,7 @@ describe("ZoomState", () => {
       y: 0,
     } as unknown as ZoomTransform);
     expect(x2.onZoomPan).toHaveBeenCalledWith({ k: 0.2, x: 0, y: 0 });
-    const scaleSpy = zs.zoomBehavior.scaleTo as unknown as Mock;
+    const scaleSpy = vi.spyOn(zs.zoomBehavior, "scaleTo");
     scaleSpy.mockClear();
 
     zs.setScaleExtent([0.5, 5]);
@@ -755,7 +761,9 @@ describe("ZoomState", () => {
       vi.fn(),
     );
 
-    expect(() => zs.setScaleExtent([min, max])).not.toThrow();
+    expect(() => {
+      zs.setScaleExtent([min, max]);
+    }).not.toThrow();
   });
 
   it.each([
@@ -787,9 +795,9 @@ describe("ZoomState", () => {
       vi.fn(),
     );
 
-    expect(() => zs.setScaleExtent([min, max])).toThrow(
-      /scaleExtent must be two finite, positive numbers/,
-    );
+    expect(() => {
+      zs.setScaleExtent([min, max]);
+    }).toThrow(/scaleExtent must be two finite, positive numbers/);
   });
 
   it("rejects scale extents that do not contain exactly two values", () => {
@@ -810,12 +818,12 @@ describe("ZoomState", () => {
       vi.fn(),
     );
 
-    expect(() => zs.setScaleExtent([1] as unknown as [number, number])).toThrow(
-      /scaleExtent must be two finite, positive numbers/,
-    );
-    expect(() =>
-      zs.setScaleExtent([1, 2, 3] as unknown as [number, number]),
-    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+    expect(() => {
+      zs.setScaleExtent([1] as unknown as [number, number]);
+    }).toThrow(/scaleExtent must be two finite, positive numbers/);
+    expect(() => {
+      zs.setScaleExtent([1, 2, 3] as unknown as [number, number]);
+    }).toThrow(/scaleExtent must be two finite, positive numbers/);
   });
 
   it.each([

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -78,7 +78,7 @@ describe("ZoomState transform state", () => {
       refresh,
     );
 
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
 
     const first = {
       transform: { x: 1, k: 2 },

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -126,7 +126,7 @@ describe("ZoomState.updateExtents clamp", () => {
 
     const initial = zoomIdentity.translate(-120, -80).scale(2);
     zs.zoomBehavior.transform(rect, initial);
-    const transformSpy = zs.zoomBehavior.transform as unknown as Mock;
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     expect(x.onZoomPan).toHaveBeenCalledWith(initial);
     transformSpy.mockClear();
 


### PR DESCRIPTION
## Summary
- remove disabled TypeScript ESLint rules for tests to keep strict linting
- bind `zoomBehavior.transform` with `vi.spyOn` in transform state tests

## Testing
- `npm run lint`
- `npm run typecheck --workspaces --if-present`
- `npm test`

Remaining ESLint errors: 0


------
https://chatgpt.com/codex/tasks/task_e_689c447d2524832b993e499ba32f4de0