### PR TITLE
refactor: centralize minMax helpers

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -8,18 +8,7 @@ import { ViewportTransform } from "../ViewportTransform.ts";
 import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
 import type { ChartData, IMinMax } from "./data.ts";
 import { updateScaleX } from "./render/utils.ts";
-
-function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
-  return {
-    min: Math.min(fst.min, snd.min),
-    max: Math.max(fst.max, snd.max),
-  } as const;
-}
-
-const minMaxIdentity: IMinMax = {
-  min: Infinity,
-  max: -Infinity,
-};
+import { buildMinMax, minMaxIdentity } from "./minMax.ts";
 
 export class AxisModel {
   transform: ViewportTransform;

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -8,6 +8,7 @@ import {
 } from "../math/affine.ts";
 import { SlidingWindow } from "./slidingWindow.ts";
 import { assertFiniteNumber, assertPositiveInteger } from "./validation.ts";
+import { buildMinMax, minMaxIdentity } from "./minMax.ts";
 
 export interface IMinMax {
   readonly min: number;
@@ -26,18 +27,6 @@ export interface IDataSource {
   readonly seriesAxes: number[];
   getSeries(index: number, seriesIdx: number): number;
 }
-
-function buildMinMax(fst: Readonly<IMinMax>, snd: Readonly<IMinMax>): IMinMax {
-  return {
-    min: Math.min(fst.min, snd.min),
-    max: Math.max(fst.max, snd.max),
-  } as const;
-}
-
-const minMaxIdentity: IMinMax = {
-  min: Infinity,
-  max: -Infinity,
-};
 
 function validateSource(source: IDataSource): void {
   assertPositiveInteger(source.length, "ChartData length");

--- a/svg-time-series/src/chart/minMax.ts
+++ b/svg-time-series/src/chart/minMax.ts
@@ -1,0 +1,16 @@
+import type { IMinMax } from "./data.ts";
+
+export function buildMinMax(
+  fst: Readonly<IMinMax>,
+  snd: Readonly<IMinMax>,
+): IMinMax {
+  return {
+    min: Math.min(fst.min, snd.min),
+    max: Math.max(fst.max, snd.max),
+  } as const;
+}
+
+export const minMaxIdentity: IMinMax = {
+  min: Infinity,
+  max: -Infinity,
+};

--- a/svg-time-series/src/segmentTree.test.ts
+++ b/svg-time-series/src/segmentTree.test.ts
@@ -1,12 +1,7 @@
 import { expect, test } from "vitest";
 import { SegmentTree } from "segment-tree-rmq";
 import type { IMinMax } from "./chart/data.ts";
-
-function buildMinMax(a: IMinMax, b: IMinMax): IMinMax {
-  return { min: Math.min(a.min, b.min), max: Math.max(a.max, b.max) };
-}
-
-const minMaxIdentity: IMinMax = { min: Infinity, max: -Infinity };
+import { buildMinMax, minMaxIdentity } from "./chart/minMax.ts";
 
 function createSegmentTree<T>(
   elements: ReadonlyArray<T>,


### PR DESCRIPTION
## Summary
- extract minMax helpers into chart/minMax module
- import shared minMax helpers in data and axis manager
- update tests to use shared minMax utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c682193c0832bbce7a23fe4e46dd3