### PR TITLE
refactor: destroy render state on dispose

### DIFF
--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -325,7 +325,7 @@ describe("chart interaction", () => {
     }).toThrow();
   });
 
-  it("dispose removes event listeners and DOM elements", () => {
+  it("dispose cleans up resources", () => {
     const parent = document.createElement("div");
     Object.defineProperty(parent, "clientWidth", {
       value: 10,
@@ -373,6 +373,10 @@ describe("chart interaction", () => {
       () => {},
       mouseMoveHandler,
     );
+    const destroySpy = vi.spyOn(
+      (chart as unknown as { state: { destroy: () => void } }).state,
+      "destroy",
+    );
 
     const zoomRect = svgEl.querySelector("rect.zoom") as SVGRectElement;
     expect(zoomRect).not.toBeNull();
@@ -381,6 +385,8 @@ describe("chart interaction", () => {
     expect(mouseMoveHandler).toHaveBeenCalledTimes(1);
 
     chart.dispose();
+
+    expect(destroySpy).toHaveBeenCalled();
 
     expect(svgEl.querySelector("rect.zoom")).toBeNull();
     expect(svgEl.querySelectorAll("circle").length).toBe(0);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -98,9 +98,8 @@ export class TimeSeriesChart {
 
   public dispose() {
     this.zoomState.destroy();
-    this.clearEventListeners();
-    this.clearSeries();
-    this.removeAxes();
+    this.zoomArea.on("mousemove", null).on("mouseleave", null);
+    this.state.destroy();
     this.zoomArea.remove();
     this.legendController.destroy();
   }
@@ -139,30 +138,5 @@ export class TimeSeriesChart {
     this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
     this.legendController.refresh();
-  }
-
-  private clearEventListeners(): void {
-    this.zoomArea.on("mousemove", null).on("mouseleave", null);
-  }
-
-  private clearSeries(): void {
-    for (const s of this.state.series) {
-      s.path.remove();
-      s.view.remove();
-    }
-    this.state.series.length = 0;
-  }
-
-  private removeAxes(): void {
-    const axisX = this.state.axes.x;
-    if (axisX.g) {
-      axisX.g.remove();
-      axisX.g = undefined;
-    }
-    for (const r of this.state.axisRenders) {
-      r.g.remove();
-    }
-    this.state.axisRenders.length = 0;
-    this.state.axes.y.length = 0;
   }
 }


### PR DESCRIPTION
## Summary
- delegate `TimeSeriesChart.dispose` cleanup to `state.destroy`
- drop now-unused cleanup helpers
- ensure disposal test spies on `state.destroy`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c68425444832b8958a88c509fc7a1