### PR TITLE
Enable linting for benchmarks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -113,16 +113,6 @@ export default config(
       },
     },
     {
-      files: ["samples/benchmarks/**"],
-      rules: {
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-      },
-    },
-    {
       files: ["samples/competitors/**"],
       languageOptions: {
         globals: { ...globals.browser, d3: "readonly" },

--- a/samples/benchmarks/path-recreate-dom/index.ts
+++ b/samples/benchmarks/path-recreate-dom/index.ts
@@ -1,6 +1,10 @@
-﻿import { select, selectAll } from "d3-selection";
+import { select, selectAll } from "d3-selection";
 import { measure, measureOnce, onCsv } from "../bench.ts";
 import { TimeSeriesChart } from "./draw.ts";
+
+interface PathDataSVGPathElement extends SVGPathElement {
+  setPathData: (pathData: { type: string; values: [number, number] }[]) => void;
+}
 
 onCsv((data) => {
   const dataLength = data.length;
@@ -71,7 +75,9 @@ onCsv((data) => {
     }
 
     // Draw
-    pathElement.setPathData(pathsData[cityIdx]);
+    (pathElement as unknown as PathDataSVGPathElement).setPathData(
+      pathsData[cityIdx],
+    );
   };
 
   selectAll("g.view")
@@ -81,12 +87,7 @@ onCsv((data) => {
     .append("path");
 
   selectAll("svg").each(function (_, i: number) {
-    return new TimeSeriesChart(
-      select(this as SVGSVGElement),
-      dataLength,
-      drawLine,
-      i,
-    );
+    new TimeSeriesChart(select(this as SVGSVGElement), dataLength, drawLine, i);
   });
 
   measure(3, ({ fps }) => {

--- a/samples/benchmarks/viewing-pipeline-transformations/draw.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/draw.ts
@@ -21,13 +21,14 @@ export class TimeSeriesChart {
   ) {
     this.stepX = stepX;
 
-    this.SVGNode = svg.node();
+    this.SVGNode = svg.node()!;
     this.vwTransform = new VWTransform.ViewWindowTransform(
       this.SVGNode.transform.baseVal,
     );
 
-    const width = svg.node().parentNode.clientWidth,
-      height = svg.node().parentNode.clientHeight;
+    const parent = svg.node()!.parentNode as HTMLElement;
+    const width = parent.clientWidth,
+      height = parent.clientHeight;
     svg.attr("width", width);
     svg.attr("height", height);
 

--- a/samples/benchmarks/viewing-pipeline-transformations/drawModelCS.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/drawModelCS.ts
@@ -21,13 +21,14 @@ export class TimeSeriesChartModelCS {
   ) {
     this.stepX = stepX;
 
-    this.SVGNode = svg.node();
+    this.SVGNode = svg.node()!;
     this.vwTransform = new VWTransform.ViewWindowTransform(
       this.SVGNode.transform.baseVal,
     );
 
-    const width = svg.node().parentNode.clientWidth,
-      height = svg.node().parentNode.clientHeight;
+    const parent = svg.node()!.parentNode as HTMLElement;
+    const width = parent.clientWidth,
+      height = parent.clientHeight;
     svg.attr("width", width);
     svg.attr("height", height);
 


### PR DESCRIPTION
## Summary
- remove benchmark-specific lint rule disables but keep polyfill ignored
- fix benchmark sources to satisfy no-unsafe rules

## Testing
- `npm run lint`
- `npm run format`
- `npm run typecheck --workspaces --if-present`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c6e8be3c0832bb46d75d9379e07b1