### PR TITLE
Guard DOM polyfills when native implementations exist

### DIFF
--- a/svg-time-series/src/setupDom.native.test.ts
+++ b/svg-time-series/src/setupDom.native.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Ensure native DOMMatrix/DOMPoint are preserved
+describe("setupDom", () => {
+  it("does not override existing DOMMatrix and DOMPoint", async () => {
+    const globalObj = globalThis as Record<string, unknown>;
+    const originalMatrix = globalObj["DOMMatrix"];
+    const originalPoint = globalObj["DOMPoint"];
+
+    class NativeMatrix {
+      // dummy property to satisfy lint
+      m = 0;
+    }
+    class NativePoint {
+      p = 0;
+    }
+    globalObj["DOMMatrix"] = NativeMatrix;
+    globalObj["DOMPoint"] = NativePoint;
+
+    vi.resetModules();
+    await import("./setupDom.ts");
+
+    expect(globalObj["DOMMatrix"]).toBe(NativeMatrix);
+    expect(globalObj["DOMPoint"]).toBe(NativePoint);
+
+    if (originalMatrix === undefined) {
+      delete globalObj["DOMMatrix"];
+    } else {
+      globalObj["DOMMatrix"] = originalMatrix;
+    }
+    if (originalPoint === undefined) {
+      delete globalObj["DOMPoint"];
+    } else {
+      globalObj["DOMPoint"] = originalPoint;
+    }
+  });
+});

--- a/svg-time-series/src/setupDom.ts
+++ b/svg-time-series/src/setupDom.ts
@@ -103,8 +103,12 @@ class Point {
 }
 
 const globalObj = globalThis as unknown as Record<string, unknown>;
-globalObj["DOMMatrix"] = Matrix;
-globalObj["DOMPoint"] = Point;
+if (typeof globalObj["DOMMatrix"] === "undefined") {
+  globalObj["DOMMatrix"] = Matrix;
+}
+if (typeof globalObj["DOMPoint"] === "undefined") {
+  globalObj["DOMPoint"] = Point;
+}
 if (typeof SVGSVGElement !== "undefined") {
   (
     SVGSVGElement.prototype as unknown as {

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -103,8 +103,12 @@ class Point {
 }
 
 const globalObj = globalThis as unknown as Record<string, unknown>;
-globalObj["DOMMatrix"] = Matrix;
-globalObj["DOMPoint"] = Point;
+if (typeof globalObj["DOMMatrix"] === "undefined") {
+  globalObj["DOMMatrix"] = Matrix;
+}
+if (typeof globalObj["DOMPoint"] === "undefined") {
+  globalObj["DOMPoint"] = Point;
+}
 if (typeof SVGSVGElement !== "undefined") {
   (
     SVGSVGElement.prototype as unknown as {


### PR DESCRIPTION
## Summary
- Avoid overriding existing `DOMMatrix`/`DOMPoint` by only polyfilling when absent
- Add regression test ensuring native DOM types remain untouched

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7243cf8c832b9959a134779e2770