### PR TITLE
fix: round hover index before clamping

### DIFF
--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -138,4 +138,19 @@ describe("TimeSeriesChart hover clamping", () => {
 
     expect(legendController.highlightIndex).toHaveBeenCalledWith(2);
   });
+
+  it("highlights nearest point for fractional positions", () => {
+    const { onHover, legendController } = createChart([[10], [20], [30]]);
+    vi.runAllTimers();
+    legendController.highlightIndex.mockClear();
+
+    onHover(1.4);
+    vi.runAllTimers();
+    expect(legendController.highlightIndex).toHaveBeenCalledWith(1);
+
+    legendController.highlightIndex.mockClear();
+    onHover(1.6);
+    vi.runAllTimers();
+    expect(legendController.highlightIndex).toHaveBeenCalledWith(2);
+  });
 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -125,7 +125,7 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    let idx = this.state.xTransform.fromScreenToModelX(x);
+    let idx = Math.round(this.state.xTransform.fromScreenToModelX(x));
     idx = this.data.clampIndex(idx);
     this.legendController.highlightIndex(idx);
   };


### PR DESCRIPTION
## Summary
- round hover position to nearest index before clamping
- test fractional hover positions highlight nearest data point

## Testing
- `npm test svg-time-series/src/chart/interaction.hoverClamp.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689c72311818832b8fc47d1964192961