### PR TITLE
refactor: unify LegendPoint interface

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -88,49 +88,6 @@ describe("LegendController", () => {
     lc.destroy();
   });
 
-  it("handles legacy tuple return from getPoint", () => {
-    const { svg, legendDiv } = createSvgAndLegend();
-    const source: IDataSource = {
-      startTime: 0,
-      timeStep: 1,
-      length: 2,
-      seriesCount: 1,
-      getSeries: (i) => [10, 20][i]!,
-      seriesAxes: [0],
-    };
-    const data = new ChartData(source);
-    const originalGetPoint = data.getPoint.bind(data);
-    // mimic old API returning [timestamp, value...]
-    data.getPoint = ((idx: number) => {
-      const { values, timestamp } = originalGetPoint(idx);
-      return [timestamp, ...values] as [number, ...number[]];
-    }) as unknown as typeof data.getPoint;
-    const state = setupRender(svg, data);
-    select<SVGPathElement, unknown>(state.series[0]!.path).attr(
-      "stroke",
-      "green",
-    );
-    const lc = new LegendController(legendDiv);
-    lc.init({
-      getPoint: data.getPoint.bind(data),
-      length: data.length,
-      series: state.series.map((s) => ({
-        path: s.path,
-        transform: state.axes.y[s.axisIdx]!.transform,
-      })),
-    });
-
-    const updateSpy = vi
-      .spyOn(domNode, "updateNode")
-      .mockImplementation(() => {});
-
-    expect(() => {
-      lc.highlightIndex(1);
-    }).not.toThrow();
-    updateSpy.mockRestore();
-    lc.destroy();
-  });
-
   it("ignores results missing values array", () => {
     const { svg, legendDiv } = createSvgAndLegend();
     const source: IDataSource = {

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -83,24 +83,20 @@ export class LegendController implements ILegendController {
   }
 
   private update() {
-    const rawPoint = this.context.getPoint(this.highlightedDataIdx);
-    let values: number[];
-    let timestamp: number;
-
-    if (Array.isArray(rawPoint)) {
-      [timestamp, ...values] = rawPoint;
-    } else if ("values" in rawPoint) {
-      ({ timestamp, values } = rawPoint as {
-        timestamp: number;
-        values: number[];
-      });
-    } else {
+    const { values, timestamp } = this.context.getPoint(
+      this.highlightedDataIdx,
+    ) as { values?: number[]; timestamp?: number };
+    if (!values) {
       return;
     }
 
     const greenData = values[0];
     const blueData = values[1];
-    this.legendTime.text(this.formatTime(timestamp));
+    if (timestamp !== undefined) {
+      this.legendTime.text(this.formatTime(timestamp));
+    } else {
+      this.legendTime.text("");
+    }
 
     const fixNaN = <T>(n: number, valueForNaN: T): number | T =>
       isNaN(n) ? valueForNaN : n;

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -9,6 +9,7 @@ import {
 import { SlidingWindow } from "./slidingWindow.ts";
 import { assertFiniteNumber, assertPositiveInteger } from "./validation.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
+import type { LegendPoint } from "./legend.ts";
 
 export interface IMinMax {
   readonly min: number;
@@ -104,10 +105,7 @@ export class ChartData {
     return this.window.startIndex;
   }
 
-  getPoint(idx: number): {
-    values: number[];
-    timestamp: number;
-  } {
+  getPoint(idx: number): LegendPoint {
     assertFiniteNumber(idx, "ChartData.getPoint idx");
     const clamped = this.clampIndex(Math.round(idx));
     return {

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -5,9 +5,10 @@ export interface LegendSeriesInfo {
   transform: ViewportTransform;
 }
 
-export type LegendPoint =
-  | { values: number[]; timestamp: number }
-  | [number, ...number[]];
+export interface LegendPoint {
+  values: number[];
+  timestamp?: number;
+}
 
 export interface LegendContext {
   getPoint(idx: number): LegendPoint;


### PR DESCRIPTION
## Summary
- replace `LegendPoint` union with object containing values and optional timestamp
- return unified `LegendPoint` object from `ChartData.getPoint`
- simplify `LegendController` and tests to use unified point structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c71908558832ba117737ef7e5d1af