### PR TITLE
chore: restrict general node override to scripts and configs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -81,7 +81,7 @@ export default config(
     },
   },
     {
-      files: ["scripts/**", "**/*.config.*", "**/*.cjs", "**/*.mjs"],
+      files: ["scripts/**", "**/*.config.*"],
       ...nRecommended,
       ...configs.disableTypeChecked,
       settings: {


### PR DESCRIPTION
## Summary
- narrow ESLint node override to only scripts and *.config.* files
- keep dedicated overrides for CommonJS, ESM, and Vite configs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7c1a3e54832bb12c7a0e1e8318ef