### PR TITLE
chore(eslint): simplify node override

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,12 +10,9 @@ import n from "eslint-plugin-n";
 const disableTypeChecked = configs.disableTypeChecked;
 const nRecommended = n.configs["flat/recommended"];
 const nodeOverride = {
-  languageOptions: {
-    ...disableTypeChecked.languageOptions,
-    globals: globals.node,
-  },
+  ...disableTypeChecked,
+  languageOptions: { globals: globals.node },
   rules: {
-    ...disableTypeChecked.rules,
     "import/no-unresolved": "off",
     "import/order": "off",
     "import/default": "off",


### PR DESCRIPTION
## Summary
- spread `disableTypeChecked` directly in `nodeOverride`
- remove redundant nested spreads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7c237720832b8f43de3d892df0a4