### PR TITLE
refactor: centralize SlidingWindow value validation

### DIFF
--- a/svg-time-series/src/chart/slidingWindow.test.ts
+++ b/svg-time-series/src/chart/slidingWindow.test.ts
@@ -27,4 +27,18 @@ describe("SlidingWindow", () => {
         ]),
     ).not.toThrow();
   });
+
+  it("throws when appended values have different length", () => {
+    const sw = new SlidingWindow([[0, 1]]);
+    expect(() => {
+      sw.append(1);
+    }).toThrow(/requires 2 values, received 1/);
+  });
+
+  it("throws when appended values contain infinite numbers", () => {
+    const sw = new SlidingWindow([[0]]);
+    expect(() => {
+      sw.append(Infinity);
+    }).toThrow(/series 0.*finite number or NaN/);
+  });
 });

--- a/svg-time-series/src/chart/slidingWindow.ts
+++ b/svg-time-series/src/chart/slidingWindow.ts
@@ -7,46 +7,15 @@ export class SlidingWindow {
     if (initialData.length === 0) {
       throw new Error("SlidingWindow requires a non-empty data array");
     }
-    const seriesCount = initialData[0]!.length;
+    this.seriesCount = initialData[0]!.length;
     initialData.forEach((row, rowIdx) => {
-      if (row.length !== seriesCount) {
-        throw new Error(
-          `SlidingWindow requires row ${String(rowIdx)} to have ${String(
-            seriesCount,
-          )} values, received ${String(row.length)}`,
-        );
-      }
-      row.forEach((val, valueIdx) => {
-        if (!Number.isFinite(val) && !Number.isNaN(val)) {
-          throw new Error(
-            `SlidingWindow requires row ${String(rowIdx)} series ${String(
-              valueIdx,
-            )} value to be a finite number or NaN`,
-          );
-        }
-      });
+      this.validateValues(row, rowIdx);
     });
     this.data = initialData;
-    this.seriesCount = seriesCount;
   }
 
   append(...values: number[]): void {
-    if (values.length !== this.seriesCount) {
-      throw new Error(
-        `SlidingWindow.append requires ${String(
-          this.seriesCount,
-        )} values, received ${String(values.length)}`,
-      );
-    }
-    values.forEach((val, valueIdx) => {
-      if (!Number.isFinite(val) && !Number.isNaN(val)) {
-        throw new Error(
-          `SlidingWindow.append requires series ${String(
-            valueIdx,
-          )} value to be a finite number or NaN`,
-        );
-      }
-    });
+    this.validateValues(values);
     this.data.push(values);
     this.data.shift();
     this.startIndex++;
@@ -54,5 +23,38 @@ export class SlidingWindow {
 
   get length(): number {
     return this.data.length;
+  }
+
+  private validateValues(row: number[], rowIdx?: number): void {
+    if (row.length !== this.seriesCount) {
+      if (rowIdx === undefined) {
+        throw new Error(
+          `SlidingWindow.append requires ${String(
+            this.seriesCount,
+          )} values, received ${String(row.length)}`,
+        );
+      }
+      throw new Error(
+        `SlidingWindow requires row ${String(rowIdx)} to have ${String(
+          this.seriesCount,
+        )} values, received ${String(row.length)}`,
+      );
+    }
+    row.forEach((val, valueIdx) => {
+      if (!Number.isFinite(val) && !Number.isNaN(val)) {
+        if (rowIdx === undefined) {
+          throw new Error(
+            `SlidingWindow.append requires series ${String(
+              valueIdx,
+            )} value to be a finite number or NaN`,
+          );
+        }
+        throw new Error(
+          `SlidingWindow requires row ${String(rowIdx)} series ${String(
+            valueIdx,
+          )} value to be a finite number or NaN`,
+        );
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- add private `validateValues` helper to SlidingWindow
- reuse helper in constructor and append for consistent errors
- test append validation for length and value finiteness

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c715af04c832bb7ebde62b08cb812