### PR TITLE
chore: consolidate ESLint base objects

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -34,8 +34,6 @@ export default config(
   },
   {
     settings: { "import/resolver": { typescript: {} } },
-  },
-  {
     languageOptions: {
       parserOptions: {
         project: [
@@ -59,9 +57,9 @@ export default config(
   },
   ...configs.recommendedTypeChecked,
   ...configs.strictTypeChecked,
-    importPlugin.flatConfigs.recommended,
-    importPlugin.flatConfigs.typescript,
-    prettierConfig,
+  importPlugin.flatConfigs.recommended,
+  importPlugin.flatConfigs.typescript,
+  prettierConfig,
   {
     rules: {
       "import/no-unresolved": "error",


### PR DESCRIPTION
## Summary
- merge ESLint settings and parser options into a single config object
- keep ignore rules in a dedicated object while removing redundant blocks

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689c7c052eac832baad3d1c6dbf37dcc