### PR TITLE
refactor: use Number.isNaN for series line

### DIFF
--- a/svg-time-series/src/chart/series.ts
+++ b/svg-time-series/src/chart/series.ts
@@ -6,7 +6,7 @@ import { createSeriesNodes } from "./render/utils.ts";
 
 function createLine(seriesIdx: number): Line<number[]> {
   return line<number[]>()
-    .defined((d) => !isNaN(d[seriesIdx]!))
+    .defined((d) => !Number.isNaN(d[seriesIdx]!))
     .x((_, i) => i)
     .y((d) => d[seriesIdx]!);
 }


### PR DESCRIPTION
## Summary
- replace legacy `isNaN` call with `Number.isNaN` when validating series data points

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c9d989504832b94f5da2234a46a74