### PR TITLE
feat: validate axis index before building axis tree

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -471,6 +471,11 @@ describe("ChartData", () => {
     expect(tree.query(0, 2)).toEqual({ min: 1, max: 3 });
   });
 
+  it("throws when building axis tree with invalid axis index", () => {
+    const cd = new ChartData(makeSource([[0], [1]], [0]));
+    expect(() => cd.buildAxisTree(2)).toThrow(/axis.*0 or 1/);
+  });
+
   describe("single-axis", () => {
     it("handles data without second series", () => {
       const source: IDataSource = {

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -143,7 +143,12 @@ export class ChartData {
   }
 
   buildAxisTree(axis: number): SegmentTree<IMinMax> {
-    const idxs = this.seriesByAxis[axis] ?? [];
+    if (axis !== 0 && axis !== 1) {
+      throw new Error(
+        `ChartData.buildAxisTree axis must be 0 or 1; received ${String(axis)}`,
+      );
+    }
+    const idxs = this.seriesByAxis[axis];
     const arr = this.data.map((row) =>
       idxs
         .map((j) => {


### PR DESCRIPTION
## Summary
- prevent invalid axis index when building axis tree
- cover invalid axis with new unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9d84d68c832baad24e787dd8cd2f