### PR TITLE
refactor: remove dynamic DOM globals

### DIFF
--- a/svg-time-series/src/setupDom.native.test.ts
+++ b/svg-time-series/src/setupDom.native.test.ts
@@ -3,9 +3,13 @@ import { describe, it, expect, vi } from "vitest";
 // Ensure native DOMMatrix/DOMPoint are preserved
 describe("setupDom", () => {
   it("does not override existing DOMMatrix and DOMPoint", async () => {
-    const globalObj = globalThis as Record<string, unknown>;
-    const originalMatrix = globalObj["DOMMatrix"];
-    const originalPoint = globalObj["DOMPoint"];
+    interface DOMGlobals {
+      DOMMatrix?: unknown;
+      DOMPoint?: unknown;
+    }
+    const globalObj = globalThis as DOMGlobals;
+    const originalMatrix = globalObj.DOMMatrix;
+    const originalPoint = globalObj.DOMPoint;
 
     class NativeMatrix {
       // dummy property to satisfy lint
@@ -14,24 +18,24 @@ describe("setupDom", () => {
     class NativePoint {
       p = 0;
     }
-    globalObj["DOMMatrix"] = NativeMatrix;
-    globalObj["DOMPoint"] = NativePoint;
+    globalObj.DOMMatrix = NativeMatrix;
+    globalObj.DOMPoint = NativePoint;
 
     vi.resetModules();
     await import("./setupDom.ts");
 
-    expect(globalObj["DOMMatrix"]).toBe(NativeMatrix);
-    expect(globalObj["DOMPoint"]).toBe(NativePoint);
+    expect(globalObj.DOMMatrix).toBe(NativeMatrix);
+    expect(globalObj.DOMPoint).toBe(NativePoint);
 
     if (originalMatrix === undefined) {
-      delete globalObj["DOMMatrix"];
+      delete globalObj.DOMMatrix;
     } else {
-      globalObj["DOMMatrix"] = originalMatrix;
+      globalObj.DOMMatrix = originalMatrix;
     }
     if (originalPoint === undefined) {
-      delete globalObj["DOMPoint"];
+      delete globalObj.DOMPoint;
     } else {
-      globalObj["DOMPoint"] = originalPoint;
+      globalObj.DOMPoint = originalPoint;
     }
   });
 });

--- a/svg-time-series/src/setupDom.ts
+++ b/svg-time-series/src/setupDom.ts
@@ -1,5 +1,4 @@
 class Matrix {
-  [key: string]: unknown;
   constructor(
     public a = 1,
     public b = 0,
@@ -102,7 +101,6 @@ class Matrix {
 }
 
 class Point {
-  [key: string]: unknown;
   constructor(
     public x = 0,
     public y = 0,
@@ -120,12 +118,17 @@ class Point {
   }
 }
 
-const globalObj = globalThis as unknown as Record<string, unknown>;
-if (typeof globalObj["DOMMatrix"] === "undefined") {
-  globalObj["DOMMatrix"] = Matrix;
+interface DOMGlobals {
+  DOMMatrix?: typeof Matrix;
+  DOMPoint?: typeof Point;
 }
-if (typeof globalObj["DOMPoint"] === "undefined") {
-  globalObj["DOMPoint"] = Point;
+
+const globalObj = globalThis as unknown as DOMGlobals;
+if (typeof globalObj.DOMMatrix === "undefined") {
+  globalObj.DOMMatrix = Matrix;
+}
+if (typeof globalObj.DOMPoint === "undefined") {
+  globalObj.DOMPoint = Point;
 }
 if (typeof SVGSVGElement !== "undefined") {
   (

--- a/test/setupDom.ts
+++ b/test/setupDom.ts
@@ -1,5 +1,4 @@
 class Matrix {
-  [key: string]: unknown;
   constructor(
     public a = 1,
     public b = 0,
@@ -84,7 +83,6 @@ class Matrix {
 }
 
 class Point {
-  [key: string]: unknown;
   constructor(
     public x = 0,
     public y = 0,
@@ -102,12 +100,17 @@ class Point {
   }
 }
 
-const globalObj = globalThis as unknown as Record<string, unknown>;
-if (typeof globalObj["DOMMatrix"] === "undefined") {
-  globalObj["DOMMatrix"] = Matrix;
+interface DOMGlobals {
+  DOMMatrix?: typeof Matrix;
+  DOMPoint?: typeof Point;
 }
-if (typeof globalObj["DOMPoint"] === "undefined") {
-  globalObj["DOMPoint"] = Point;
+
+const globalObj = globalThis as unknown as DOMGlobals;
+if (typeof globalObj.DOMMatrix === "undefined") {
+  globalObj.DOMMatrix = Matrix;
+}
+if (typeof globalObj.DOMPoint === "undefined") {
+  globalObj.DOMPoint = Point;
 }
 if (typeof SVGSVGElement !== "undefined") {
   (


### PR DESCRIPTION
## Summary
- drop string index signatures from DOM polyfills
- introduce explicit DOMGlobals interface for DOMMatrix/DOMPoint
- update tests to use explicit global members

## Testing
- `npm run format`
- `git commit -am "refactor: remove dynamic DOM globals"`


------
https://chatgpt.com/codex/tasks/task_e_689c9d71f280832bab3cdc83634170da