### PR TITLE
refactor: remove drawNewData method

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -78,7 +78,7 @@ export class TimeSeriesChart {
       zoomOptions,
     );
 
-    this.drawNewData();
+    this.refreshAll();
     this.onHover(this.state.dimensions.width - 1);
   }
 
@@ -93,7 +93,7 @@ export class TimeSeriesChart {
 
   public updateChartWithNewData(...values: number[]): void {
     this.data.append(...values);
-    this.drawNewData();
+    this.refreshAll();
   }
 
   public dispose() {
@@ -129,10 +129,6 @@ export class TimeSeriesChart {
     idx = this.data.clampIndex(idx);
     this.legendController.highlightIndex(idx);
   };
-
-  private drawNewData(): void {
-    this.refreshAll();
-  }
 
   private refreshAll(): void {
     this.state.seriesRenderer.draw(this.data.data);


### PR DESCRIPTION
## Summary
- remove obsolete drawNewData helper in TimeSeriesChart
- refresh chart directly via refreshAll when new data is appended

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c9d5db4e4832ba8ce22892e1b04ad