### PR TITLE
refactor: delegate axis transform to ChartData

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -5,7 +5,7 @@ import { SegmentTree } from "segment-tree-rmq";
 
 import type { MyAxis } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
-import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
+import type { AR1Basis } from "../math/affine.ts";
 import type { ChartData, IMinMax } from "./data.ts";
 import { updateScaleX } from "./render/utils.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
@@ -30,17 +30,10 @@ export class AxisModel {
     axisIdx: number,
     bIndex: AR1Basis,
   ): void {
-    this.tree = data.buildAxisTree(axisIdx);
-    const dp = data.updateScaleY(bIndex, this.tree);
-    let [min, max] = dp.y().toArr();
-    if (!Number.isFinite(min) || !Number.isFinite(max)) {
-      min = 0;
-      max = 1;
-    }
+    const { tree, min, max, dpRef } = data.axisTransform(axisIdx, bIndex);
+    this.tree = tree;
     this.min = min;
     this.max = max;
-    const b = new AR1Basis(min, max);
-    const dpRef = DirectProductBasis.fromProjections(data.bIndexFull, b);
     this.transform.onReferenceViewWindowResize(dpRef);
     this.scale.domain([min, max]);
   }

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -180,6 +180,27 @@ export class ChartData {
     return DirectProductBasis.fromProjections(bIndexVisible, bAxisVisible);
   }
 
+  axisTransform(
+    axisIdx: number,
+    bIndexVisible: AR1Basis,
+  ): {
+    tree: SegmentTree<IMinMax>;
+    min: number;
+    max: number;
+    dpRef: DirectProductBasis;
+  } {
+    const tree = this.buildAxisTree(axisIdx);
+    const dp = this.updateScaleY(bIndexVisible, tree);
+    let [min, max] = dp.y().toArr();
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+      min = 0;
+      max = 1;
+    }
+    const b = new AR1Basis(min, max);
+    const dpRef = DirectProductBasis.fromProjections(this.bIndexFull, b);
+    return { tree, min, max, dpRef };
+  }
+
   combinedAxisDp(
     bIndexVisible: AR1Basis,
     tree0: SegmentTree<IMinMax>,

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -81,6 +81,17 @@ describe("updateScales", () => {
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
       },
+      axisTransform(axis: number, b: AR1Basis) {
+        const tree = this.buildAxisTree(axis);
+        const dp = this.updateScaleY(b, tree);
+        const [min, max] = dp.y().toArr();
+        const bAxis = new AR1Basis(min, max);
+        const dpRef = DirectProductBasis.fromProjections(
+          this.bIndexFull,
+          bAxis,
+        );
+        return { tree, min, max, dpRef };
+      },
     };
 
     const bIndexVisible = new AR1Basis(0, 1);
@@ -136,6 +147,17 @@ describe("updateScales", () => {
         const { min, max } = tree.query(0, 1);
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
+      },
+      axisTransform(axis: number, b: AR1Basis) {
+        const tree = this.buildAxisTree(axis);
+        const dp = this.updateScaleY(b, tree);
+        const [min, max] = dp.y().toArr();
+        const bAxis = new AR1Basis(min, max);
+        const dpRef = DirectProductBasis.fromProjections(
+          this.bIndexFull,
+          bAxis,
+        );
+        return { tree, min, max, dpRef };
       },
     };
 


### PR DESCRIPTION
## Summary
- reduce feature envy by moving axis transform logic into ChartData
- update AxisModel to consume precomputed transform details
- adjust tests for new axisTransform helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cecda0610832b8d2266af443a7195