### PR TITLE
Validate series axis bounds in chart data

### DIFF
--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { scaleTime } from "d3-scale";
 import { AR1Basis } from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
@@ -23,11 +23,13 @@ describe("AxisManager", () => {
     axes.forEach((a) => a.scale.range([0, 1]));
 
     const data = makeChartData();
+    const spy = vi.spyOn(data, "assertAxisBounds");
     const bIndexVisible = new AR1Basis(0, 1);
 
     expect(() => {
       axisManager.updateScales(bIndexVisible, data);
     }).toThrowError("Series axis index 1 out of bounds (max 0)");
+    expect(spy).toHaveBeenCalledWith(1);
   });
 
   it("does not throw when series axis indices are within bounds", () => {
@@ -37,10 +39,12 @@ describe("AxisManager", () => {
     axes.forEach((a) => a.scale.range([0, 1]));
 
     const data = makeChartData();
+    const spy = vi.spyOn(data, "assertAxisBounds");
     const bIndexVisible = new AR1Basis(0, 1);
 
     expect(() => {
       axisManager.updateScales(bIndexVisible, data);
     }).not.toThrow();
+    expect(spy).toHaveBeenCalledWith(2);
   });
 });

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -58,17 +58,11 @@ export class AxisManager {
   }
 
   updateScales(bIndex: AR1Basis, data: ChartData): void {
+    data.assertAxisBounds(this.axes.length);
     updateScaleX(this.x, bIndex, data);
     for (const [i, idxs] of data.seriesByAxis.entries()) {
       if (idxs.length === 0) {
         continue;
-      }
-      if (i >= this.axes.length) {
-        throw new Error(
-          `Series axis index ${String(i)} out of bounds (max ${String(
-            this.axes.length - 1,
-          )})`,
-        );
       }
       this.axes[i]!.updateAxisTransform(data, i, bIndex);
     }

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -121,6 +121,21 @@ describe("ChartData", () => {
     expect(() => new ChartData(source)).toThrow(/0 or 1/);
   });
 
+  it("throws when series axis index exceeds axisCount", () => {
+    const cd = new ChartData(
+      makeSource(
+        [
+          [0, 0],
+          [1, 1],
+        ],
+        [0, 1],
+      ),
+    );
+    expect(() => {
+      cd.assertAxisBounds(1);
+    }).toThrowError("Series axis index 1 out of bounds (max 0)");
+  });
+
   it("updates data and time mapping on append", () => {
     const source = makeSource(
       [

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -142,6 +142,16 @@ export class ChartData {
     return Math.min(Math.max(idx, 0), this.window.length - 1);
   }
 
+  public assertAxisBounds(axisCount: number): void {
+    this.seriesByAxis.forEach((series, i) => {
+      if (i >= axisCount && series.length > 0) {
+        throw new Error(
+          `Series axis index ${String(i)} out of bounds (max ${String(axisCount - 1)})`,
+        );
+      }
+    });
+  }
+
   buildAxisTree(axis: number): SegmentTree<IMinMax> {
     if (axis !== 0 && axis !== 1) {
       throw new Error(

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -48,6 +48,17 @@ describe("updateScales", () => {
         [3, 30, 5, 25],
       ],
       bIndexFull: new AR1Basis(0, 1),
+      assertAxisBounds(axisCount: number) {
+        this.seriesByAxis.forEach((series: number[], i: number) => {
+          if (i >= axisCount && series.length > 0) {
+            throw new Error(
+              `Series axis index ${String(i)} out of bounds (max ${String(
+                axisCount - 1,
+              )})`,
+            );
+          }
+        });
+      },
       buildAxisTree(axis: number) {
         const idxs = this.seriesByAxis[axis] ?? [];
         return {
@@ -115,6 +126,17 @@ describe("updateScales", () => {
         [1, 20, 5],
       ],
       bIndexFull: new AR1Basis(0, 1),
+      assertAxisBounds(axisCount: number) {
+        this.seriesByAxis.forEach((series: number[], i: number) => {
+          if (i >= axisCount && series.length > 0) {
+            throw new Error(
+              `Series axis index ${String(i)} out of bounds (max ${String(
+                axisCount - 1,
+              )})`,
+            );
+          }
+        });
+      },
       buildAxisTree(axis: number) {
         const idxs = this.seriesByAxis[axis] ?? [];
         return {


### PR DESCRIPTION
## Summary
- add `assertAxisBounds` to `ChartData` for validating series axis indices
- call `assertAxisBounds` from `AxisManager.updateScales`
- update and extend tests for new axis bounds validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf1980b4c832b9a62cc710ec4a361