### PR TITLE
refactor: initialize AxisManager with ChartData

### DIFF
--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -17,33 +17,29 @@ const makeChartData = (): ChartData =>
 
 describe("AxisManager", () => {
   it("throws when series axes exceed created axes", () => {
-    const axisManager = new AxisManager();
-    axisManager.setXAxis(scaleTime().range([0, 1]));
-    const axes = axisManager.create(1);
-    axes.forEach((a) => a.scale.range([0, 1]));
-
     const data = makeChartData();
+    const axisManager = new AxisManager(1, data);
+    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
     const spy = vi.spyOn(data, "assertAxisBounds");
     const bIndexVisible = new AR1Basis(0, 1);
 
     expect(() => {
-      axisManager.updateScales(bIndexVisible, data);
+      axisManager.updateScales(bIndexVisible);
     }).toThrowError("Series axis index 1 out of bounds (max 0)");
     expect(spy).toHaveBeenCalledWith(1);
   });
 
   it("does not throw when series axis indices are within bounds", () => {
-    const axisManager = new AxisManager();
-    axisManager.setXAxis(scaleTime().range([0, 1]));
-    const axes = axisManager.create(2);
-    axes.forEach((a) => a.scale.range([0, 1]));
-
     const data = makeChartData();
+    const axisManager = new AxisManager(2, data);
+    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
     const spy = vi.spyOn(data, "assertAxisBounds");
     const bIndexVisible = new AR1Basis(0, 1);
 
     expect(() => {
-      axisManager.updateScales(bIndexVisible, data);
+      axisManager.updateScales(bIndexVisible);
     }).not.toThrow();
     expect(spy).toHaveBeenCalledWith(2);
   });

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -47,24 +47,29 @@ export interface AxisRenderState {
 export class AxisManager {
   public axes: AxisModel[] = [];
   public x!: ScaleTime<number, number>;
+  private data: ChartData;
 
-  create(treeCount: number): AxisModel[] {
+  constructor(treeCount: number, data: ChartData) {
+    this.data = data;
     this.axes = Array.from({ length: treeCount }, () => new AxisModel());
-    return this.axes;
+  }
+
+  setData(data: ChartData): void {
+    this.data = data;
   }
 
   setXAxis(scale: ScaleTime<number, number>): void {
     this.x = scale;
   }
 
-  updateScales(bIndex: AR1Basis, data: ChartData): void {
-    data.assertAxisBounds(this.axes.length);
-    updateScaleX(this.x, bIndex, data);
-    for (const [i, idxs] of data.seriesByAxis.entries()) {
+  updateScales(bIndex: AR1Basis): void {
+    this.data.assertAxisBounds(this.axes.length);
+    updateScaleX(this.x, bIndex, this.data);
+    for (const [i, idxs] of this.data.seriesByAxis.entries()) {
       if (idxs.length === 0) {
         continue;
       }
-      this.axes[i]!.updateAxisTransform(data, i, bIndex);
+      this.axes[i]!.updateAxisTransform(this.data, i, bIndex);
     }
   }
 }

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -80,7 +80,8 @@ export function refreshRenderState(state: RenderState, data: ChartData): void {
     state.screenXBasis,
   );
 
-  state.axisManager.updateScales(bIndexVisible, data);
+  state.axisManager.setData(data);
+  state.axisManager.updateScales(bIndexVisible);
 
   for (const s of state.series) {
     const t = state.axes.y[s.axisIdx]!.transform;
@@ -157,13 +158,13 @@ export function setupRender(
   ];
   const xScale: ScaleTime<number, number> = scaleTime().range(xRange);
 
-  const axisManager = new AxisManager();
+  const axisManager = new AxisManager(axisCount, data);
   axisManager.setXAxis(xScale);
-  const yAxes = axisManager.create(axisCount);
+  const yAxes = axisManager.axes;
   for (const a of yAxes) {
     a.scale.range(yRange);
   }
-  axisManager.updateScales(data.bIndexFull, data);
+  axisManager.updateScales(data.bIndexFull);
 
   const referenceBasis = DirectProductBasis.fromProjections(
     data.bIndexFull,

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -11,11 +11,6 @@ import "../setupDom.ts";
 
 describe("updateScales", () => {
   it("updates domains for two axes using ChartData", () => {
-    const axisManager = new AxisManager();
-    axisManager.setXAxis(scaleTime().range([0, 1]));
-    const axes = axisManager.create(2);
-    axes.forEach((a) => a.scale.range([0, 1]));
-
     const source = {
       startTime: 0,
       timeStep: 1,
@@ -26,20 +21,18 @@ describe("updateScales", () => {
         seriesIdx === 0 ? [1, 3][i]! : [10, 30][i]!,
     };
     const data = new ChartData(source);
+    const axisManager = new AxisManager(2, data);
+    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
 
     const bIndexVisible = new AR1Basis(0, 1);
-    axisManager.updateScales(bIndexVisible, data);
+    axisManager.updateScales(bIndexVisible);
 
-    expect(axes[0]!.scale.domain()).toEqual([1, 3]);
-    expect(axes[1]!.scale.domain()).toEqual([10, 30]);
+    expect(axisManager.axes[0]!.scale.domain()).toEqual([1, 3]);
+    expect(axisManager.axes[1]!.scale.domain()).toEqual([10, 30]);
   });
 
   it("updates domains for multiple axes", () => {
-    const axisManager = new AxisManager();
-    axisManager.setXAxis(scaleTime().range([0, 1]));
-    const axes = axisManager.create(3);
-    axes.forEach((a) => a.scale.range([0, 1]));
-
     const data = {
       seriesAxes: [0, 1, 2, 1],
       seriesByAxis: [[0], [1, 3], [2]],
@@ -104,20 +97,19 @@ describe("updateScales", () => {
         return { tree, min, max, dpRef };
       },
     };
+    const axisManager = new AxisManager(3, data as unknown as ChartData);
+    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
 
     const bIndexVisible = new AR1Basis(0, 1);
-    axisManager.updateScales(bIndexVisible, data as unknown as ChartData);
+    axisManager.updateScales(bIndexVisible);
 
-    expect(axes[0]!.scale.domain()).toEqual([1, 3]);
-    expect(axes[1]!.scale.domain()).toEqual([10, 30]);
-    expect(axes[2]!.scale.domain()).toEqual([-5, 5]);
+    expect(axisManager.axes[0]!.scale.domain()).toEqual([1, 3]);
+    expect(axisManager.axes[1]!.scale.domain()).toEqual([10, 30]);
+    expect(axisManager.axes[2]!.scale.domain()).toEqual([-5, 5]);
   });
 
   it("throws when a series references an out-of-range axis index", () => {
-    const axisManager = new AxisManager();
-    axisManager.setXAxis(scaleTime().range([0, 1]));
-    axisManager.create(2).forEach((a) => a.scale.range([0, 1]));
-
     const data = {
       seriesAxes: [0, 1, 2],
       seriesByAxis: [[0], [1], [2]],
@@ -182,10 +174,13 @@ describe("updateScales", () => {
         return { tree, min, max, dpRef };
       },
     };
+    const axisManager = new AxisManager(2, data as unknown as ChartData);
+    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
 
     const bIndexVisible = new AR1Basis(0, 1);
     expect(() => {
-      axisManager.updateScales(bIndexVisible, data as unknown as ChartData);
+      axisManager.updateScales(bIndexVisible);
     }).toThrow(/axis index 2/i);
   });
 });


### PR DESCRIPTION
## Summary
- construct AxisManager with axis count and ChartData instead of using create()
- update refresh flow to set new data and drop redundant ChartData param from updateScales
- adjust tests for new AxisManager API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cfd5d4300832baa4794a0932ebd4f