### PR TITLE
refactor: consolidate scale extent validation

### DIFF
--- a/svg-time-series/src/chart/validation.ts
+++ b/svg-time-series/src/chart/validation.ts
@@ -9,3 +9,22 @@ export function assertFiniteNumber(value: number, name: string): void {
     throw new Error(`${name} must be a finite number`);
   }
 }
+
+export function assertTupleSize(
+  value: unknown,
+  size: number,
+  name: string,
+): asserts value is unknown[] {
+  if (!Array.isArray(value) || value.length !== size) {
+    throw new Error(`${name} must be a tuple of size ${String(size)}`);
+  }
+}
+
+export function assertPositiveFinite(
+  value: unknown,
+  name: string,
+): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a finite, positive number`);
+  }
+}

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -797,7 +797,7 @@ describe("ZoomState", () => {
 
     expect(() => {
       zs.setScaleExtent([min, max]);
-    }).toThrow(/scaleExtent must be two finite, positive numbers/);
+    }).toThrow(new RegExp(`Received: \\[${String(min)},${String(max)}\\]`));
   });
 
   it("rejects scale extents that do not contain exactly two values", () => {
@@ -820,10 +820,10 @@ describe("ZoomState", () => {
 
     expect(() => {
       zs.setScaleExtent([1] as unknown as [number, number]);
-    }).toThrow(/scaleExtent must be two finite, positive numbers/);
+    }).toThrow(/Received: \[1\]/);
     expect(() => {
       zs.setScaleExtent([1, 2, 3] as unknown as [number, number]);
-    }).toThrow(/scaleExtent must be two finite, positive numbers/);
+    }).toThrow(/Received: \[1,2,3\]/);
   });
 
   it.each([
@@ -859,7 +859,7 @@ describe("ZoomState", () => {
           undefined,
           { scaleExtent: [min, max] },
         ),
-    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+    ).toThrow(new RegExp(`Received: \\[${String(min)},${String(max)}\\]`));
   });
 
   it("rejects constructor scale extents without exactly two values", () => {
@@ -884,7 +884,7 @@ describe("ZoomState", () => {
           undefined,
           { scaleExtent: [1] as unknown as [number, number] },
         ),
-    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+    ).toThrow(/Received: \[1\]/);
     expect(
       () =>
         new ZoomState(
@@ -899,6 +899,6 @@ describe("ZoomState", () => {
           undefined,
           { scaleExtent: [1, 2, 3] as unknown as [number, number] },
         ),
-    ).toThrow(/scaleExtent must be two finite, positive numbers/);
+    ).toThrow(/Received: \[1,2,3\]/);
   });
 });

--- a/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
+++ b/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
@@ -11,10 +11,10 @@ describe("ZoomState.validateScaleExtent", () => {
   it("rejects arrays without exactly two elements", () => {
     expect(() => {
       ZoomState.validateScaleExtent([1] as unknown);
-    }).toThrow(/Received: 1/);
+    }).toThrow(/Received: \[1\]/);
     expect(() => {
       ZoomState.validateScaleExtent([1, 2, 3] as unknown);
-    }).toThrow(/Received: 1,2,3/);
+    }).toThrow(/Received: \[1,2,3\]/);
   });
 
   it("rejects non-positive numbers", () => {
@@ -30,5 +30,9 @@ describe("ZoomState.validateScaleExtent", () => {
     expect(() => {
       ZoomState.validateScaleExtent([a, b]);
     }).toThrow(new RegExp(`Received: \\[${String(a)},${String(b)}\\]`));
+  });
+
+  it("returns extent when valid", () => {
+    expect(ZoomState.validateScaleExtent([1, 2])).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary
- add reusable tuple and positive-number assertions
- streamline ZoomState.scaleExtent validation and usage
- update tests for new validation helpers and messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d8619eee8832bb03a9b6749d8ed75