### PR TITLE
feat: unify DOMMatrix to SVGMatrix conversion

### DIFF
--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { Matrix } from "../setupDom.ts";
-import { updateNode, isSVGMatrix } from "./domNodeTransform.ts";
+import {
+  updateNode,
+  isSVGMatrix,
+  domMatrixToSVGMatrix,
+} from "./domNodeTransform.ts";
 
 class FakeSVGMatrix {
   constructor(
@@ -67,6 +71,30 @@ describe("updateNode", () => {
     expect(last).toBeInstanceOf(FakeSVGMatrix);
     expect(last.e).toBeCloseTo(5);
     expect(last.f).toBeCloseTo(6);
+  });
+});
+
+describe("domMatrixToSVGMatrix", () => {
+  it("returns same matrix for SVGMatrix", () => {
+    const svg = new FakeSVGSVGElement();
+    const matrix = svg.createSVGMatrix();
+    const result = domMatrixToSVGMatrix(
+      svg as unknown as SVGSVGElement,
+      matrix as unknown as DOMMatrix,
+    );
+    expect(result).toBe(matrix);
+  });
+
+  it("converts DOMMatrix to SVGMatrix", () => {
+    const svg = new FakeSVGSVGElement();
+    const domMatrix = new Matrix().translate(5, 6);
+    const result = domMatrixToSVGMatrix(
+      svg as unknown as SVGSVGElement,
+      domMatrix as unknown as DOMMatrix,
+    );
+    expect(result).toBeInstanceOf(FakeSVGMatrix);
+    expect(result.e).toBeCloseTo(5);
+    expect(result.f).toBeCloseTo(6);
   });
 });
 

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -5,6 +5,24 @@ export function isSVGMatrix(
   return matrix.constructor === svg.createSVGMatrix().constructor;
 }
 
+export function domMatrixToSVGMatrix(
+  svg: SVGSVGElement,
+  m: DOMMatrix,
+): SVGMatrix {
+  if (isSVGMatrix(m, svg)) {
+    return m;
+  }
+  const sm = svg.createSVGMatrix();
+  const dm = m as DOMMatrix;
+  sm.a = dm.a;
+  sm.b = dm.b;
+  sm.c = dm.c;
+  sm.d = dm.d;
+  sm.e = dm.e;
+  sm.f = dm.f;
+  return sm;
+}
+
 export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
   const svgTransformList = n.transform.baseVal;
   const svg = (
@@ -13,20 +31,7 @@ export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
       : n.ownerSVGElement
   )!;
 
-  let matrix: SVGMatrix;
-  if (isSVGMatrix(m, svg)) {
-    matrix = m;
-  } else {
-    const sm = svg.createSVGMatrix();
-    const dm = m as DOMMatrix;
-    sm.a = dm.a;
-    sm.b = dm.b;
-    sm.c = dm.c;
-    sm.d = dm.d;
-    sm.e = dm.e;
-    sm.f = dm.f;
-    matrix = sm;
-  }
+  const matrix = domMatrixToSVGMatrix(svg, m);
   const t = svgTransformList.createSVGTransformFromMatrix(matrix);
   svgTransformList.initialize(t);
 }


### PR DESCRIPTION
## Summary
- add `domMatrixToSVGMatrix` helper for converting DOMMatrix instances to SVGMatrix
- reuse helper within `updateNode` so DOMMatrix and SVGMatrix share the same code path
- add tests for the new helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d85c38898832bb4a204e16032ac88