### PR TITLE
refactor: use d3 scales for index-time mapping

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -226,12 +226,12 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const transform = cd.indexToTime();
+    const scale = cd.indexToTime();
     for (let i = 0; i < cd.length; i++) {
-      const t = transform.applyToPoint(i);
+      const t = scale(i);
       const idx = cd.timeToIndex(t);
       expect(idx).toBeCloseTo(i);
-      const t2 = transform.applyToPoint(idx);
+      const t2 = scale(idx);
       expect(t2).toBeCloseTo(t);
     }
   });
@@ -247,9 +247,9 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const transform = cd.indexToTime();
-    const earliest = transform.applyToPoint(0);
-    const latest = transform.applyToPoint(cd.length - 1);
+    const scale = cd.indexToTime();
+    const earliest = scale(0);
+    const latest = scale(cd.length - 1);
     expect(cd.timeToIndex(earliest - 1000)).toBe(0);
     expect(cd.timeToIndex(latest + 1000)).toBe(cd.length - 1);
     expect(() => cd.timeToIndex(NaN)).toThrow(/time/);

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -1,11 +1,7 @@
 import { SegmentTree } from "segment-tree-rmq";
 
-import type { AR1 } from "../math/affine.ts";
-import {
-  AR1Basis,
-  DirectProductBasis,
-  betweenTBasesAR1,
-} from "../math/affine.ts";
+import { scaleLinear, type ScaleLinear } from "d3-scale";
+import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
 import { SlidingWindow } from "./slidingWindow.ts";
 import { assertFiniteNumber, assertPositiveInteger } from "./validation.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
@@ -115,22 +111,16 @@ export class ChartData {
     };
   }
 
-  indexToTime(): AR1 {
-    const bIndexBase = new AR1Basis(
-      this.window.startIndex,
-      this.window.startIndex + 1,
-    );
-    const bTimeBase = new AR1Basis(
-      this.startTime,
-      this.startTime + this.timeStep,
-    );
-    return betweenTBasesAR1(bIndexBase, bTimeBase);
+  indexToTime(): ScaleLinear<number, number> {
+    return scaleLinear<number, number>()
+      .domain([this.window.startIndex, this.window.startIndex + 1])
+      .range([this.startTime, this.startTime + this.timeStep]);
   }
 
   timeToIndex(time: number): number {
     assertFiniteNumber(time, "ChartData.timeToIndex time");
-    const transform = this.indexToTime().inverse();
-    const idx = transform.applyToPoint(time);
+    const scale = this.indexToTime();
+    const idx = scale.invert(time);
     return this.clampIndex(idx);
   }
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -35,9 +35,9 @@ export function updateScaleX(
   bIndexVisible: AR1Basis,
   data: ChartData,
 ) {
-  const transform = data.indexToTime();
-  const bTimeVisible = bIndexVisible.transformWith(transform);
-  x.domain(bTimeVisible.toArr());
+  const scale = data.indexToTime().copy();
+  const [i0, i1] = bIndexVisible.toArr();
+  x.domain([scale(i0), scale(i1)]);
 }
 
 export function createSeriesNodes(

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { scaleTime } from "d3-scale";
-import {
-  AR1Basis,
-  DirectProductBasis,
-  betweenTBasesAR1,
-} from "../math/affine.ts";
+import { scaleLinear, scaleTime } from "d3-scale";
+import { AR1Basis, DirectProductBasis } from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
 import { ChartData } from "./data.ts";
 import "../setupDom.ts";
@@ -73,7 +69,7 @@ describe("updateScales", () => {
         };
       },
       indexToTime() {
-        return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
+        return scaleLinear().domain([0, 1]).range([0, 1]);
       },
       updateScaleY(
         b: AR1Basis,
@@ -150,7 +146,7 @@ describe("updateScales", () => {
         };
       },
       indexToTime() {
-        return betweenTBasesAR1(new AR1Basis(0, 1), new AR1Basis(0, 1));
+        return scaleLinear().domain([0, 1]).range([0, 1]);
       },
       updateScaleY(
         b: AR1Basis,


### PR DESCRIPTION
## Summary
- replace `ChartData.indexToTime` with a d3 scale and compute `timeToIndex` via `invert`
- use the scale directly in `updateScaleX` and drop AR1 transforms
- adjust tests for scale-based time conversion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0642c71fc832baf299f3e56577ba8