### PR TITLE
feat: add zoom overlay cursor control

### DIFF
--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -67,3 +67,24 @@ npx vite
 ```
 
 Then open `demo1.html` or `demo2.html` in your browser for interactive charts.
+
+## Styling
+
+The chart inserts a transparent `<rect>` with the class `zoom-overlay`
+above the plotting area to capture zoom and pan interactions. It uses the
+classes `cursor-grab` and `cursor-grabbing` to signal the cursor state while
+dragging. Provide CSS rules to style these classes as needed, for example:
+
+```css
+.zoom-overlay.cursor-grab {
+  cursor: grab;
+  pointer-events: all;
+}
+
+.zoom-overlay.cursor-grabbing {
+  cursor: grabbing;
+}
+```
+
+Setting `pointer-events: none` on `.zoom-overlay` disables zoom handling so
+other interactions (such as brushing) can temporarily take over.

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -378,7 +378,7 @@ describe("chart interaction", () => {
       "destroy",
     );
 
-    const zoomRect = svgEl.querySelector("rect.zoom") as SVGRectElement;
+    const zoomRect = svgEl.querySelector("rect.zoom-overlay") as SVGRectElement;
     expect(zoomRect).not.toBeNull();
 
     zoomRect.dispatchEvent(new MouseEvent("mousemove"));
@@ -388,7 +388,7 @@ describe("chart interaction", () => {
 
     expect(destroySpy).toHaveBeenCalled();
 
-    expect(svgEl.querySelector("rect.zoom")).toBeNull();
+    expect(svgEl.querySelector("rect.zoom-overlay")).toBeNull();
     expect(svgEl.querySelectorAll("circle").length).toBe(0);
 
     mouseMoveHandler.mockClear();

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -183,4 +183,24 @@ describe("TimeSeriesChart", () => {
     expect(mouseMove).not.toHaveBeenCalled();
     expect(legend.destroy).toHaveBeenCalled();
   });
+
+  it("toggles cursor classes on the zoom overlay", () => {
+    const { chart } = createChart();
+    const internal = chart as unknown as {
+      zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>;
+    };
+    const rectNode = internal.zoomArea.node()!;
+
+    expect(rectNode.getAttribute("class")).toContain("zoom-overlay");
+    expect(rectNode.classList.contains("cursor-grab")).toBe(true);
+    expect(rectNode.style.pointerEvents).toBe("all");
+
+    rectNode.dispatchEvent(new Event("pointerdown"));
+    expect(rectNode.classList.contains("cursor-grabbing")).toBe(true);
+    expect(rectNode.classList.contains("cursor-grab")).toBe(false);
+
+    rectNode.dispatchEvent(new Event("pointerup"));
+    expect(rectNode.classList.contains("cursor-grab")).toBe(true);
+    expect(rectNode.classList.contains("cursor-grabbing")).toBe(false);
+  });
 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -45,9 +45,10 @@ export class TimeSeriesChart {
 
     this.zoomArea = svg
       .append("rect")
-      .attr("class", "zoom")
+      .attr("class", "zoom-overlay cursor-grab")
       .attr("width", this.state.dimensions.width)
-      .attr("height", this.state.dimensions.height);
+      .attr("height", this.state.dimensions.height)
+      .style("pointer-events", "all");
 
     this.legendController = legendController;
 
@@ -61,9 +62,21 @@ export class TimeSeriesChart {
     };
     this.legendController.init(context);
 
-    this.zoomArea.on("mousemove", mouseMoveHandler).on("mouseleave", () => {
-      this.legendController.clearHighlight();
-    });
+    this.zoomArea
+      .on("mousemove", mouseMoveHandler)
+      .on("mouseleave", () => {
+        this.legendController.clearHighlight();
+      })
+      .on("pointerdown.zoomCursor", () => {
+        this.zoomArea
+          .classed("cursor-grab", false)
+          .classed("cursor-grabbing", true);
+      })
+      .on("pointerup.zoomCursor pointerleave.zoomCursor", () => {
+        this.zoomArea
+          .classed("cursor-grabbing", false)
+          .classed("cursor-grab", true);
+      });
 
     this.zoomState = new ZoomState(
       this.zoomArea,
@@ -98,7 +111,10 @@ export class TimeSeriesChart {
 
   public dispose() {
     this.zoomState.destroy();
-    this.zoomArea.on("mousemove", null).on("mouseleave", null);
+    this.zoomArea
+      .on("mousemove", null)
+      .on("mouseleave", null)
+      .on(".zoomCursor", null);
     this.state.destroy();
     this.zoomArea.remove();
     this.legendController.destroy();


### PR DESCRIPTION
## Summary
- rename zoom rect to `.zoom-overlay` and toggle `cursor-grab`/`cursor-grabbing`
- allow pointer-events toggling so other interactions can disable the overlay
- document required CSS for the overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0651f3160832b95348cbf5701769a