### PR TITLE
feat: add brush zoom interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2426,6 +2426,16 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -4881,6 +4891,22 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
       },
       "engines": {
         "node": ">=12"
@@ -13685,6 +13711,7 @@
       "version": "0.1.0",
       "license": "WTFPL",
       "dependencies": {
+        "d3-brush": "^3.0.0",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
@@ -13693,6 +13720,7 @@
         "segment-tree-rmq": "^0.1.0"
       },
       "devDependencies": {
+        "@types/d3-brush": "^3.0.6",
         "@types/d3-scale": "^4.0.9",
         "@types/d3-selection": "^3.0.11",
         "@types/d3-shape": "^3.1.7",

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -14,6 +14,7 @@
   "main": "src/draw.ts",
   "type": "module",
   "dependencies": {
+    "d3-brush": "^3.0.0",
     "d3-scale": "^4.0.2",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
@@ -22,6 +23,7 @@
     "segment-tree-rmq": "^0.1.0"
   },
   "devDependencies": {
+    "@types/d3-brush": "^3.0.6",
     "@types/d3-scale": "^4.0.9",
     "@types/d3-selection": "^3.0.11",
     "@types/d3-shape": "^3.1.7",


### PR DESCRIPTION
## Summary
- add d3-brush dependency and hidden brush layer
- allow selecting time window to zoom and update domains
- expose APIs to toggle brush and read selected window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a064fa93ac832bac78905c7066f881