### PR TITLE
feat: use d3 rescaled scales for zoom

### DIFF
--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { scaleTime } from "d3-scale";
-import { AR1Basis } from "../math/affine.ts";
 import { AxisManager } from "./axisManager.ts";
 import { ChartData } from "./data.ts";
 import "../setupDom.ts";
@@ -19,13 +18,12 @@ describe("AxisManager", () => {
   it("throws when series axes exceed created axes", () => {
     const data = makeChartData();
     const axisManager = new AxisManager(1, data);
-    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.setXAxis(scaleTime().range([0, 1]).domain([0, 1]));
     axisManager.axes.forEach((a) => a.scale.range([0, 1]));
     const spy = vi.spyOn(data, "assertAxisBounds");
-    const bIndexVisible = new AR1Basis(0, 1);
 
     expect(() => {
-      axisManager.updateScales(bIndexVisible);
+      axisManager.updateScales();
     }).toThrowError("Series axis index 1 out of bounds (max 0)");
     expect(spy).toHaveBeenCalledWith(1);
   });
@@ -33,13 +31,12 @@ describe("AxisManager", () => {
   it("does not throw when series axis indices are within bounds", () => {
     const data = makeChartData();
     const axisManager = new AxisManager(2, data);
-    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.setXAxis(scaleTime().range([0, 1]).domain([0, 1]));
     axisManager.axes.forEach((a) => a.scale.range([0, 1]));
     const spy = vi.spyOn(data, "assertAxisBounds");
-    const bIndexVisible = new AR1Basis(0, 1);
 
     expect(() => {
-      axisManager.updateScales(bIndexVisible);
+      axisManager.updateScales();
     }).not.toThrow();
     expect(spy).toHaveBeenCalledWith(2);
   });

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -5,9 +5,8 @@ import { SegmentTree } from "segment-tree-rmq";
 
 import type { MyAxis } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
-import type { AR1Basis } from "../math/affine.ts";
+import { AR1Basis } from "../math/affine.ts";
 import type { ChartData, IMinMax } from "./data.ts";
-import { updateScaleX } from "./render/utils.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
 
 export class AxisModel {
@@ -74,9 +73,15 @@ export class AxisManager {
     this.x = scale;
   }
 
-  updateScales(bIndex: AR1Basis): void {
+  updateScales(): void {
     this.data.assertAxisBounds(this.axes.length);
-    updateScaleX(this.x, bIndex, this.data);
+    const [d0, d1] = this.x.domain();
+    const t0 = d0 instanceof Date ? d0.getTime() : Number(d0);
+    const t1 = d1 instanceof Date ? d1.getTime() : Number(d1);
+    const bIndex = new AR1Basis(
+      this.data.timeToIndex(t0),
+      this.data.timeToIndex(t1),
+    );
     for (const [i, idxs] of this.data.seriesByAxis.entries()) {
       if (idxs.length === 0) {
         continue;

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,5 +1,6 @@
 import type { Selection } from "d3-selection";
 import type { ScaleTime } from "d3-scale";
+import type { AR1 } from "../../math/affine.ts";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 import type { ChartData } from "../data.ts";
 
@@ -35,9 +36,15 @@ export function updateScaleX(
   bIndexVisible: AR1Basis,
   data: ChartData,
 ) {
-  const transform = data.indexToTime();
-  const bTimeVisible = bIndexVisible.transformWith(transform);
-  x.domain(bTimeVisible.toArr());
+  const transform: AR1 | ((i: number) => number) = data.indexToTime() as
+    | AR1
+    | ((i: number) => number);
+  const toTime =
+    typeof transform === "function"
+      ? (i: number) => transform(i)
+      : (i: number) => transform.applyToPoint(i);
+  const [i0, i1] = bIndexVisible.toArr();
+  x.domain([toTime(i0), toTime(i1)]);
 }
 
 export function createSeriesNodes(

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -22,11 +22,10 @@ describe("updateScales", () => {
     };
     const data = new ChartData(source);
     const axisManager = new AxisManager(2, data);
-    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.setXAxis(scaleTime().range([0, 1]).domain([0, 1]));
     axisManager.axes.forEach((a) => a.scale.range([0, 1]));
 
-    const bIndexVisible = new AR1Basis(0, 1);
-    axisManager.updateScales(bIndexVisible);
+    axisManager.updateScales();
 
     expect(axisManager.axes[0]!.scale.domain()).toEqual([1, 3]);
     expect(axisManager.axes[1]!.scale.domain()).toEqual([10, 30]);
@@ -96,13 +95,15 @@ describe("updateScales", () => {
         );
         return { tree, min, max, dpRef };
       },
+      timeToIndex(t: number) {
+        return t;
+      },
     };
     const axisManager = new AxisManager(3, data as unknown as ChartData);
-    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.setXAxis(scaleTime().range([0, 1]).domain([0, 1]));
     axisManager.axes.forEach((a) => a.scale.range([0, 1]));
 
-    const bIndexVisible = new AR1Basis(0, 1);
-    axisManager.updateScales(bIndexVisible);
+    axisManager.updateScales();
 
     expect(axisManager.axes[0]!.scale.domain()).toEqual([1, 3]);
     expect(axisManager.axes[1]!.scale.domain()).toEqual([10, 30]);
@@ -173,14 +174,16 @@ describe("updateScales", () => {
         );
         return { tree, min, max, dpRef };
       },
+      timeToIndex(t: number) {
+        return t;
+      },
     };
     const axisManager = new AxisManager(2, data as unknown as ChartData);
-    axisManager.setXAxis(scaleTime().range([0, 1]));
+    axisManager.setXAxis(scaleTime().range([0, 1]).domain([0, 1]));
     axisManager.axes.forEach((a) => a.scale.range([0, 1]));
 
-    const bIndexVisible = new AR1Basis(0, 1);
     expect(() => {
-      axisManager.updateScales(bIndexVisible);
+      axisManager.updateScales();
     }).toThrow(/axis index 2/i);
   });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,7 +1,7 @@
 import type { Selection } from "d3-selection";
 import { zoom as d3zoom, zoomIdentity, zoomTransform } from "d3-zoom";
 import type { D3ZoomEvent, ZoomBehavior, ZoomTransform } from "d3-zoom";
-import type { ScaleLinear } from "d3-scale";
+import type { ScaleLinear, ScaleTime } from "d3-scale";
 import { ZoomScheduler, sameTransform } from "./zoomScheduler.ts";
 import type { RenderState } from "./render.ts";
 import { assertPositiveFinite, assertTupleSize } from "./validation.ts";
@@ -82,9 +82,7 @@ export class ZoomState {
       return;
     }
     const t = event.transform as ZoomTransform & {
-      rescaleX?: (
-        s: ScaleLinear<number, number>,
-      ) => ScaleLinear<number, number>;
+      rescaleX?: (s: ScaleTime<number, number>) => ScaleTime<number, number>;
       rescaleY?: (
         s: ScaleLinear<number, number>,
       ) => ScaleLinear<number, number>;

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -1,7 +1,11 @@
 import type { Selection } from "d3-selection";
 import { zoom as d3zoom, zoomIdentity, zoomTransform } from "d3-zoom";
-import type { D3ZoomEvent, ZoomBehavior, ZoomTransform } from "d3-zoom";
-import type { ScaleLinear, ScaleTime } from "d3-scale";
+import type {
+  D3ZoomEvent,
+  ZoomBehavior,
+  ZoomTransform,
+  ZoomScale,
+} from "d3-zoom";
 import { ZoomScheduler, sameTransform } from "./zoomScheduler.ts";
 import type { RenderState } from "./render.ts";
 import { assertPositiveFinite, assertTupleSize } from "./validation.ts";
@@ -82,21 +86,21 @@ export class ZoomState {
       return;
     }
     const t = event.transform as ZoomTransform & {
-      rescaleX?: (s: ScaleTime<number, number>) => ScaleTime<number, number>;
-      rescaleY?: (
-        s: ScaleLinear<number, number>,
-      ) => ScaleLinear<number, number>;
+      rescaleX?: (x: ZoomScale) => ZoomScale;
+      rescaleY?: (y: ZoomScale) => ZoomScale;
     };
     this.state.xTransform.onZoomPan(t);
     this.state.axes.y.forEach((a) => a.transform.onZoomPan(t));
-    const xRescaled = t.rescaleX?.(this.state.axes.x.scale);
+    const xRescaled = t.rescaleX?.(
+      this.state.axes.x.scale as unknown as ZoomScale,
+    );
     if (xRescaled) {
-      this.state.axes.x.scale.domain(xRescaled.domain());
+      this.state.axes.x.scale.domain(xRescaled.domain() as [number, number]);
     }
     this.state.axes.y.forEach((a) => {
-      const yRescaled = t.rescaleY?.(a.scale);
+      const yRescaled = t.rescaleY?.(a.scale as unknown as ZoomScale);
       if (yRescaled) {
-        a.scale.domain(yRescaled.domain());
+        a.scale.domain(yRescaled.domain() as [number, number]);
       }
     });
     if (!this.zoomScheduler.zoom(t, event.sourceEvent)) {

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -95,7 +95,9 @@ export class ZoomState {
       this.state.axes.x.scale as unknown as ZoomScale,
     );
     if (xRescaled) {
-      this.state.axes.x.scale.domain(xRescaled.domain() as [number, number]);
+      this.state.axes.x.scale.domain(
+        xRescaled.domain() as [Date | number, Date | number],
+      );
     }
     this.state.axes.y.forEach((a) => {
       const yRescaled = t.rescaleY?.(a.scale as unknown as ZoomScale);


### PR DESCRIPTION
## Summary
- derive visible index range from event.transform.rescaleX/rescaleY
- update AxisManager and render pipeline to consume rescaled scales
- recompute series matrices from updated scales

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0641eff40832bb7b9f2a89edc8b55