### PR TITLE
feat: add brush-based zoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2426,6 +2426,16 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -4881,6 +4891,22 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
       },
       "engines": {
         "node": ">=12"
@@ -13685,6 +13711,7 @@
       "version": "0.1.0",
       "license": "WTFPL",
       "dependencies": {
+        "d3-brush": "^3.0.0",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
@@ -13693,6 +13720,7 @@
         "segment-tree-rmq": "^0.1.0"
       },
       "devDependencies": {
+        "@types/d3-brush": "^3.0.6",
         "@types/d3-scale": "^4.0.9",
         "@types/d3-selection": "^3.0.11",
         "@types/d3-shape": "^3.1.7",

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -19,6 +19,7 @@
     "d3-shape": "^3.2.0",
     "d3-timer": "^3.0.1",
     "d3-zoom": "^3.0.0",
+    "d3-brush": "^3.0.0",
     "segment-tree-rmq": "^0.1.0"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@types/d3-shape": "^3.1.7",
     "@types/d3-timer": "^3.0.2",
     "@types/d3-zoom": "^3.0.8",
+    "@types/d3-brush": "^3.0.6",
     "rollup-plugin-node-externals": "^8.0.1",
     "vite": "^7.1.2",
     "vite-plugin-dts": "^4.5.4"

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,5 +1,7 @@
 import type { Selection } from "d3-selection";
 import type { D3ZoomEvent } from "d3-zoom";
+import { zoomIdentity } from "d3-zoom";
+import { brush, type BrushBehavior, type D3BrushEvent } from "d3-brush";
 
 import { ChartData } from "./chart/data.ts";
 import type { IDataSource } from "./chart/data.ts";
@@ -18,6 +20,9 @@ export interface IPublicInteraction {
   onHover: (x: number) => void;
   resetZoom: () => void;
   setScaleExtent: (extent: [number, number]) => void;
+  enableBrush: () => void;
+  disableBrush: () => void;
+  getSelectedTimeWindow: () => [number, number] | null;
 }
 
 export class TimeSeriesChart {
@@ -27,6 +32,9 @@ export class TimeSeriesChart {
   private zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>;
   private zoomState: ZoomState;
   private legendController: ILegendController;
+  private brushLayer: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+  private brushBehavior: BrushBehavior<unknown>;
+  private selectedTimeWindow: [number, number] | null = null;
 
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -49,6 +57,19 @@ export class TimeSeriesChart {
       .attr("width", this.state.dimensions.width)
       .attr("height", this.state.dimensions.height)
       .style("pointer-events", "all");
+
+    this.brushBehavior = brush()
+      .extent([
+        [0, 0],
+        [this.state.dimensions.width, this.state.dimensions.height],
+      ])
+      .on("end", this.onBrushEnd);
+
+    this.brushLayer = svg
+      .append("g")
+      .attr("class", "brush-layer")
+      .style("display", "none")
+      .call(this.brushBehavior);
 
     this.legendController = legendController;
 
@@ -101,6 +122,9 @@ export class TimeSeriesChart {
       onHover: this.onHover,
       resetZoom: this.resetZoom,
       setScaleExtent: this.setScaleExtent,
+      enableBrush: this.enableBrush,
+      disableBrush: this.disableBrush,
+      getSelectedTimeWindow: this.getSelectedTimeWindow,
     };
   }
 
@@ -132,11 +156,30 @@ export class TimeSeriesChart {
     this.zoomState.setScaleExtent(extent);
   };
 
+  public enableBrush = () => {
+    this.brushLayer.style("display", null);
+  };
+
+  public disableBrush = () => {
+    this.brushLayer.style("display", "none");
+    this.clearBrush();
+    this.selectedTimeWindow = null;
+  };
+
+  public getSelectedTimeWindow = (): [number, number] | null => {
+    return this.selectedTimeWindow;
+  };
+
   public resize = (dimensions: { width: number; height: number }) => {
     const { width, height } = dimensions;
     this.svg.attr("width", width).attr("height", height);
     this.state.resize(dimensions, this.zoomState);
     this.state.refresh(this.data);
+    this.brushBehavior.extent([
+      [0, 0],
+      [width, height],
+    ]);
+    this.brushLayer.call(this.brushBehavior);
     this.refreshAll();
   };
 
@@ -151,4 +194,45 @@ export class TimeSeriesChart {
     this.zoomState.refresh();
     this.legendController.refresh();
   }
+
+  private onBrushEnd = (event: D3BrushEvent<unknown>) => {
+    if (!event.selection) {
+      return;
+    }
+    let [[x0], [x1]] = event.selection as [[number, number], [number, number]];
+    if (x0 === x1) {
+      this.clearBrush();
+      return;
+    }
+    if (x1 < x0) {
+      [x0, x1] = [x1, x0];
+    }
+    const m0 = this.data.clampIndex(
+      this.state.xTransform.fromScreenToModelX(x0),
+    );
+    const m1 = this.data.clampIndex(
+      this.state.xTransform.fromScreenToModelX(x1),
+    );
+    const sx0 = this.state.xTransform.toScreenFromModelX(m0);
+    const sx1 = this.state.xTransform.toScreenFromModelX(m1);
+    const k = this.state.dimensions.width / (sx1 - sx0);
+    const t = zoomIdentity.scale(k).translate(-sx0, 0);
+    this.zoomState.zoomBehavior.transform(this.zoomArea, t);
+    const startIdx = this.data.startIndex;
+    const t0 = this.data.startTime + (startIdx + m0) * this.data.timeStep;
+    const t1 = this.data.startTime + (startIdx + m1) * this.data.timeStep;
+    this.selectedTimeWindow = [t0, t1];
+    this.clearBrush();
+  };
+
+  private clearBrush = () => {
+    (
+      this.brushBehavior as unknown as {
+        move: (
+          selection: Selection<SVGGElement, unknown, HTMLElement, unknown>,
+          value: null,
+        ) => void;
+      }
+    ).move(this.brushLayer, null);
+  };
 }


### PR DESCRIPTION
## Summary
- integrate d3-brush to allow brushed zoom and time window retrieval
- expose public APIs for enabling/disabling brush and fetching selection
- support brush layer resize with chart dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06b3be360832bbd27fe08c2c5a0ab