### PR TITLE
feat: support multiple series and axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ work is possible. Keep watching!
 
 ## Y-axis modes
 
-Charts can display one or two data series. The library supports at most two
-series; additional series are ignored. By default, all series share a single
-Y-axis whose scale is computed from the combined minimum and maximum of every
-series. To draw series with different units, assign each series to a Y-axis via
-the `seriesAxes` array. If any series is assigned to axis index 1, a second
-independent Y scale is created automatically.
+Charts can display any number of data series. Each series is assigned to a
+Y-axis via the `seriesAxes` array. Only two Y axes are supported: index `0`
+represents the right axis and index `1` represents the left axis. Series that
+share an index use the same scale, computed from the combined minimum and
+maximum of every series on that axis.
 
 ```ts
 import { TimeSeriesChart, IDataSource } from "svg-time-series";
@@ -59,9 +58,8 @@ const source: IDataSource = {
   startTime,
   timeStep,
   length: data.length,
-  seriesCount: 2,
-  // Assign the first series to the left axis and the second to the right.
-  seriesAxes: [0, 1],
+  // Assign the first two series to axis 0 and the third to axis 1.
+  seriesAxes: [0, 0, 1],
   getSeries: (i, seriesIdx) => data[i][seriesIdx],
 };
 
@@ -77,41 +75,16 @@ const chart = new TimeSeriesChart(
 );
 ```
 
-`getSeries` returns the value for the specified series index, while
-`seriesCount` declares how many series are available from the data source.
-`seriesAxes` maps each series to axis 0 (left) or axis 1 (right), and its
-length must equal `seriesCount`.
+`getSeries` returns the value for the specified series index. `seriesAxes`
+maps each series to a Y-axis, and its length determines how many series are
+available from the data source.
 
 The third argument creates a legend controller, letting you customize how
 legend entries are rendered, including timestamp formatting.
 
-For two series sharing a single Y-axis, assign both series to axis 0:
-
-```ts
-const singleSource: IDataSource = {
-  startTime,
-  timeStep,
-  length: data.length,
-  seriesCount: 2,
-  // Both series use the left axis
-  seriesAxes: [0, 0],
-  getSeries: (i, seriesIdx) => data[i][seriesIdx],
-};
-
-const chartSingle = new TimeSeriesChart(
-  svg,
-  singleSource,
-  (state, data) =>
-    new LegendController(legend, state, data, (ts) =>
-      new Date(ts).toISOString(),
-    ),
-  onZoom,
-  onMouseMove,
-);
-```
-
-If you only have one series, set `seriesCount` to 1; the chart
-will render a single path and axis.
+For a chart where all series share one Y-axis, assign each entry in
+`seriesAxes` to 0. A single-series chart uses `seriesAxes: [0]` and renders one
+path and axis.
 
 ### Adjusting zoom extents
 

--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -46,7 +46,6 @@ describe("LegendController", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 1,
       getSeries: (i) => [10, 20][i]!,
       seriesAxes: [0],
     };
@@ -94,7 +93,6 @@ describe("LegendController", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 1,
       getSeries: (i) => [10, 20][i]!,
       seriesAxes: [0],
     };

--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -25,7 +25,6 @@ onCsv((data: [number, number][]) => {
     startTime: Date.now(),
     timeStep: 86400000,
     length: data.length,
-    seriesCount: 2,
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i][seriesIdx],
   };

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -49,7 +49,6 @@ export function drawCharts(
       startTime: Date.now(),
       timeStep: 86400000,
       length: data.length,
-      seriesCount: 2,
       seriesAxes,
       getSeries: (i, seriesIdx) => data[i][seriesIdx],
     };

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -1,6 +1,6 @@
 # svg-time-series
 
-A small library for rendering high-performance SVG time series charts with D3. It exports a single class, `TimeSeriesChart`, which handles drawing, zooming and hover interactions. The library supports at most two data series.
+A small library for rendering high-performance SVG time series charts with D3. It exports a single class, `TimeSeriesChart`, which handles drawing, zooming and hover interactions. The library supports an arbitrary number of data series across up to two Y axes (left and right).
 
 ## Installation
 
@@ -27,15 +27,16 @@ const legend = select("#legend");
 // example data arrays
 const ny = [10, 11];
 const sf = [12, 13];
+const other = [20, 21];
 
 const source: IDataSource = {
   startTime: Date.now(),
   timeStep: 1000, // time step in ms
   length: ny.length,
-  seriesCount: 2,
-  // Use the left axis for the first series and the right axis for the second
-  seriesAxes: [0, 1],
-  getSeries: (i, seriesIdx) => (seriesIdx === 0 ? ny[i] : sf[i]),
+  // Assign series 0 and 1 to axis 0, and series 2 to axis 1
+  seriesAxes: [0, 0, 1],
+  getSeries: (i, seriesIdx) =>
+    seriesIdx === 0 ? ny[i] : seriesIdx === 1 ? sf[i] : other[i],
 };
 
 const chart = new TimeSeriesChart(
@@ -50,9 +51,10 @@ const chart = new TimeSeriesChart(
 );
 ```
 
-`getSeries` returns a value for the requested series index, while `seriesCount`
-declares how many series are available. The library supports at most two series;
-additional series are ignored.
+`getSeries` returns a value for the requested series index. Any number of
+series may be provided, but each must be assigned to either the left or right Y
+axis by specifying 0 or 1 in `seriesAxes`. The length of `seriesAxes` determines
+how many series are available.
 
 The third argument lets you supply a custom legend controller. See
 `samples/LegendController.ts` for a reference implementation.

--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -10,7 +10,6 @@ const makeChartData = (): ChartData =>
     startTime: 0,
     timeStep: 1,
     length: 2,
-    seriesCount: 2,
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => (seriesIdx === 0 ? [0, 1][i]! : [10, 20][i]!),
   });

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -8,7 +8,6 @@ describe("ChartData", () => {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: data[0]?.length ?? 0,
     getSeries: (i, seriesIdx) => data[i]![seriesIdx]!,
     seriesAxes,
   });
@@ -18,7 +17,6 @@ describe("ChartData", () => {
       startTime: 0,
       timeStep: 1,
       length: 1,
-      seriesCount: 1,
       getSeries: () => 0,
       seriesAxes: [0],
     };
@@ -33,32 +31,11 @@ describe("ChartData", () => {
     );
   });
 
-  it("throws when seriesCount is not a positive integer", () => {
-    const base: IDataSource = {
-      startTime: 0,
-      timeStep: 1,
-      length: 1,
-      seriesCount: 1,
-      getSeries: () => 0,
-      seriesAxes: [0],
-    };
-    expect(() => new ChartData({ ...base, seriesCount: 0 })).toThrow(
-      /seriesCount.*positive integer/,
-    );
-    expect(() => new ChartData({ ...base, seriesCount: -1 })).toThrow(
-      /seriesCount.*positive integer/,
-    );
-    expect(() => new ChartData({ ...base, seriesCount: 1.5 })).toThrow(
-      /seriesCount.*positive integer/,
-    );
-  });
-
   it("throws when startTime is not finite", () => {
     const source: IDataSource = {
       startTime: NaN,
       timeStep: 1,
       length: 1,
-      seriesCount: 1,
       getSeries: () => 0,
       seriesAxes: [0],
     };
@@ -69,7 +46,6 @@ describe("ChartData", () => {
     const base = {
       startTime: 0,
       length: 1,
-      seriesCount: 1,
       getSeries: () => 0,
       seriesAxes: [0],
     };
@@ -86,7 +62,6 @@ describe("ChartData", () => {
     const base: IDataSource = {
       startTime: 0,
       length: 1,
-      seriesCount: 1,
       getSeries: () => 0,
       seriesAxes: [0],
       timeStep: 0,
@@ -99,17 +74,6 @@ describe("ChartData", () => {
     );
   });
 
-  it("throws when seriesAxes length does not match seriesCount", () => {
-    const source = makeSource(
-      [
-        [0, 0],
-        [1, 1],
-      ],
-      [0],
-    );
-    expect(() => new ChartData(source)).toThrow(/seriesAxes length/);
-  });
-
   it("throws when seriesAxes contains unsupported axis index", () => {
     const source = makeSource(
       [
@@ -119,6 +83,11 @@ describe("ChartData", () => {
       [0, 2],
     );
     expect(() => new ChartData(source)).toThrow(/0 or 1/);
+  });
+
+  it("throws when seriesAxes is empty", () => {
+    const source = makeSource([[0], [1]], []);
+    expect(() => new ChartData(source)).toThrow(/at least one series/);
   });
 
   it("throws when series axis index exceeds axisCount", () => {
@@ -497,7 +466,6 @@ describe("ChartData", () => {
         startTime: 0,
         timeStep: 1,
         length: 2,
-        seriesCount: 1,
         getSeries: (i) => [0, 1][i]!,
         seriesAxes: [0],
       };
@@ -514,7 +482,6 @@ describe("ChartData", () => {
         startTime: 0,
         timeStep: 1,
         length: 1,
-        seriesCount: 1,
         getSeries: (i) => [0][i]!,
         seriesAxes: [0],
       };

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -20,10 +20,8 @@ export interface IDataSource {
   readonly startTime: number;
   readonly timeStep: number;
   readonly length: number;
-  readonly seriesCount: number;
   /**
-   * Mapping from series index to Y-axis index. Each entry must be either 0 or 1
-   * and the array length must equal `seriesCount`.
+   * Mapping from series index to Y-axis index. Each entry must be either 0 or 1.
    */
   readonly seriesAxes: number[];
   getSeries(index: number, seriesIdx: number): number;
@@ -31,19 +29,15 @@ export interface IDataSource {
 
 function validateSource(source: IDataSource): void {
   assertPositiveInteger(source.length, "ChartData length");
-  assertPositiveInteger(source.seriesCount, "ChartData seriesCount");
   assertFiniteNumber(source.startTime, "ChartData startTime");
   assertFiniteNumber(source.timeStep, "ChartData timeStep");
   if (source.timeStep <= 0) {
     throw new Error("ChartData requires timeStep to be greater than 0");
   }
-  if (source.seriesAxes.length !== source.seriesCount) {
-    throw new Error(
-      `ChartData requires seriesAxes length to match seriesCount (${String(
-        source.seriesCount,
-      )})`,
-    );
-  }
+  assertPositiveInteger(
+    source.seriesAxes.length,
+    "ChartData requires at least one series",
+  );
   source.seriesAxes.forEach((axis, axisIdx) => {
     if (axis !== 0 && axis !== 1) {
       throw new Error(
@@ -71,8 +65,8 @@ export class ChartData {
    */
   constructor(source: IDataSource) {
     validateSource(source);
-    this.seriesCount = source.seriesCount;
     this.seriesAxes = source.seriesAxes;
+    this.seriesCount = this.seriesAxes.length;
     this.seriesAxes.forEach((axis, axisIdx) =>
       this.seriesByAxis[axis as 0 | 1].push(axisIdx),
     );

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -85,7 +85,6 @@ function createChart(data: Array<[number]>) {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: 1,
     seriesAxes: [0],
     getSeries: (i) => data[i]![0],
   };

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -140,7 +140,6 @@ function createChart(
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: 2,
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i]![seriesIdx]!,
   };

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -107,7 +107,6 @@ function createChart(data: Array<[number]>) {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: 1,
     seriesAxes: [0],
     getSeries: (i) => data[i]![0],
   };

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -112,7 +112,6 @@ function createChart(
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: 2,
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i]![seriesIdx]!,
   };
@@ -349,7 +348,6 @@ describe("chart interaction", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i) => [0, 1][i]!,
     };

--- a/svg-time-series/src/chart/render.destroy.test.ts
+++ b/svg-time-series/src/chart/render.destroy.test.ts
@@ -30,7 +30,6 @@ describe("RenderState.destroy", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: (i, _s) => [1, 2][i]!,
     };

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -37,7 +37,6 @@ describe("RenderState.refresh integration", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -53,7 +53,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i]!,
     };
@@ -81,7 +80,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
@@ -111,7 +109,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 0],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
@@ -130,7 +127,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, s) => (s === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!),
     };
@@ -141,7 +137,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, s) => (s === 0 ? [4, 5, 6][i]! : [40, 50, 60][i]!),
     };
@@ -162,7 +157,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i]!,
     };
@@ -182,7 +176,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: () => Infinity,
     };
@@ -194,7 +187,6 @@ describe("RenderState.refresh", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: () => Infinity,
     };

--- a/svg-time-series/src/chart/render.series.test.ts
+++ b/svg-time-series/src/chart/render.series.test.ts
@@ -36,7 +36,6 @@ describe("buildSeries", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i]!,
     };
@@ -52,7 +51,6 @@ describe("buildSeries", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 0],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,
@@ -70,7 +68,6 @@ describe("buildSeries", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,
@@ -90,7 +87,6 @@ describe("setupRender DOM order", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -63,7 +63,6 @@ describe("updateScaleX", () => {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: 1,
     seriesAxes: [0],
     getSeries: (i) => data[i]![0]!,
   });
@@ -83,7 +82,6 @@ describe("updateScaleY", () => {
     startTime: 0,
     timeStep: 1,
     length: data.length,
-    seriesCount: 1,
     seriesAxes: [0],
     getSeries: (i) => data[i]![0]!,
   });

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -33,7 +33,6 @@ describe("setupRender Y-axis modes", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 0],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,
@@ -50,7 +49,6 @@ describe("setupRender Y-axis modes", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i, seriesIdx) =>
         seriesIdx === 0 ? [1, 2, 3][i]! : [10, 20, 30][i]!,

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -46,7 +46,6 @@ describe("TimeSeriesChart.resize", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i]!,
     };
@@ -101,7 +100,6 @@ describe("TimeSeriesChart.resize", () => {
       startTime: 0,
       timeStep: 1,
       length: 3,
-      seriesCount: 1,
       seriesAxes: [0],
       getSeries: (i) => [1, 2, 3][i]!,
     };

--- a/svg-time-series/src/chart/seriesRenderer.ts
+++ b/svg-time-series/src/chart/seriesRenderer.ts
@@ -1,6 +1,7 @@
 import type { Series } from "./render.ts";
 
 export class SeriesRenderer {
+  /** Ordered collection of series to render. */
   public series: Series[] = [];
 
   public draw(dataArr: number[][]): void {

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -15,7 +15,6 @@ describe("updateScales", () => {
       startTime: 0,
       timeStep: 1,
       length: 2,
-      seriesCount: 2,
       seriesAxes: [0, 1],
       getSeries: (i: number, seriesIdx: number) =>
         seriesIdx === 0 ? [1, 3][i]! : [10, 30][i]!,

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -51,7 +51,6 @@ function createChart(options?: {
     startTime: 0,
     timeStep: 1,
     length: dataRows.length,
-    seriesCount: 1,
     seriesAxes: [0],
     getSeries: (i, seriesIdx) => dataRows[i]![seriesIdx]!,
   };


### PR DESCRIPTION
## Summary
- allow data source to omit explicit series count, inferring it from axis assignments
- document series configuration using `seriesAxes` length and update tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a06532ff08832b8e44bdd7b36f8522