### PR TITLE
feat(samples): add brush and reset zoom controls to demos

### DIFF
--- a/samples/demos/demo1.html
+++ b/samples/demos/demo1.html
@@ -10,6 +10,8 @@
     <title>SVG Time Series Demo 1</title>
   </head>
   <body>
+    <button id="reset-zoom">Reset Zoom</button>
+    <button id="toggle-brush">Enable Brush</button>
     <div id="fps">n/a</div>
     <div class="charts">
       <div class="chart">

--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,3 +1,26 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw([0, 1]);
+void loadAndDraw([0, 1]).then((charts) => {
+  const resetButton = document.getElementById("reset-zoom");
+  resetButton?.addEventListener("click", () => {
+    charts.forEach((c) => {
+      c.interaction.resetZoom();
+    });
+  });
+
+  const brushButton = document.getElementById("toggle-brush");
+  if (brushButton) {
+    let brushEnabled = false;
+    brushButton.addEventListener("click", () => {
+      brushEnabled = !brushEnabled;
+      charts.forEach((c) => {
+        if (brushEnabled) {
+          c.interaction.enableBrush();
+        } else {
+          c.interaction.disableBrush();
+        }
+      });
+      brushButton.textContent = brushEnabled ? "Disable Brush" : "Enable Brush";
+    });
+  }
+});

--- a/samples/demos/demo2.html
+++ b/samples/demos/demo2.html
@@ -10,6 +10,8 @@
     <title>SVG Time Series Demo 2</title>
   </head>
   <body>
+    <button id="reset-zoom">Reset Zoom</button>
+    <button id="toggle-brush">Enable Brush</button>
     <div id="fps">n/a</div>
     <div class="charts">
       <div class="chart">

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,3 +1,26 @@
 import { loadAndDraw } from "./common.ts";
 
-loadAndDraw([0, 0]);
+void loadAndDraw([0, 0]).then((charts) => {
+  const resetButton = document.getElementById("reset-zoom");
+  resetButton?.addEventListener("click", () => {
+    charts.forEach((c) => {
+      c.interaction.resetZoom();
+    });
+  });
+
+  const brushButton = document.getElementById("toggle-brush");
+  if (brushButton) {
+    let brushEnabled = false;
+    brushButton.addEventListener("click", () => {
+      brushEnabled = !brushEnabled;
+      charts.forEach((c) => {
+        if (brushEnabled) {
+          c.interaction.enableBrush();
+        } else {
+          c.interaction.disableBrush();
+        }
+      });
+      brushButton.textContent = brushEnabled ? "Disable Brush" : "Enable Brush";
+    });
+  }
+});

--- a/samples/demos/resetZoom.ts
+++ b/samples/demos/resetZoom.ts
@@ -2,8 +2,8 @@ import { loadAndDraw } from "./common.ts";
 
 // Demo entry for testing chart reset logic. Uses the updated IDataSource API.
 // A button with id 'reset-zoom' will redraw the charts to simulate a reset.
-loadAndDraw([0, 0]);
+void loadAndDraw([0, 0]);
 
 document.getElementById("reset-zoom")?.addEventListener("click", () => {
-  loadAndDraw([0, 0]);
+  void loadAndDraw([0, 0]);
 });


### PR DESCRIPTION
## Summary
- expose chart instances from demos via promise-based loader
- add Reset Zoom and Enable Brush buttons to demo1 and demo2
- wire up controls for zoom reset and brush toggling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0762eaf94832b8511748506ec157c