### PR TITLE
fix: make zoom overlay transparent

### DIFF
--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -193,6 +193,7 @@ describe("TimeSeriesChart", () => {
     expect(rectNode.getAttribute("class")).toContain("zoom-overlay");
     expect(rectNode.classList.contains("cursor-grab")).toBe(true);
     expect(rectNode.style.pointerEvents).toBe("all");
+    expect(rectNode.getAttribute("fill")).toBe("none");
 
     rectNode.dispatchEvent(new Event("pointerdown"));
     expect(rectNode.classList.contains("cursor-grabbing")).toBe(true);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -56,6 +56,7 @@ export class TimeSeriesChart {
       .attr("class", "zoom-overlay cursor-grab")
       .attr("width", this.state.dimensions.width)
       .attr("height", this.state.dimensions.height)
+      .attr("fill", "none")
       .style("pointer-events", "all");
 
     this.brushBehavior = brush()


### PR DESCRIPTION
## Summary
- avoid black rectangles in demos by giving zoom overlay no fill
- test zoom overlay defaults to transparent fill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a082b4ee28832b9882fa78ec7ead29