### PR TITLE
refactor: store baseline y-axis scales

### DIFF
--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -23,7 +23,10 @@ describe("AxisManager", () => {
         .domain([new Date(0), new Date(1)])
         .range([0, 1]),
     );
-    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
+    axisManager.axes.forEach((a) => {
+      a.scale.range([0, 1]);
+      a.baseScale.range([0, 1]);
+    });
     const spy = vi.spyOn(data, "assertAxisBounds");
     expect(() => {
       axisManager.updateScales(zoomIdentity);
@@ -39,7 +42,10 @@ describe("AxisManager", () => {
         .domain([new Date(0), new Date(1)])
         .range([0, 1]),
     );
-    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
+    axisManager.axes.forEach((a) => {
+      a.scale.range([0, 1]);
+      a.baseScale.range([0, 1]);
+    });
     const spy = vi.spyOn(data, "assertAxisBounds");
     expect(() => {
       axisManager.updateScales(zoomIdentity);

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -137,6 +137,7 @@ function resizeRenderState(
   for (const a of state.axes.y) {
     a.transform.onViewPortResize(bScreenVisible);
     a.scale.range([height, 0]);
+    a.baseScale.range([height, 0]);
   }
 }
 
@@ -165,6 +166,7 @@ export function setupRender(
   const yAxes = axisManager.axes;
   for (const a of yAxes) {
     a.scale.range(yRange);
+    a.baseScale.range(yRange);
   }
   axisManager.updateScales(zoomIdentity);
 

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -23,7 +23,10 @@ describe("updateScales", () => {
         .domain([new Date(0), new Date(1)])
         .range([0, 1]),
     );
-    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
+    axisManager.axes.forEach((a) => {
+      a.scale.range([0, 1]);
+      a.baseScale.range([0, 1]);
+    });
 
     axisManager.updateScales(zoomIdentity);
 
@@ -39,6 +42,7 @@ describe("updateScales", () => {
         [1, 10, -5, 15],
         [3, 30, 5, 25],
       ],
+      length: 2,
       bIndexFull: new AR1Basis(0, 1),
       assertAxisBounds(axisCount: number) {
         this.seriesByAxis.forEach((series: number[], i: number) => {
@@ -121,7 +125,10 @@ describe("updateScales", () => {
         .domain([new Date(0), new Date(1)])
         .range([0, 1]),
     );
-    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
+    axisManager.axes.forEach((a) => {
+      a.scale.range([0, 1]);
+      a.baseScale.range([0, 1]);
+    });
 
     axisManager.updateScales(zoomIdentity);
 
@@ -138,6 +145,7 @@ describe("updateScales", () => {
         [0, 10, -5],
         [1, 20, 5],
       ],
+      length: 2,
       bIndexFull: new AR1Basis(0, 1),
       assertAxisBounds(axisCount: number) {
         this.seriesByAxis.forEach((series: number[], i: number) => {
@@ -217,7 +225,10 @@ describe("updateScales", () => {
         .domain([new Date(0), new Date(1)])
         .range([0, 1]),
     );
-    axisManager.axes.forEach((a) => a.scale.range([0, 1]));
+    axisManager.axes.forEach((a) => {
+      a.scale.range([0, 1]);
+      a.baseScale.range([0, 1]);
+    });
 
     expect(() => {
       axisManager.updateScales(zoomIdentity);


### PR DESCRIPTION
## Summary
- track base scale per Y axis and derive visible scale via `transform.rescaleY`
- simplify Y axis updates to rescale directly from the current zoom
- apply base scale ranges during render and resize

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0b4eea368832b99d72b0045d1855a