### PR TITLE
feat: persist index-to-time scale

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -195,7 +195,7 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const scale = cd.indexToTime();
+    const scale = cd.indexToTime.copy();
     for (let i = 0; i < cd.length; i++) {
       const t = scale(i);
       const idx = cd.timeToIndex(t);
@@ -216,7 +216,7 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    const scale = cd.indexToTime();
+    const scale = cd.indexToTime.copy();
     const earliest = scale(0);
     const latest = scale(cd.length - 1);
     expect(cd.timeToIndex(earliest - 1000)).toBe(0);

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -75,9 +75,7 @@ describe("updateScales", () => {
           },
         };
       },
-      indexToTime() {
-        return scaleLinear().domain([0, 1]).range([0, 1]);
-      },
+      indexToTime: scaleLinear().domain([0, 1]).range([0, 1]),
       timeDomainFull(): [Date, Date] {
         return [new Date(0), new Date(1)];
       },
@@ -178,9 +176,7 @@ describe("updateScales", () => {
           },
         };
       },
-      indexToTime() {
-        return scaleLinear().domain([0, 1]).range([0, 1]);
-      },
+      indexToTime: scaleLinear().domain([0, 1]).range([0, 1]),
       timeDomainFull(): [Date, Date] {
         return [new Date(0), new Date(1)];
       },


### PR DESCRIPTION
## Summary
- maintain a persistent index-to-time scale inside `ChartData`
- reuse the same scale as the sliding window advances instead of rebuilding
- adjust tests to use the stored scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0bc583cb8832bba43ba4088579e76