### PR TITLE
refactor: derive DOMMatrix from d3 scales

### DIFF
--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -2,13 +2,10 @@ import { select } from "d3-selection";
 import { range } from "d3-array";
 import { zoom } from "d3-zoom";
 import type { D3ZoomEvent, ZoomTransform } from "d3-zoom";
+import { scaleLinear } from "d3-scale";
 
 import { measure, measureOnce } from "../../benchmarks/bench.ts";
-import { betweenBasesAR1 } from "../../../svg-time-series/src/math/affine.ts";
-import {
-  applyAR1ToMatrixX,
-  applyAR1ToMatrixY,
-} from "../../../svg-time-series/src/utils/domMatrix.ts";
+import { scalesToDomMatrix } from "../../../svg-time-series/src/utils/domMatrix.ts";
 import { updateNode } from "../../../svg-time-series/src/utils/domNodeTransform.ts";
 
 const svg = select("svg"),
@@ -140,10 +137,10 @@ measureOnce(60, ({ fps }) => {
 
 function test(svgNode: SVGSVGElement, viewNode: SVGGElement, width: number) {
   const id = svgNode.createSVGMatrix();
-  const affX = betweenBasesAR1([-550, 550], [0, width]);
-  const affY = betweenBasesAR1([-550, 550], [0, width]);
+  const scaleX = scaleLinear().domain([-550, 550]).range([0, width]);
+  const scaleY = scaleLinear().domain([-550, 550]).range([0, width]);
 
-  const m = applyAR1ToMatrixY(affY, applyAR1ToMatrixX(affX, id));
+  const m = scalesToDomMatrix(scaleX, scaleY, id);
 
   const newPoint = (x: number, y: number) => {
     const p = svgNode.createSVGPoint();

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -1,11 +1,8 @@
+import { scaleLinear } from "d3-scale";
 import type { ZoomTransform } from "d3-zoom";
 import type { DirectProductBasis } from "./math/affine.ts";
-import {
-  AR1Basis,
-  betweenTBasesDirectProduct,
-  dpbPlaceholder,
-} from "./math/affine.ts";
-import { applyDirectProductToMatrix } from "./utils/domMatrix.ts";
+import { AR1Basis, dpbPlaceholder } from "./math/affine.ts";
+import { scalesToDomMatrix } from "./utils/domMatrix.ts";
 
 export class ViewportTransform {
   private viewPortPoints: DirectProductBasis = dpbPlaceholder;
@@ -20,11 +17,21 @@ export class ViewportTransform {
   private static readonly DET_EPSILON = 1e-12;
 
   private updateReferenceTransform() {
-    const dp = betweenTBasesDirectProduct(
-      this.referenceViewWindowPoints,
-      this.viewPortPoints,
+    const [refX, refY] = this.referenceViewWindowPoints.toArr() as [
+      [number, number],
+      [number, number],
+    ];
+    const [viewX, viewY] = this.viewPortPoints.toArr() as [
+      [number, number],
+      [number, number],
+    ];
+    const scaleX = scaleLinear().domain(refX).range(viewX);
+    const scaleY = scaleLinear().domain(refY).range(viewY);
+    this.referenceTransform = scalesToDomMatrix(
+      scaleX,
+      scaleY,
+      new DOMMatrix(),
     );
-    this.referenceTransform = applyDirectProductToMatrix(dp, new DOMMatrix());
     this.updateComposedMatrix();
   }
 

--- a/svg-time-series/src/utils/domMatrix.test.ts
+++ b/svg-time-series/src/utils/domMatrix.test.ts
@@ -1,42 +1,40 @@
 import { describe, expect, it } from "vitest";
-import { AR1, DirectProduct } from "../math/affine.ts";
+import { scaleLinear } from "d3-scale";
 import { Matrix } from "../setupDom.ts";
-import {
-  applyAR1ToMatrixX,
-  applyAR1ToMatrixY,
-  applyDirectProductToMatrix,
-} from "./domMatrix.ts";
+import { scaleToDomMatrix, scalesToDomMatrix } from "./domMatrix.ts";
 
-describe("applyAR1ToMatrix helpers", () => {
-  it("translates and scales along X axis", () => {
-    const matrix = applyAR1ToMatrixX(
-      new AR1([2, 3]),
+describe("scaleToDomMatrix", () => {
+  it("creates a transform for the X axis", () => {
+    const scale = scaleLinear().domain([0, 2]).range([3, 7]);
+    const m = scaleToDomMatrix(
+      scale,
+      "x",
       new Matrix() as unknown as DOMMatrix,
     );
-    expect(matrix.a).toBeCloseTo(2);
-    expect(matrix.e).toBeCloseTo(3);
+    expect(m.a).toBeCloseTo(2);
+    expect(m.e).toBeCloseTo(3);
   });
 
-  it("translates and scales along Y axis", () => {
-    const matrix = applyAR1ToMatrixY(
-      new AR1([4, 5]),
+  it("creates a transform for the Y axis", () => {
+    const scale = scaleLinear().domain([0, 4]).range([5, 13]);
+    const m = scaleToDomMatrix(
+      scale,
+      "y",
       new Matrix() as unknown as DOMMatrix,
     );
-    expect(matrix.d).toBeCloseTo(4);
-    expect(matrix.f).toBeCloseTo(5);
+    expect(m.d).toBeCloseTo(2);
+    expect(m.f).toBeCloseTo(5);
   });
 });
 
-describe("applyDirectProductToMatrix", () => {
-  it("combines independent AR1 transforms", () => {
-    const dp = new DirectProduct(new AR1([2, 3]), new AR1([4, 5]));
-    const matrix = applyDirectProductToMatrix(
-      dp,
-      new Matrix() as unknown as DOMMatrix,
-    );
-    expect(matrix.a).toBeCloseTo(2);
-    expect(matrix.d).toBeCloseTo(4);
-    expect(matrix.e).toBeCloseTo(3);
-    expect(matrix.f).toBeCloseTo(5);
+describe("scalesToDomMatrix", () => {
+  it("combines independent scales", () => {
+    const sx = scaleLinear().domain([0, 2]).range([3, 7]);
+    const sy = scaleLinear().domain([0, 4]).range([5, 13]);
+    const m = scalesToDomMatrix(sx, sy, new Matrix() as unknown as DOMMatrix);
+    expect(m.a).toBeCloseTo(2);
+    expect(m.d).toBeCloseTo(2);
+    expect(m.e).toBeCloseTo(3);
+    expect(m.f).toBeCloseTo(5);
   });
 });

--- a/svg-time-series/src/utils/domMatrix.ts
+++ b/svg-time-series/src/utils/domMatrix.ts
@@ -1,18 +1,43 @@
-import type { AR1, DirectProduct } from "../math/affine.ts";
+import type { ScaleContinuousNumeric } from "d3-scale";
 
-export function applyAR1ToMatrixX(transform: AR1, sm: DOMMatrix): DOMMatrix {
-  const [a, b] = transform.m;
-  return sm.translate(b, 0).scale(a, 1);
-}
-
-export function applyAR1ToMatrixY(transform: AR1, sm: DOMMatrix): DOMMatrix {
-  const [a, b] = transform.m;
-  return sm.translate(0, b).scale(1, a);
-}
-
-export function applyDirectProductToMatrix(
-  dp: DirectProduct,
+function matrixFromDomainRange(
+  domain: [number, number],
+  range: [number, number],
+  axis: "x" | "y",
   sm: DOMMatrix,
 ): DOMMatrix {
-  return applyAR1ToMatrixY(dp.s2, applyAR1ToMatrixX(dp.s1, sm));
+  const [d0, d1] = domain;
+  const [r0, r1] = range;
+  const a = (r1 - r0) / (d1 - d0);
+  const b = r0 - d0 * a;
+  return axis === "x"
+    ? sm.translate(b, 0).scale(a, 1)
+    : sm.translate(0, b).scale(1, a);
+}
+
+/**
+ * Convert a D3 scale's domain and range into a DOMMatrix along a specific axis.
+ */
+export function scaleToDomMatrix(
+  scale: ScaleContinuousNumeric<number, number>,
+  axis: "x" | "y" = "x",
+  sm: DOMMatrix = new DOMMatrix(),
+): DOMMatrix {
+  return matrixFromDomainRange(
+    scale.domain() as [number, number],
+    scale.range() as [number, number],
+    axis,
+    sm,
+  );
+}
+
+/**
+ * Combine independent X and Y scales into a single DOMMatrix.
+ */
+export function scalesToDomMatrix(
+  scaleX: ScaleContinuousNumeric<number, number>,
+  scaleY: ScaleContinuousNumeric<number, number>,
+  sm: DOMMatrix = new DOMMatrix(),
+): DOMMatrix {
+  return scaleToDomMatrix(scaleY, "y", scaleToDomMatrix(scaleX, "x", sm));
 }

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -1,16 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { scaleLinear } from "d3-scale";
 import {
   AR1,
   AR1Basis,
   betweenTBasesAR1,
   DirectProductBasis,
-  betweenTBasesDirectProduct,
 } from "./math/affine.ts";
-import {
-  applyAR1ToMatrixX,
-  applyAR1ToMatrixY,
-  applyDirectProductToMatrix,
-} from "./utils/domMatrix.ts";
+import { scaleToDomMatrix } from "./utils/domMatrix.ts";
 import { updateNode } from "./utils/domNodeTransform.ts";
 import { Matrix } from "./setupDom.ts";
 
@@ -40,21 +36,6 @@ describe("AR1 and AR1Basis", () => {
   });
 });
 
-describe("DirectProduct", () => {
-  it("applies independent transforms on axes", () => {
-    const identity = new Matrix() as unknown as DOMMatrix;
-    const b1 = new DirectProductBasis([0, 0], [1, 1]);
-    const b2 = new DirectProductBasis([10, 10], [20, 30]);
-    const dp = betweenTBasesDirectProduct(b1, b2);
-    const m = applyDirectProductToMatrix(dp, identity);
-
-    expect(m.a).toBeCloseTo(10);
-    expect(m.d).toBeCloseTo(20);
-    expect(m.e).toBeCloseTo(10);
-    expect(m.f).toBeCloseTo(10);
-  });
-});
-
 describe("DirectProductBasis utilities", () => {
   it("builds from axis projections", () => {
     const bx = new AR1Basis(0, 2);
@@ -71,18 +52,14 @@ describe("DirectProductBasis utilities", () => {
 });
 
 describe("viewZoomTransform helpers", () => {
-  it("applies AR1 transforms along X and Y axes", () => {
-    const mx = applyAR1ToMatrixX(
-      new AR1([2, 3]),
-      new Matrix() as unknown as DOMMatrix,
-    );
+  it("applies scale transforms along X and Y axes", () => {
+    const sx = scaleLinear().domain([0, 1]).range([3, 5]);
+    const mx = scaleToDomMatrix(sx, "x", new Matrix() as unknown as DOMMatrix);
     expect(mx.a).toBeCloseTo(2);
     expect(mx.e).toBeCloseTo(3);
 
-    const my = applyAR1ToMatrixY(
-      new AR1([3, 4]),
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const sy = scaleLinear().domain([0, 1]).range([4, 7]);
+    const my = scaleToDomMatrix(sy, "y", new Matrix() as unknown as DOMMatrix);
     expect(my.d).toBeCloseTo(3);
     expect(my.f).toBeCloseTo(4);
   });


### PR DESCRIPTION
## Summary
- add `scaleToDomMatrix` and `scalesToDomMatrix` utilities for turning d3 scales into DOMMatrix transforms
- refactor `ViewportTransform` and tests to use d3 `scaleLinear`
- adjust sample and unit tests for new helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c21a9570832bbc7b075aed852787