### PR TITLE
refactor: use persistent scales for zoom

### DIFF
--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -4,12 +4,10 @@
 import { describe, it, expect } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
-import { scaleTime } from "d3-scale";
-import { zoomIdentity } from "d3-zoom";
 import { AR1Basis } from "../math/affine.ts";
 import { ChartData } from "./data.ts";
 import type { IDataSource } from "./data.ts";
-import { createDimensions, updateScaleX } from "./render/utils.ts";
+import { createDimensions } from "./render/utils.ts";
 
 describe("createDimensions", () => {
   it("sets width and height and returns screen basis", () => {
@@ -56,18 +54,6 @@ describe("createDimensions", () => {
       unknown
     >;
     expect(() => createDimensions(selection)).toThrow(/HTMLElement parent/);
-  });
-});
-
-describe("updateScaleX", () => {
-  it("adjusts domain based on zoom transform", () => {
-    const x = scaleTime()
-      .domain([new Date(0), new Date(2)])
-      .range([0, 100]);
-    updateScaleX(x, zoomIdentity);
-    const [d0, d1] = x.domain();
-    expect(d0!.getTime()).toBe(0);
-    expect(d1!.getTime()).toBe(2);
   });
 });
 

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,6 +1,4 @@
 import type { Selection } from "d3-selection";
-import type { ScaleTime } from "d3-scale";
-import type { ZoomTransform } from "d3-zoom";
 import { AR1Basis, DirectProductBasis } from "../../math/affine.ts";
 
 export function createDimensions(
@@ -28,13 +26,6 @@ export function createDimensions(
   const bScreenYVisible = new AR1Basis(height, 0);
 
   return DirectProductBasis.fromProjections(bScreenXVisible, bScreenYVisible);
-}
-
-export function updateScaleX(
-  x: ScaleTime<number, number>,
-  transform: ZoomTransform,
-): void {
-  x.domain(transform.rescaleX(x).domain());
 }
 
 export function createSeriesNodes(

--- a/svg-time-series/src/chart/updateYScales.test.ts
+++ b/svg-time-series/src/chart/updateYScales.test.ts
@@ -79,18 +79,11 @@ describe("updateScales", () => {
       timeDomainFull(): [Date, Date] {
         return [new Date(0), new Date(1)];
       },
-      bIndexFromTransform(
-        transform: ZoomTransform,
-        range: [number, number],
-      ): AR1Basis {
+      bIndexFromTransform(transform: ZoomTransform, range: [number, number]) {
         const indexBase = scaleLinear()
           .domain(this.bIndexFull.toArr())
           .range(range);
-        const [i0, i1] = transform.rescaleX(indexBase).domain() as [
-          number,
-          number,
-        ];
-        return new AR1Basis(i0, i1);
+        return transform.rescaleX(indexBase);
       },
       timeToIndex(t: number) {
         return t;
@@ -105,8 +98,9 @@ describe("updateScales", () => {
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
       },
-      axisTransform(axis: number, b: AR1Basis) {
+      axisTransform(axis: number, domain: [number, number]) {
         const tree = this.buildAxisTree(axis);
+        const b = new AR1Basis(domain[0], domain[1]);
         const dp = this.updateScaleY(b, tree);
         const [min, max] = dp.y().toArr();
         const bAxis = new AR1Basis(min, max);
@@ -180,18 +174,11 @@ describe("updateScales", () => {
       timeDomainFull(): [Date, Date] {
         return [new Date(0), new Date(1)];
       },
-      bIndexFromTransform(
-        transform: ZoomTransform,
-        range: [number, number],
-      ): AR1Basis {
+      bIndexFromTransform(transform: ZoomTransform, range: [number, number]) {
         const indexBase = scaleLinear()
           .domain(this.bIndexFull.toArr())
           .range(range);
-        const [i0, i1] = transform.rescaleX(indexBase).domain() as [
-          number,
-          number,
-        ];
-        return new AR1Basis(i0, i1);
+        return transform.rescaleX(indexBase);
       },
       updateScaleY(
         b: AR1Basis,
@@ -203,8 +190,9 @@ describe("updateScales", () => {
         const by = new AR1Basis(min, max);
         return DirectProductBasis.fromProjections(b, by);
       },
-      axisTransform(axis: number, b: AR1Basis) {
+      axisTransform(axis: number, domain: [number, number]) {
         const tree = this.buildAxisTree(axis);
+        const b = new AR1Basis(domain[0], domain[1]);
         const dp = this.updateScaleY(b, tree);
         const [min, max] = dp.y().toArr();
         const bAxis = new AR1Basis(min, max);


### PR DESCRIPTION
## Summary
- track index with a persistent linear scale and rescale directly
- inline axis rescaling and drop custom updateScaleX helper
- refresh render state using new scale copies for axes
- rename index domain params to `dIndex*` and keep resize updates within render state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ce844be8832b8954e9b304f6eaea