### PR TITLE
refactor: expose render state via helpers

### DIFF
--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -138,12 +138,10 @@ describe("TimeSeriesChart", () => {
     const legend = createLegend();
     const { chart } = createChart({ legend });
     const internal = chart as unknown as {
-      state: { xTransform: { fromScreenToModelX: ReturnType<typeof vi.fn> } };
+      state: { screenToModelX: ReturnType<typeof vi.fn> };
       data: { length: number };
     };
-    vi.spyOn(internal.state.xTransform, "fromScreenToModelX").mockReturnValue(
-      10,
-    );
+    vi.spyOn(internal.state, "screenToModelX").mockReturnValue(10);
 
     chart.onHover(5);
 


### PR DESCRIPTION
## Summary
- add helper methods on RenderState to access dimensions, legend info, and convert screen x to model x
- update TimeSeriesChart to use new helpers and build legend context via render state
- adjust unit tests for new screenToModelX helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d55e4ca4832bb9b46578655eb720