### PR TITLE
refactor: encapsulate render state zoom updates

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -74,6 +74,8 @@ export interface RenderState {
   getLegendSeriesInfo: () => readonly LegendSeriesInfo[];
   screenToModelX: (x: number) => number;
   createLegendContext: (data: ChartData) => LegendContext;
+  applyZoomTransform: (transform: ZoomTransform) => void;
+  setDimensions: (dimensions: Dimensions) => void;
 }
 
 export function refreshRenderState(
@@ -150,6 +152,22 @@ function resizeRenderState(
     a.scale.range([height, 0]);
     a.baseScale.range([height, 0]);
   }
+}
+
+function applyZoomTransformInternal(
+  state: RenderState,
+  transform: ZoomTransform,
+): void {
+  state.xTransform.onZoomPan(transform);
+  state.axes.y.forEach((a) => a.transform.onZoomPan(transform));
+}
+
+function setDimensionsInternal(
+  state: RenderState,
+  dimensions: Dimensions,
+): void {
+  state.dimensions.width = dimensions.width;
+  state.dimensions.height = dimensions.height;
 }
 
 function getDimensions(state: RenderState): Dimensions {
@@ -260,6 +278,8 @@ export function setupRender(
   state.getLegendSeriesInfo = getLegendSeriesInfo.bind(null, state);
   state.screenToModelX = screenToModelX.bind(null, state);
   state.createLegendContext = createLegendContext.bind(null, state);
+  state.applyZoomTransform = applyZoomTransformInternal.bind(null, state);
+  state.setDimensions = setDimensionsInternal.bind(null, state);
 
   return state;
 }

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -62,12 +62,9 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
-      },
       axisRenders: [],
-      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -107,12 +104,9 @@ describe("ZoomState.destroy", () => {
     const rect = select(svg).append("rect");
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: { onZoomPan: vi.fn<(t: unknown) => void>() } }],
-      },
       axisRenders: [],
-      xTransform: { onZoomPan: vi.fn<(t: unknown) => void>() },
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -64,16 +64,12 @@ describe("ZoomState programmatic transforms", () => {
   it("handles identical value transforms as the same", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -93,8 +89,7 @@ describe("ZoomState programmatic transforms", () => {
     vi.runAllTimers();
 
     expect(transformSpy).toHaveBeenCalledTimes(2);
-    expect(x.onZoomPan).toHaveBeenCalledWith(initial);
-    expect(y.onZoomPan).toHaveBeenCalledWith(initial);
+    expect(applyZoomTransform).toHaveBeenCalledWith(initial);
     expect(refresh).toHaveBeenCalledTimes(1);
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -114,17 +114,12 @@ describe("ZoomState", () => {
   it("updates transforms and triggers refresh on zoom", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const y2 = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }, { transform: y2 }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -147,9 +142,7 @@ describe("ZoomState", () => {
     zs.zoom(event);
     vi.runAllTimers();
 
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
-    expect(y2.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 2 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 5, k: 2 });
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
@@ -164,16 +157,12 @@ describe("ZoomState", () => {
   it("forwards programmatic transform to zoom behavior", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zoomCb = vi.fn();
@@ -202,8 +191,7 @@ describe("ZoomState", () => {
       x: 2,
       k: 3,
     });
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 2, k: 3 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 2, k: 3 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 2, k: 3 });
     expect(refresh).toHaveBeenCalledTimes(1);
     expect(zoomCb).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenNthCalledWith(1, event);
@@ -218,16 +206,12 @@ describe("ZoomState", () => {
   it("accumulates forwarded and user zoom events", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -266,10 +250,8 @@ describe("ZoomState", () => {
       x: 5,
       k: 4,
     });
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 3, k: 2 });
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 4 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 3, k: 2 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 4 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 3, k: 2 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 5, k: 4 });
     expect(refresh).toHaveBeenCalledTimes(2);
   });
 
@@ -278,12 +260,12 @@ describe("ZoomState", () => {
     const rect1 = select(svg1).append("rect");
     const svg2 = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect2 = select(svg2).append("rect");
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs2 = new ZoomState(
       rect2 as unknown as Selection<
@@ -336,8 +318,8 @@ describe("ZoomState", () => {
       x: 5,
       k: 4,
     });
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 2 });
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 5, k: 4 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 1, k: 2 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 5, k: 4 });
   });
 
   it("does not leave source chart stuck after target chart zoom", () => {
@@ -345,12 +327,12 @@ describe("ZoomState", () => {
     const rect1 = select(svg1).append("rect");
     const svg2 = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect2 = select(svg2).append("rect");
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const createZoomState = (
       rect: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
@@ -405,22 +387,18 @@ describe("ZoomState", () => {
     const zs1Internal = zs1 as unknown as ZoomStateInternal;
     expect(zs1Internal.zoomScheduler.isPending()).toBe(false);
     expect(zs1Internal.zoomScheduler.getCurrentTransform()).toBeNull();
-    expect(x.onZoomPan).toHaveBeenCalled();
+    expect(applyZoomTransform).toHaveBeenCalled();
   });
 
   it("programmatic zoom does not reapply transform on subsequent refresh", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -440,8 +418,7 @@ describe("ZoomState", () => {
       transform: { x: 4, k: 5 },
     } as unknown as D3ZoomEvent<SVGRectElement, unknown>);
     vi.runAllTimers();
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 4, k: 5 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 4, k: 5 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 4, k: 5 });
 
     transformSpy.mockClear();
     refresh.mockClear();
@@ -456,16 +433,12 @@ describe("ZoomState", () => {
   it("refresh triggers refresh callback without reapplying transform", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -484,8 +457,7 @@ describe("ZoomState", () => {
       sourceEvent: {},
     } as unknown as D3ZoomEvent<SVGRectElement, unknown>);
     vi.runAllTimers();
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 1 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 1 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 1, k: 1 });
 
     const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     transformSpy.mockClear();
@@ -501,16 +473,12 @@ describe("ZoomState", () => {
   it("reset sets transform to identity and triggers zoom event", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -526,8 +494,7 @@ describe("ZoomState", () => {
 
     const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     transformSpy.mockClear();
-    y.onZoomPan.mockClear();
-    x.onZoomPan.mockClear();
+    applyZoomTransform.mockClear();
     refresh.mockClear();
 
     zs.reset();
@@ -538,8 +505,7 @@ describe("ZoomState", () => {
       expect.objectContaining({ k: 1, x: 0, y: 0 }),
     );
     const identity = expect.objectContaining({ k: 1, x: 0, y: 0 }) as unknown;
-    expect(x.onZoomPan).toHaveBeenCalledWith(identity);
-    expect(y.onZoomPan).toHaveBeenCalledWith(identity);
+    expect(applyZoomTransform).toHaveBeenCalledWith(identity);
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;
     }
@@ -552,16 +518,12 @@ describe("ZoomState", () => {
   it("updates zoom extents on resize", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const setDimensions = vi.fn();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform: vi.fn(),
+      setDimensions,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -587,6 +549,7 @@ describe("ZoomState", () => {
 
     expect(rect.attr("width")).toBe("20");
     expect(rect.attr("height")).toBe("30");
+    expect(setDimensions).toHaveBeenCalledWith({ width: 20, height: 30 });
     expect(scaleSpy).toHaveBeenCalledWith([1, 40]);
     expect(translateSpy).toHaveBeenCalledWith([
       [0, 0],
@@ -597,14 +560,11 @@ describe("ZoomState", () => {
   it("uses provided scale extents", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -635,12 +595,11 @@ describe("ZoomState", () => {
   it("updates scale extent at runtime", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -668,12 +627,12 @@ describe("ZoomState", () => {
   it("clamps existing transform to new scale extent", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -691,7 +650,7 @@ describe("ZoomState", () => {
       x: 0,
       y: 0,
     } as unknown as ZoomTransform);
-    expect(x.onZoomPan).toHaveBeenCalledWith({ k: 10, x: 0, y: 0 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ k: 10, x: 0, y: 0 });
     const scaleSpy = vi.spyOn(zs.zoomBehavior, "scaleTo");
     scaleSpy.mockClear();
 
@@ -704,12 +663,12 @@ describe("ZoomState", () => {
   it("clamps existing transform to new minimum", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const x2 = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x2,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -727,7 +686,7 @@ describe("ZoomState", () => {
       x: 0,
       y: 0,
     } as unknown as ZoomTransform);
-    expect(x2.onZoomPan).toHaveBeenCalledWith({ k: 0.2, x: 0, y: 0 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ k: 0.2, x: 0, y: 0 });
     const scaleSpy = vi.spyOn(zs.zoomBehavior, "scaleTo");
     scaleSpy.mockClear();
 
@@ -743,12 +702,11 @@ describe("ZoomState", () => {
   ])("accepts valid scale extent %j", (min, max) => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -783,6 +741,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -806,6 +766,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -843,6 +805,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
 
     expect(
@@ -868,6 +832,8 @@ describe("ZoomState", () => {
     const state = {
       dimensions: { width: 10, height: 10 },
       axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
 
     expect(

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -55,16 +55,12 @@ describe("ZoomState transform state", () => {
   it("clears transform after application to avoid reapplying stale values", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const y = { onZoomPan: vi.fn<(t: unknown) => void>() };
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
     const state = {
       dimensions: { width: 10, height: 10 },
-      axes: {
-        x: { axis: {}, g: {}, scale: {} },
-        y: [{ transform: y }],
-      },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions: vi.fn(),
     } as unknown as RenderState;
     const refresh = vi.fn();
     const zs = new ZoomState(
@@ -88,8 +84,7 @@ describe("ZoomState transform state", () => {
     vi.runAllTimers();
 
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 1, k: 2 });
-    expect(x.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 2 });
-    expect(y.onZoomPan).toHaveBeenCalledWith({ x: 1, k: 2 });
+    expect(applyZoomTransform).toHaveBeenCalledWith({ x: 1, k: 2 });
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;
     }
@@ -118,7 +113,6 @@ describe("ZoomState transform state", () => {
 
     expect(transformSpy).toHaveBeenCalledTimes(1);
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 5, k: 3 });
-    expect(x.onZoomPan).toHaveBeenLastCalledWith({ x: 5, k: 3 });
-    expect(y.onZoomPan).toHaveBeenLastCalledWith({ x: 5, k: 3 });
+    expect(applyZoomTransform).toHaveBeenLastCalledWith({ x: 5, k: 3 });
   });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -63,8 +63,7 @@ export class ZoomState {
   }
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
-    this.state.xTransform.onZoomPan(event.transform);
-    this.state.axes.y.forEach((a) => a.transform.onZoomPan(event.transform));
+    this.state.applyZoomTransform(event.transform);
     if (!this.zoomScheduler.zoom(event.transform, event.sourceEvent)) {
       return;
     }
@@ -87,8 +86,7 @@ export class ZoomState {
   };
 
   public updateExtents = (dimensions: { width: number; height: number }) => {
-    this.state.dimensions.width = dimensions.width;
-    this.state.dimensions.height = dimensions.height;
+    this.state.setDimensions(dimensions);
     this.zoomArea
       .attr("width", dimensions.width)
       .attr("height", dimensions.height);

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -106,12 +106,13 @@ describe("ZoomState.updateExtents clamp", () => {
   it("clamps existing translation to new bounds", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
-    const x = { onZoomPan: vi.fn<(t: unknown) => void>() };
+    const applyZoomTransform = vi.fn<(t: unknown) => void>();
+    const setDimensions = vi.fn();
     const state = {
       dimensions: { width: 100, height: 100 },
-      axes: { x: { axis: {}, g: {}, scale: {} }, y: [] },
       axisRenders: [],
-      xTransform: x,
+      applyZoomTransform,
+      setDimensions,
     } as unknown as RenderState;
     const zs = new ZoomState(
       rect as unknown as Selection<
@@ -127,10 +128,11 @@ describe("ZoomState.updateExtents clamp", () => {
     const initial = zoomIdentity.translate(-120, -80).scale(2);
     zs.zoomBehavior.transform(rect, initial);
     const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
-    expect(x.onZoomPan).toHaveBeenCalledWith(initial);
+    expect(applyZoomTransform).toHaveBeenCalledWith(initial);
     transformSpy.mockClear();
 
     zs.updateExtents({ width: 50, height: 50 });
+    expect(setDimensions).toHaveBeenCalledWith({ width: 50, height: 50 });
 
     expect(transformSpy).toHaveBeenCalledWith(
       rect,


### PR DESCRIPTION
## Summary
- encapsulate transform & dimension handling in render state
- update zoom state to use new RenderState methods
- adjust zoomState tests for new API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0d81754a4832bb0a24a4927e55462