### PR TITLE
refactor: compute axis domains with d3.extent

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,5 +1,6 @@
 import { scaleLinear } from "d3-scale";
 import type { ScaleLinear, ScaleTime } from "d3-scale";
+import { extent } from "d3-array";
 import type { Selection } from "d3-selection";
 import type { ZoomTransform } from "d3-zoom";
 import { SegmentTree } from "segment-tree-rmq";
@@ -46,11 +47,12 @@ export class AxisModel {
     dIndex: [number, number],
     transform: ZoomTransform,
   ): void {
-    const { tree, dpRef } = data.axisTransform(axisIdx, dIndex);
+    const { tree, min, max } = data.axisTransform(axisIdx, dIndex);
     this.tree = tree;
-    this.transform.onReferenceViewWindowResize(dpRef);
+    this.transform.onReferenceViewWindowResize([data.bIndexFull, [min, max]]);
     const full = tree.query(0, data.length - 1);
-    this.baseScale.domain([full.min, full.max]);
+    const [fullMin, fullMax] = extent([full.min, full.max]) as [number, number];
+    this.baseScale.domain([fullMin, fullMax]);
     const scaled = transform.rescaleY(this.baseScale);
     this.scale = scaled.copy();
   }

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -413,10 +413,8 @@ describe("ChartData", () => {
     );
     const tree0 = cd.buildAxisTree(0);
     const tree1 = cd.buildAxisTree(1);
-    const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
+    const combined = cd.combinedAxisDomain(cd.bIndexFull, tree0, tree1);
     expect(combined).toEqual([-3, 10]);
-    expect(dp[0]).toEqual([0, 2]);
-    expect(dp[1]).toEqual([-3, 10]);
   });
 
   it("throws when initial data contains infinite values", () => {

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -69,8 +69,7 @@ describe("updateScaleY", () => {
   it("respects the supplied index window", () => {
     const cd = new ChartData(makeSource([[10], [20], [40], [5]]));
     const tree = cd.buildAxisTree(0);
-    const dp = cd.updateScaleY([1, 2], tree);
-    expect(dp[0]).toEqual([1, 2]);
-    expect(dp[1]).toEqual([20, 40]);
+    const domain = cd.updateScaleY([1, 2], tree);
+    expect(domain).toEqual([20, 40]);
   });
 });


### PR DESCRIPTION
## Summary
- refactor ChartData to derive axis domains with `d3.extent` and remove basis conversions
- simplify AxisModel to consume scale domains directly
- update unit tests for new axis helpers and zoom behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0eac37b6c832b91c08cb06682917e