### PR TITLE
refactor: simplify viewport transform resize api

### DIFF
--- a/svg-time-series/bench/viewportTransform.bench.ts
+++ b/svg-time-series/bench/viewportTransform.bench.ts
@@ -1,7 +1,6 @@
 import { bench, describe } from "vitest";
 import { zoomIdentity } from "d3-zoom";
 import { ViewportTransform } from "../src/ViewportTransform.ts";
-import { toDirectProductBasis } from "../src/basis.ts";
 
 class Matrix {
   constructor(
@@ -69,8 +68,8 @@ globalObj.DOMPoint = Point;
 
 describe("ViewportTransform performance", () => {
   const vt = new ViewportTransform();
-  vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-  vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+  vt.onViewPortResize([0, 100], [0, 100]);
+  vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
   const t = zoomIdentity.translate(10, 0).scale(2);
 

--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -2,7 +2,6 @@ import "./setupDom.ts";
 import { beforeAll, describe, expect, it } from "vitest";
 import { zoomIdentity } from "d3-zoom";
 import type { Basis } from "./basis.ts";
-import { toDirectProductBasis } from "./basis.ts";
 import type { ViewportTransform as ViewportTransformClass } from "./ViewportTransform.ts";
 
 let ViewportTransform: typeof ViewportTransformClass;
@@ -15,8 +14,8 @@ describe("ViewportTransform", () => {
   it("composes zoom and reference transforms and inverts them", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
     // without zoom
     expect(vt.fromScreenToModelX(50)).toBeCloseTo(5);
@@ -31,8 +30,8 @@ describe("ViewportTransform", () => {
   it("maps screen bases back to model bases through inverse transforms", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const basis = vt.fromScreenToModelBasisX([20, 40]);
@@ -44,8 +43,8 @@ describe("ViewportTransform", () => {
   it("converts screen points to model points", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const x = vt.fromScreenToModelX(70);
@@ -57,8 +56,8 @@ describe("ViewportTransform", () => {
   it("round-trips between screen and model coordinates", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const xScreen = 70;
@@ -90,8 +89,8 @@ describe("ViewportTransform", () => {
   it("throws a helpful error when scale is zero", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
     vt.onZoomPan(zoomIdentity.scale(0));
     expect(() => vt.fromScreenToModelX(10)).toThrow(/not invertible/);
@@ -100,8 +99,8 @@ describe("ViewportTransform", () => {
   it("throws a helpful error when scale is near zero", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
     vt.onZoomPan(zoomIdentity.scale(1e-15));
     expect(() => vt.fromScreenToModelX(10)).toThrow(/not invertible/);

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -1,6 +1,6 @@
 import { scaleLinear, type ScaleLinear } from "d3-scale";
 import { zoomIdentity, type ZoomTransform } from "d3-zoom";
-import type { Basis, DirectProductBasis } from "./basis.ts";
+import type { Basis } from "./basis.ts";
 import { scalesToDomMatrix } from "./utils/domMatrix.ts";
 
 export class ViewportTransform {
@@ -27,18 +27,16 @@ export class ViewportTransform {
     );
   }
 
-  public onViewPortResize(bScreenVisible: DirectProductBasis): this {
-    const [viewX, viewY] = bScreenVisible;
-    this.baseScaleX = this.baseScaleX.copy().range(viewX);
-    this.baseScaleY = this.baseScaleY.copy().range(viewY);
+  public onViewPortResize(rangeX: Basis, rangeY: Basis): this {
+    this.baseScaleX.range(rangeX);
+    this.baseScaleY.range(rangeY);
     this.updateScales();
     return this;
   }
 
-  public onReferenceViewWindowResize(newPoints: DirectProductBasis): this {
-    const [refX, refY] = newPoints;
-    this.baseScaleX = this.baseScaleX.copy().domain(refX);
-    this.baseScaleY = this.baseScaleY.copy().domain(refY);
+  public onReferenceViewWindowResize(domainX: Basis, domainY: Basis): this {
+    this.baseScaleX.domain(domainX);
+    this.baseScaleY.domain(domainY);
     this.updateScales();
     return this;
   }

--- a/svg-time-series/src/basis.ts
+++ b/svg-time-series/src/basis.ts
@@ -3,10 +3,6 @@ export type DirectProductBasis = [Basis, Basis];
 
 export const bPlaceholder: Basis = [0, 1];
 
-export function toDirectProductBasis(bx: Basis, by: Basis): DirectProductBasis {
-  return [bx, by];
-}
-
 export function basisRange(b: Basis): number {
   return Math.abs(b[1] - b[0]);
 }

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -48,7 +48,7 @@ export class AxisModel {
   ): void {
     const { tree, dpRef } = data.axisTransform(axisIdx, dIndex);
     this.tree = tree;
-    this.transform.onReferenceViewWindowResize(dpRef);
+    this.transform.onReferenceViewWindowResize(dpRef[0], dpRef[1]);
     const full = tree.query(0, data.length - 1);
     this.baseScale.domain([full.min, full.max]);
     const scaled = transform.rescaleY(this.baseScale);

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -3,7 +3,6 @@ import { SegmentTree } from "segment-tree-rmq";
 import { scaleLinear, type ScaleLinear } from "d3-scale";
 import type { ZoomTransform } from "d3-zoom";
 import type { Basis, DirectProductBasis } from "../basis.ts";
-import { toDirectProductBasis } from "../basis.ts";
 import { SlidingWindow } from "./slidingWindow.ts";
 import { assertFiniteNumber, assertPositiveInteger } from "./validation.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
@@ -199,7 +198,7 @@ export class ChartData {
     tree: SegmentTree<IMinMax>,
   ): DirectProductBasis {
     const bAxisVisible = this.bAxisVisible(bIndexVisible, tree);
-    return toDirectProductBasis(bIndexVisible, bAxisVisible);
+    return [bIndexVisible, bAxisVisible];
   }
 
   axisTransform(
@@ -220,7 +219,7 @@ export class ChartData {
       max = 1;
     }
     const b: Basis = [min, max];
-    const dpRef = toDirectProductBasis(this.bIndexFull, b);
+    const dpRef: DirectProductBasis = [this.bIndexFull, b];
     return { tree, min, max, dpRef };
   }
 
@@ -237,7 +236,7 @@ export class ChartData {
     const [min0, max0] = b0;
     const [min1, max1] = b1;
     const combined: Basis = [Math.min(min0, min1), Math.max(max0, max1)];
-    const dp = toDirectProductBasis(this.bIndexFull, combined);
+    const dp: DirectProductBasis = [this.bIndexFull, combined];
     return { combined, dp };
   }
 }

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,6 +1,5 @@
 import type { Selection } from "d3-selection";
 import type { Basis, DirectProductBasis } from "../../basis.ts";
-import { toDirectProductBasis } from "../../basis.ts";
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -26,7 +25,7 @@ export function createDimensions(
   const bScreenXVisible: Basis = [0, width];
   const bScreenYVisible: Basis = [height, 0];
 
-  return toDirectProductBasis(bScreenXVisible, bScreenYVisible);
+  return [bScreenXVisible, bScreenYVisible];
 }
 
 export function createSeriesNodes(

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -29,6 +29,7 @@ import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import { TimeSeriesChart } from "../draw.ts";
 import type { IDataSource } from "../draw.ts";
+import type { Basis } from "../basis.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 import "../setupDom.ts";
 
@@ -151,10 +152,9 @@ describe("TimeSeriesChart.resize", () => {
     expect(updateSpy).toHaveBeenCalledWith({ width: 250, height: 120 });
     expect(chartInternal.state.dimensions).toEqual({ width: 250, height: 120 });
 
-    type AxisRange = [[number, number], [number, number]];
-    const arg = resizeSpy.mock.calls.at(0)![0] as unknown as AxisRange;
-    expect(arg[0]).toEqual([0, 250]);
-    expect(arg[1]).toEqual([120, 0]);
+    const [rangeX, rangeY] = resizeSpy.mock.calls.at(0)! as [Basis, Basis];
+    expect(rangeX).toEqual([0, 250]);
+    expect(rangeY).toEqual([120, 0]);
 
     expect(chartInternal.state.axes.x.scale.range()).toEqual([0, 250]);
     expect(chartInternal.state.axes.y[0]!.scale.range()).toEqual([120, 0]);


### PR DESCRIPTION
## Summary
- refactor ViewportTransform resize methods to accept axis tuples and update scales directly
- remove toDirectProductBasis helper and update callers to pass numeric tuples
- adjust rendering and axis management to the streamlined API

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ec6a6c9c832b924a313e61a62df5