### PR TITLE
refactor: use scales for y-axis domains

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -6,6 +6,7 @@ import { SegmentTree } from "segment-tree-rmq";
 
 import type { MyAxis } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
+import type { Basis } from "../basis.ts";
 import type { ChartData, IMinMax } from "./data.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
 
@@ -46,9 +47,12 @@ export class AxisModel {
     dIndex: [number, number],
     transform: ZoomTransform,
   ): void {
-    const { tree, dpRef } = data.axisTransform(axisIdx, dIndex);
+    const { tree, scale } = data.axisTransform(axisIdx, dIndex);
     this.tree = tree;
-    this.transform.onReferenceViewWindowResize(dpRef);
+    this.transform.onReferenceViewWindowResize([
+      data.bIndexFull,
+      scale.domain() as Basis,
+    ] as [Basis, Basis]);
     const full = tree.query(0, data.length - 1);
     this.baseScale.domain([full.min, full.max]);
     const scaled = transform.rescaleY(this.baseScale);

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { scaleLinear } from "d3-scale";
 import type { Basis } from "../basis.ts";
 import type { IDataSource } from "./data.ts";
 import { ChartData } from "./data.ts";
@@ -400,7 +401,7 @@ describe("ChartData", () => {
     expect(cd.bAxisVisible(rightRange, tree1)).toEqual([60, 60]);
   });
 
-  it("computes combined temperature basis and direct product", () => {
+  it("computes combined temperature extent and updates scale", () => {
     const cd = new ChartData(
       makeSource(
         [
@@ -413,10 +414,10 @@ describe("ChartData", () => {
     );
     const tree0 = cd.buildAxisTree(0);
     const tree1 = cd.buildAxisTree(1);
-    const { combined, dp } = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
+    const scale = scaleLinear<number, number>();
+    const combined = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1, scale);
     expect(combined).toEqual([-3, 10]);
-    expect(dp[0]).toEqual([0, 2]);
-    expect(dp[1]).toEqual([-3, 10]);
+    expect(scale.domain()).toEqual([-3, 10]);
   });
 
   it("throws when initial data contains infinite values", () => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -90,9 +90,6 @@ export class RenderState {
   }
 
   public refresh(data: ChartData, transform: ZoomTransform): void {
-    const referenceBasis = toDirectProductBasis(data.bIndexFull, bPlaceholder);
-    this.xTransform.onReferenceViewWindowResize(referenceBasis);
-
     this.axisManager.setData(data);
     this.axisManager.updateScales(transform);
 

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -67,8 +67,7 @@ describe("updateScaleY", () => {
   it("respects the supplied index window", () => {
     const cd = new ChartData(makeSource([[10], [20], [40], [5]]));
     const tree = cd.buildAxisTree(0);
-    const dp = cd.updateScaleY([1, 2], tree);
-    expect(dp[0]).toEqual([1, 2]);
-    expect(dp[1]).toEqual([20, 40]);
+    const scale = cd.updateScaleY([1, 2], tree);
+    expect(scale.domain()).toEqual([20, 40]);
   });
 });


### PR DESCRIPTION
## Summary
- construct Y-axis scales directly from min/max ranges
- propagate Y-axis scales through AxisManager and render logic
- compute combined Y domains using d3.extent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ed2b8ac0832bb87784a356be44fd