### PR TITLE
refactor: simplify dimension handling

### DIFF
--- a/svg-time-series/bench/viewportTransform.bench.ts
+++ b/svg-time-series/bench/viewportTransform.bench.ts
@@ -1,7 +1,6 @@
 import { bench, describe } from "vitest";
 import { zoomIdentity } from "d3-zoom";
 import { ViewportTransform } from "../src/ViewportTransform.ts";
-import { toDirectProductBasis } from "../src/basis.ts";
 
 class Matrix {
   constructor(
@@ -69,8 +68,14 @@ globalObj.DOMPoint = Point;
 
 describe("ViewportTransform performance", () => {
   const vt = new ViewportTransform();
-  vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-  vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+  vt.onViewPortResize([
+    [0, 100],
+    [0, 100],
+  ]);
+  vt.onReferenceViewWindowResize([
+    [0, 10],
+    [0, 10],
+  ]);
 
   const t = zoomIdentity.translate(10, 0).scale(2);
 

--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -2,7 +2,6 @@ import "./setupDom.ts";
 import { beforeAll, describe, expect, it } from "vitest";
 import { zoomIdentity } from "d3-zoom";
 import type { Basis } from "./basis.ts";
-import { toDirectProductBasis } from "./basis.ts";
 import type { ViewportTransform as ViewportTransformClass } from "./ViewportTransform.ts";
 
 let ViewportTransform: typeof ViewportTransformClass;
@@ -15,8 +14,14 @@ describe("ViewportTransform", () => {
   it("composes zoom and reference transforms and inverts them", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([
+      [0, 100],
+      [0, 100],
+    ]);
+    vt.onReferenceViewWindowResize([
+      [0, 10],
+      [0, 10],
+    ]);
 
     // without zoom
     expect(vt.fromScreenToModelX(50)).toBeCloseTo(5);
@@ -31,8 +36,14 @@ describe("ViewportTransform", () => {
   it("maps screen bases back to model bases through inverse transforms", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([
+      [0, 100],
+      [0, 100],
+    ]);
+    vt.onReferenceViewWindowResize([
+      [0, 10],
+      [0, 10],
+    ]);
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const basis = vt.fromScreenToModelBasisX([20, 40]);
@@ -44,8 +55,14 @@ describe("ViewportTransform", () => {
   it("converts screen points to model points", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([
+      [0, 100],
+      [0, 100],
+    ]);
+    vt.onReferenceViewWindowResize([
+      [0, 10],
+      [0, 10],
+    ]);
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const x = vt.fromScreenToModelX(70);
@@ -57,8 +74,14 @@ describe("ViewportTransform", () => {
   it("round-trips between screen and model coordinates", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([
+      [0, 100],
+      [0, 100],
+    ]);
+    vt.onReferenceViewWindowResize([
+      [0, 10],
+      [0, 10],
+    ]);
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
 
     const xScreen = 70;
@@ -90,8 +113,14 @@ describe("ViewportTransform", () => {
   it("throws a helpful error when scale is zero", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([
+      [0, 100],
+      [0, 100],
+    ]);
+    vt.onReferenceViewWindowResize([
+      [0, 10],
+      [0, 10],
+    ]);
 
     vt.onZoomPan(zoomIdentity.scale(0));
     expect(() => vt.fromScreenToModelX(10)).toThrow(/not invertible/);
@@ -100,8 +129,14 @@ describe("ViewportTransform", () => {
   it("throws a helpful error when scale is near zero", () => {
     const vt = new ViewportTransform();
 
-    vt.onViewPortResize(toDirectProductBasis([0, 100], [0, 100]));
-    vt.onReferenceViewWindowResize(toDirectProductBasis([0, 10], [0, 10]));
+    vt.onViewPortResize([
+      [0, 100],
+      [0, 100],
+    ]);
+    vt.onReferenceViewWindowResize([
+      [0, 10],
+      [0, 10],
+    ]);
 
     vt.onZoomPan(zoomIdentity.scale(1e-15));
     expect(() => vt.fromScreenToModelX(10)).toThrow(/not invertible/);

--- a/svg-time-series/src/basis.ts
+++ b/svg-time-series/src/basis.ts
@@ -2,11 +2,3 @@ export type Basis = [number, number];
 export type DirectProductBasis = [Basis, Basis];
 
 export const bPlaceholder: Basis = [0, 1];
-
-export function toDirectProductBasis(bx: Basis, by: Basis): DirectProductBasis {
-  return [bx, by];
-}
-
-export function basisRange(b: Basis): number {
-  return Math.abs(b[1] - b[0]);
-}

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -3,7 +3,6 @@ import { SegmentTree } from "segment-tree-rmq";
 import { scaleLinear, type ScaleLinear } from "d3-scale";
 import type { ZoomTransform } from "d3-zoom";
 import type { Basis, DirectProductBasis } from "../basis.ts";
-import { toDirectProductBasis } from "../basis.ts";
 import { SlidingWindow } from "./slidingWindow.ts";
 import { assertFiniteNumber, assertPositiveInteger } from "./validation.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
@@ -199,7 +198,7 @@ export class ChartData {
     tree: SegmentTree<IMinMax>,
   ): DirectProductBasis {
     const bAxisVisible = this.bAxisVisible(bIndexVisible, tree);
-    return toDirectProductBasis(bIndexVisible, bAxisVisible);
+    return [bIndexVisible, bAxisVisible];
   }
 
   axisTransform(
@@ -220,7 +219,7 @@ export class ChartData {
       max = 1;
     }
     const b: Basis = [min, max];
-    const dpRef = toDirectProductBasis(this.bIndexFull, b);
+    const dpRef: DirectProductBasis = [this.bIndexFull, b];
     return { tree, min, max, dpRef };
   }
 
@@ -237,7 +236,7 @@ export class ChartData {
     const [min0, max0] = b0;
     const [min1, max1] = b1;
     const combined: Basis = [Math.min(min0, min1), Math.max(max0, max1)];
-    const dp = toDirectProductBasis(this.bIndexFull, combined);
+    const dp: DirectProductBasis = [this.bIndexFull, combined];
     return { combined, dp };
   }
 }

--- a/svg-time-series/src/chart/render/utils.ts
+++ b/svg-time-series/src/chart/render/utils.ts
@@ -1,5 +1,4 @@
 import type { Selection } from "d3-selection";
-// createDimensions no longer returns basis objects; only width and height
 
 export function createDimensions(
   svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,


### PR DESCRIPTION
## Summary
- streamline dimension creation utilities
- remove basis helpers and set scale ranges directly
- refactor viewport and data transforms to use numeric dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ed26377c832bae7ef5e7b5cfedbf