### PR TITLE
refactor: use scales for axis domains

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -1,6 +1,5 @@
 import { scaleLinear } from "d3-scale";
 import type { ScaleLinear, ScaleTime } from "d3-scale";
-import { extent } from "d3-array";
 import type { Selection } from "d3-selection";
 import type { ZoomTransform } from "d3-zoom";
 import { SegmentTree } from "segment-tree-rmq";
@@ -47,14 +46,16 @@ export class AxisModel {
     dIndex: [number, number],
     transform: ZoomTransform,
   ): void {
-    const { tree, min, max } = data.axisTransform(axisIdx, dIndex);
+    const { tree, scale } = data.axisTransform(axisIdx, dIndex);
     this.tree = tree;
-    this.transform.onReferenceViewWindowResize([data.bIndexFull, [min, max]]);
-    const full = tree.query(0, data.length - 1);
-    const [fullMin, fullMax] = extent([full.min, full.max]) as [number, number];
-    this.baseScale.domain([fullMin, fullMax]);
-    const scaled = transform.rescaleY(this.baseScale);
-    this.scale = scaled.copy();
+    const range = this.baseScale.range() as [number, number];
+    scale.range(range);
+    this.baseScale = scale;
+    this.transform.onReferenceViewWindowResize([
+      data.bIndexFull,
+      scale.domain() as [number, number],
+    ]);
+    this.scale = transform.rescaleY(scale).copy();
   }
 }
 

--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { scaleLinear } from "d3-scale";
 import type { Basis } from "../basis.ts";
 import type { IDataSource } from "./data.ts";
 import { ChartData } from "./data.ts";
@@ -413,8 +414,9 @@ describe("ChartData", () => {
     );
     const tree0 = cd.buildAxisTree(0);
     const tree1 = cd.buildAxisTree(1);
-    const combined = cd.combinedAxisDomain(cd.bIndexFull, tree0, tree1);
-    expect(combined).toEqual([-3, 10]);
+    const scale = scaleLinear<number, number>();
+    cd.combinedAxisDp(cd.bIndexFull, tree0, tree1, scale);
+    expect(scale.domain()).toEqual([-3, 10]);
   });
 
   it("throws when initial data contains infinite values", () => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -7,7 +7,6 @@ import { zoomIdentity, type ZoomTransform } from "d3-zoom";
 import { MyAxis, Orientation } from "../axis.ts";
 import { updateNode } from "../utils/domNodeTransform.ts";
 import type { Basis } from "../basis.ts";
-import { bPlaceholder, toDirectProductBasis } from "../basis.ts";
 
 import { ViewportTransform } from "../ViewportTransform.ts";
 import { AxisManager } from "./axisManager.ts";
@@ -90,8 +89,7 @@ export class RenderState {
   }
 
   public refresh(data: ChartData, transform: ZoomTransform): void {
-    const referenceBasis = toDirectProductBasis(data.bIndexFull, bPlaceholder);
-    this.xTransform.onReferenceViewWindowResize(referenceBasis);
+    this.xTransform.onReferenceViewWindowResize([data.bIndexFull, [0, 1]]);
 
     this.axisManager.setData(data);
     this.axisManager.updateScales(transform);
@@ -134,10 +132,7 @@ export class RenderState {
     const { width, height } = dimensions;
     const bScreenXVisible: Basis = [0, width];
     const bScreenYVisible: Basis = [height, 0];
-    const bScreenVisible = toDirectProductBasis(
-      bScreenXVisible,
-      bScreenYVisible,
-    );
+    const bScreenVisible: [Basis, Basis] = [bScreenXVisible, bScreenYVisible];
 
     this.axes.x.scale.range([0, width]);
     this.axes.x.axis.setScale(this.axes.x.scale);
@@ -195,7 +190,7 @@ export function setupRender(
   const { width, height } = createDimensions(svg);
   const screenXBasis: Basis = [0, width];
   const screenYBasis: Basis = [height, 0];
-  const screenBasis = toDirectProductBasis(screenXBasis, screenYBasis);
+  const screenBasis: [Basis, Basis] = [screenXBasis, screenYBasis];
   const maxAxisIdx = data.seriesAxes.reduce(
     (max, idx) => Math.max(max, idx),
     0,
@@ -211,7 +206,7 @@ export function setupRender(
   }
   axisManager.updateScales(zoomIdentity);
 
-  const referenceBasis = toDirectProductBasis(data.bIndexFull, bPlaceholder);
+  const referenceBasis: [Basis, Basis] = [data.bIndexFull, [0, 1]];
   for (const a of yAxes) {
     a.transform.onViewPortResize(screenBasis);
     a.transform.onReferenceViewWindowResize(referenceBasis);

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -67,7 +67,7 @@ describe("updateScaleY", () => {
   it("respects the supplied index window", () => {
     const cd = new ChartData(makeSource([[10], [20], [40], [5]]));
     const tree = cd.buildAxisTree(0);
-    const domain = cd.updateScaleY([1, 2], tree);
-    expect(domain).toEqual([20, 40]);
+    const scale = cd.updateScaleY([1, 2], tree);
+    expect(scale.domain()).toEqual([20, 40]);
   });
 });


### PR DESCRIPTION
## Summary
- build linear scales for Y-axis domains instead of basis arrays
- update axis and render logic to accept scales and drop DirectProductBasis helpers
- combine axis domains using d3.extent and apply to shared scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f214948c832ba5d604551a09ea52