### PR TITLE
refactor: add brush utility to clear selection

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -2,6 +2,7 @@ import type { Selection } from "d3-selection";
 import type { D3ZoomEvent } from "d3-zoom";
 import { zoomIdentity, zoomTransform } from "d3-zoom";
 import { brush, type BrushBehavior, type D3BrushEvent } from "d3-brush";
+import { clearBrushSelection } from "./draw/brushUtils.ts";
 
 import { ChartData } from "./chart/data.ts";
 import type { IDataSource } from "./chart/data.ts";
@@ -220,13 +221,6 @@ export class TimeSeriesChart {
   };
 
   private clearBrush = () => {
-    (
-      this.brushBehavior as unknown as {
-        move: (
-          selection: Selection<SVGGElement, unknown, HTMLElement, unknown>,
-          value: null,
-        ) => void;
-      }
-    ).move(this.brushLayer, null);
+    clearBrushSelection(this.brushBehavior, this.brushLayer);
   };
 }

--- a/svg-time-series/src/draw/brushUtils.ts
+++ b/svg-time-series/src/draw/brushUtils.ts
@@ -1,0 +1,21 @@
+import type { BrushBehavior } from "d3-brush";
+import type { Selection } from "d3-selection";
+
+interface BrushWithMove<Datum> extends BrushBehavior<Datum> {
+  move(
+    group: Selection<SVGGElement, Datum, HTMLElement, unknown>,
+    selection: null,
+    event?: Event,
+  ): void;
+}
+
+/**
+ * Programmatically clear a brush selection on the given layer using the
+ * `brush.move` API.
+ */
+export function clearBrushSelection(
+  brushBehavior: BrushBehavior<unknown>,
+  layer: Selection<SVGGElement, unknown, HTMLElement, unknown>,
+): void {
+  (brushBehavior as BrushWithMove<unknown>).move(layer, null);
+}


### PR DESCRIPTION
## Summary
- add `clearBrushSelection` helper wrapping `brush.move`
- use helper in TimeSeriesChart to clear brush without casts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2cc1968832b8a20616f12ea7d17