### PR TITLE
refactor: sequential scale extent validation

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -3,7 +3,6 @@ import { zoom as d3zoom, zoomIdentity, zoomTransform } from "d3-zoom";
 import type { D3ZoomEvent, ZoomBehavior, ZoomTransform } from "d3-zoom";
 import { ZoomScheduler, sameTransform } from "./zoomScheduler.ts";
 import type { RenderState } from "./render.ts";
-import { assertPositiveFinite, assertTupleSize } from "./validation.ts";
 
 export { sameTransform };
 
@@ -21,18 +20,31 @@ export class ZoomState {
       new Error(
         `scaleExtent must be two finite, positive numbers where extent[0] < extent[1]. Received: ${Array.isArray(extent) ? `[${extent.join(",")}]` : String(extent)}`,
       );
-    try {
-      assertTupleSize(extent, 2, "scaleExtent");
-      const [min, max] = extent as [unknown, unknown];
-      assertPositiveFinite(min, "scaleExtent[0]");
-      assertPositiveFinite(max, "scaleExtent[1]");
-      if (min >= max) {
-        throw error();
-      }
-      return [min, max];
-    } catch {
+
+    if (!Array.isArray(extent) || extent.length !== 2) {
       throw error();
     }
+
+    const [min, max] = extent as [unknown, unknown];
+
+    if (
+      typeof min !== "number" ||
+      typeof max !== "number" ||
+      !Number.isFinite(min) ||
+      !Number.isFinite(max)
+    ) {
+      throw error();
+    }
+
+    if (min <= 0 || max <= 0) {
+      throw error();
+    }
+
+    if (min >= max) {
+      throw error();
+    }
+
+    return [min, max];
   }
 
   constructor(

--- a/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
+++ b/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
@@ -23,6 +23,21 @@ describe("ZoomState.validateScaleExtent", () => {
     }).toThrow(/Received: \[0,2\]/);
   });
 
+  it("rejects non-number or non-finite values", () => {
+    expect(() => {
+      ZoomState.validateScaleExtent(["1", 2] as unknown);
+    }).toThrow(/Received: \[1,2\]/);
+    expect(() => {
+      ZoomState.validateScaleExtent([1, "2"] as unknown);
+    }).toThrow(/Received: \[1,2\]/);
+    expect(() => {
+      ZoomState.validateScaleExtent([NaN, 2]);
+    }).toThrow(/Received: \[NaN,2\]/);
+    expect(() => {
+      ZoomState.validateScaleExtent([1, Infinity]);
+    }).toThrow(/Received: \[1,Infinity\]/);
+  });
+
   it.each([
     [2, 1],
     [1, 1],


### PR DESCRIPTION
## Summary
- simplify scale extent validation to explicit early-return checks
- add test coverage for non-numeric and non-finite extent values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2e34354832ba8ce267d38f2bf02