### PR TITLE
refactor: extract constrainTranslation helper

### DIFF
--- a/svg-time-series/src/chart/zoomState.constrainTranslation.test.ts
+++ b/svg-time-series/src/chart/zoomState.constrainTranslation.test.ts
@@ -1,0 +1,20 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import { zoomIdentity } from "d3-zoom";
+import { constrainTranslation } from "./zoomState.ts";
+
+describe("constrainTranslation", () => {
+  it("clamps translation to bounds", () => {
+    const current = zoomIdentity.translate(-120, -80).scale(2);
+    const constrained = constrainTranslation(current, 50, 50);
+    expect(constrained).toMatchObject({ x: -50, y: -50, k: 2 });
+  });
+
+  it("returns original transform when no adjustment needed", () => {
+    const current = zoomIdentity;
+    const constrained = constrainTranslation(current, 100, 100);
+    expect(constrained).toBe(current);
+  });
+});

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -7,6 +7,20 @@ import { assertPositiveFinite, assertTupleSize } from "./validation.ts";
 
 export { sameTransform };
 
+export const constrainTranslation = (
+  current: ZoomTransform,
+  width: number,
+  height: number,
+): ZoomTransform => {
+  const x0 = current.invertX(0);
+  const x1 = current.invertX(width) - width;
+  const y0 = current.invertY(0);
+  const y1 = current.invertY(height) - height;
+  const tx = x1 > x0 ? (x0 + x1) / 2 : Math.min(0, x0) || Math.max(0, x1);
+  const ty = y1 > y0 ? (y0 + y1) / 2 : Math.min(0, y0) || Math.max(0, y1);
+  return tx !== 0 || ty !== 0 ? current.translate(tx, ty) : current;
+};
+
 export interface IZoomStateOptions {
   scaleExtent: [number, number];
 }
@@ -95,14 +109,12 @@ export class ZoomState {
       [dimensions.width, dimensions.height],
     ]);
     const current = zoomTransform(this.zoomArea.node()!);
-    const x0 = current.invertX(0);
-    const x1 = current.invertX(dimensions.width) - dimensions.width;
-    const y0 = current.invertY(0);
-    const y1 = current.invertY(dimensions.height) - dimensions.height;
-    const tx = x1 > x0 ? (x0 + x1) / 2 : Math.min(0, x0) || Math.max(0, x1);
-    const ty = y1 > y0 ? (y0 + y1) / 2 : Math.min(0, y0) || Math.max(0, y1);
-    if (tx !== 0 || ty !== 0) {
-      const constrained = current.translate(tx, ty);
+    const constrained = constrainTranslation(
+      current,
+      dimensions.width,
+      dimensions.height,
+    );
+    if (constrained !== current) {
       this.zoomBehavior.transform(this.zoomArea, constrained);
     }
   };


### PR DESCRIPTION
## Summary
- add constrainTranslation helper to compute translation bounds for zoom state
- reuse helper in updateExtents and add unit tests

## Testing
- `npm run format`
- `git commit -m "test: cover constrainTranslation"` (pre-commit with `npm run typecheck`, `vitest run`)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2e9099c832b8b7dc40d1a169b6f