### PR TITLE
fix: make DOMMatrix helpers immutable

### DIFF
--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -136,11 +136,10 @@ measureOnce(60, ({ fps }) => {
 });
 
 function test(svgNode: SVGSVGElement, viewNode: SVGGElement, width: number) {
-  const id = svgNode.createSVGMatrix();
   const scaleX = scaleLinear().domain([-550, 550]).range([0, width]);
   const scaleY = scaleLinear().domain([-550, 550]).range([0, width]);
 
-  const m = scalesToDomMatrix(scaleX, scaleY, id);
+  const m = scalesToDomMatrix(scaleX, scaleY);
 
   const newPoint = (x: number, y: number) => {
     const p = svgNode.createSVGPoint();

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -20,11 +20,7 @@ export class ViewportTransform {
   }
 
   private updateComposedMatrix() {
-    this.composedMatrix = scalesToDomMatrix(
-      this.scaleX,
-      this.scaleY,
-      new DOMMatrix(),
-    );
+    this.composedMatrix = scalesToDomMatrix(this.scaleX, this.scaleY);
   }
 
   public onViewPortResize(bScreenVisible: DirectProductBasis): this {

--- a/svg-time-series/src/utils/domMatrix.test.ts
+++ b/svg-time-series/src/utils/domMatrix.test.ts
@@ -4,34 +4,44 @@ import { Matrix } from "../setupDom.ts";
 import { scaleToDomMatrix, scalesToDomMatrix } from "./domMatrix.ts";
 
 describe("scaleToDomMatrix", () => {
-  it("creates a transform for the X axis", () => {
+  it("creates a transform for the X axis without mutating the base", () => {
     const scale = scaleLinear().domain([0, 2]).range([3, 7]);
-    const m = scaleToDomMatrix(
-      scale,
-      "x",
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const base = new Matrix() as unknown as DOMMatrix;
+    const m = scaleToDomMatrix(scale, "x", base);
+    expect(m).not.toBe(base);
+    expect(base.a).toBe(1);
+    expect(base.d).toBe(1);
+    expect(base.e).toBe(0);
+    expect(base.f).toBe(0);
     expect(m.a).toBeCloseTo(2);
     expect(m.e).toBeCloseTo(3);
   });
 
-  it("creates a transform for the Y axis", () => {
+  it("creates a transform for the Y axis without mutating the base", () => {
     const scale = scaleLinear().domain([0, 4]).range([5, 13]);
-    const m = scaleToDomMatrix(
-      scale,
-      "y",
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const base = new Matrix() as unknown as DOMMatrix;
+    const m = scaleToDomMatrix(scale, "y", base);
+    expect(m).not.toBe(base);
+    expect(base.a).toBe(1);
+    expect(base.d).toBe(1);
+    expect(base.e).toBe(0);
+    expect(base.f).toBe(0);
     expect(m.d).toBeCloseTo(2);
     expect(m.f).toBeCloseTo(5);
   });
 });
 
 describe("scalesToDomMatrix", () => {
-  it("combines independent scales", () => {
+  it("combines independent scales without mutating the base", () => {
     const sx = scaleLinear().domain([0, 2]).range([3, 7]);
     const sy = scaleLinear().domain([0, 4]).range([5, 13]);
-    const m = scalesToDomMatrix(sx, sy, new Matrix() as unknown as DOMMatrix);
+    const base = new Matrix() as unknown as DOMMatrix;
+    const m = scalesToDomMatrix(sx, sy, base);
+    expect(m).not.toBe(base);
+    expect(base.a).toBe(1);
+    expect(base.d).toBe(1);
+    expect(base.e).toBe(0);
+    expect(base.f).toBe(0);
     expect(m.a).toBeCloseTo(2);
     expect(m.d).toBeCloseTo(2);
     expect(m.e).toBeCloseTo(3);

--- a/svg-time-series/src/utils/domMatrix.ts
+++ b/svg-time-series/src/utils/domMatrix.ts
@@ -1,5 +1,10 @@
 import type { ScaleContinuousNumeric } from "d3-scale";
 
+/**
+ * Build a DOMMatrix representing the mapping from the provided domain to range
+ * along the given axis. The supplied matrix is treated as a base value and will
+ * not be modified; instead a new matrix with the transform applied is returned.
+ */
 function matrixFromDomainRange(
   domain: [number, number],
   range: [number, number],
@@ -10,13 +15,17 @@ function matrixFromDomainRange(
   const [r0, r1] = range;
   const a = (r1 - r0) / (d1 - d0);
   const b = r0 - d0 * a;
+  const m = new DOMMatrix().multiply(sm);
   return axis === "x"
-    ? sm.translate(b, 0).scale(a, 1)
-    : sm.translate(0, b).scale(1, a);
+    ? m.translateSelf(b, 0).scaleSelf(a, 1)
+    : m.translateSelf(0, b).scaleSelf(1, a);
 }
 
 /**
  * Convert a D3 scale's domain and range into a DOMMatrix along a specific axis.
+ *
+ * The returned matrix is a new instance based on `sm`; the supplied matrix is
+ * left unmodified.
  */
 export function scaleToDomMatrix(
   scale: ScaleContinuousNumeric<number, number>,
@@ -32,12 +41,14 @@ export function scaleToDomMatrix(
 }
 
 /**
- * Combine independent X and Y scales into a single DOMMatrix.
+ * Combine independent X and Y scales into a single DOMMatrix. A new matrix with
+ * both transforms applied is returned; the provided matrix is never mutated.
  */
 export function scalesToDomMatrix(
   scaleX: ScaleContinuousNumeric<number, number>,
   scaleY: ScaleContinuousNumeric<number, number>,
   sm: DOMMatrix = new DOMMatrix(),
 ): DOMMatrix {
-  return scaleToDomMatrix(scaleY, "y", scaleToDomMatrix(scaleX, "x", sm));
+  const mx = scaleToDomMatrix(scaleX, "x", sm);
+  return scaleToDomMatrix(scaleY, "y", mx);
 }

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -7,12 +7,12 @@ import { Matrix } from "./setupDom.ts";
 describe("viewZoomTransform helpers", () => {
   it("applies scale transforms along X and Y axes", () => {
     const sx = scaleLinear().domain([0, 1]).range([3, 5]);
-    const mx = scaleToDomMatrix(sx, "x", new Matrix() as unknown as DOMMatrix);
+    const mx = scaleToDomMatrix(sx, "x");
     expect(mx.a).toBeCloseTo(2);
     expect(mx.e).toBeCloseTo(3);
 
     const sy = scaleLinear().domain([0, 1]).range([4, 7]);
-    const my = scaleToDomMatrix(sy, "y", new Matrix() as unknown as DOMMatrix);
+    const my = scaleToDomMatrix(sy, "y");
     expect(my.d).toBeCloseTo(3);
     expect(my.f).toBeCloseTo(4);
   });


### PR DESCRIPTION
## Summary
- ensure DOMMatrix scale helpers return new matrices instead of mutating inputs
- document immutability and update call sites
- add tests to verify base matrices remain unchanged

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0f2f55ffc832bb0407e5b8a34c3a7