### PR TITLE
refactor: derive DOM matrices from zoom transforms

### DIFF
--- a/samples/misc/d3-pan-zoom-vwt/index.ts
+++ b/samples/misc/d3-pan-zoom-vwt/index.ts
@@ -136,11 +136,10 @@ measureOnce(60, ({ fps }) => {
 });
 
 function test(svgNode: SVGSVGElement, viewNode: SVGGElement, width: number) {
-  const id = svgNode.createSVGMatrix();
   const scaleX = scaleLinear().domain([-550, 550]).range([0, width]);
   const scaleY = scaleLinear().domain([-550, 550]).range([0, width]);
 
-  const m = scalesToDomMatrix(scaleX, scaleY, id);
+  const m = scalesToDomMatrix(scaleX, scaleY);
 
   const newPoint = (x: number, y: number) => {
     const p = svgNode.createSVGPoint();

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -20,11 +20,7 @@ export class ViewportTransform {
   }
 
   private updateComposedMatrix() {
-    this.composedMatrix = scalesToDomMatrix(
-      this.scaleX,
-      this.scaleY,
-      new DOMMatrix(),
-    );
+    this.composedMatrix = scalesToDomMatrix(this.scaleX, this.scaleY);
   }
 
   public onViewPortResize(bScreenVisible: DirectProductBasis): this {

--- a/svg-time-series/src/utils/domMatrix.test.ts
+++ b/svg-time-series/src/utils/domMatrix.test.ts
@@ -1,27 +1,19 @@
 import { describe, expect, it } from "vitest";
 import { scaleLinear } from "d3-scale";
-import { Matrix } from "../setupDom.ts";
+import "../setupDom.ts";
 import { scaleToDomMatrix, scalesToDomMatrix } from "./domMatrix.ts";
 
 describe("scaleToDomMatrix", () => {
   it("creates a transform for the X axis", () => {
     const scale = scaleLinear().domain([0, 2]).range([3, 7]);
-    const m = scaleToDomMatrix(
-      scale,
-      "x",
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const m = scaleToDomMatrix(scale, "x");
     expect(m.a).toBeCloseTo(2);
     expect(m.e).toBeCloseTo(3);
   });
 
   it("creates a transform for the Y axis", () => {
     const scale = scaleLinear().domain([0, 4]).range([5, 13]);
-    const m = scaleToDomMatrix(
-      scale,
-      "y",
-      new Matrix() as unknown as DOMMatrix,
-    );
+    const m = scaleToDomMatrix(scale, "y");
     expect(m.d).toBeCloseTo(2);
     expect(m.f).toBeCloseTo(5);
   });
@@ -31,7 +23,7 @@ describe("scalesToDomMatrix", () => {
   it("combines independent scales", () => {
     const sx = scaleLinear().domain([0, 2]).range([3, 7]);
     const sy = scaleLinear().domain([0, 4]).range([5, 13]);
-    const m = scalesToDomMatrix(sx, sy, new Matrix() as unknown as DOMMatrix);
+    const m = scalesToDomMatrix(sx, sy);
     expect(m.a).toBeCloseTo(2);
     expect(m.d).toBeCloseTo(2);
     expect(m.e).toBeCloseTo(3);

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -7,12 +7,12 @@ import { Matrix } from "./setupDom.ts";
 describe("viewZoomTransform helpers", () => {
   it("applies scale transforms along X and Y axes", () => {
     const sx = scaleLinear().domain([0, 1]).range([3, 5]);
-    const mx = scaleToDomMatrix(sx, "x", new Matrix() as unknown as DOMMatrix);
+    const mx = scaleToDomMatrix(sx, "x");
     expect(mx.a).toBeCloseTo(2);
     expect(mx.e).toBeCloseTo(3);
 
     const sy = scaleLinear().domain([0, 1]).range([4, 7]);
-    const my = scaleToDomMatrix(sy, "y", new Matrix() as unknown as DOMMatrix);
+    const my = scaleToDomMatrix(sy, "y");
     expect(my.d).toBeCloseTo(3);
     expect(my.f).toBeCloseTo(4);
   });


### PR DESCRIPTION
## Summary
- derive DOM matrices from d3-zoom transforms instead of manual translations
- compose X/Y scale matrices in one step
- update ViewportTransform and callers for new API

## Testing
- `npm test`
- `npm run bench` *(fails: process ended while waiting for file changes)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f41f3c6c832b968b6ae9880f1f06