### PR TITLE
refactor: call brush move directly

### DIFF
--- a/svg-time-series/src/draw/brushUtils.ts
+++ b/svg-time-series/src/draw/brushUtils.ts
@@ -1,14 +1,6 @@
 import type { BrushBehavior } from "d3-brush";
 import type { Selection } from "d3-selection";
 
-interface BrushWithMove<Datum> extends BrushBehavior<Datum> {
-  move(
-    group: Selection<SVGGElement, Datum, HTMLElement, unknown>,
-    selection: null,
-    event?: Event,
-  ): void;
-}
-
 /**
  * Programmatically clear a brush selection on the given layer using the
  * `brush.move` API.
@@ -17,5 +9,5 @@ export function clearBrushSelection(
   brushBehavior: BrushBehavior<unknown>,
   layer: Selection<SVGGElement, unknown, HTMLElement, unknown>,
 ): void {
-  (brushBehavior as BrushWithMove<unknown>).move(layer, null);
+  brushBehavior.move(layer, null);
 }


### PR DESCRIPTION
## Summary
- delete `BrushWithMove` and cast in brush utils
- call `brushBehavior.move` directly to clear selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fcdbdcbc832bb5c334e0b7ba2e9e