### PR TITLE
refactor: streamline axis rescale logic

### DIFF
--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -26,7 +26,6 @@ describe("AxisManager", () => {
     );
     axisManager.axes.forEach((a) => {
       a.scale.range([0, 1]);
-      a.baseScale.range([0, 1]);
     });
     const spy = vi.spyOn(data, "assertAxisBounds");
     expect(() => {
@@ -45,7 +44,6 @@ describe("AxisManager", () => {
     );
     axisManager.axes.forEach((a) => {
       a.scale.range([0, 1]);
-      a.baseScale.range([0, 1]);
     });
     const spy = vi.spyOn(data, "assertAxisBounds");
     expect(() => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -145,7 +145,6 @@ export class RenderState {
     for (const a of this.axes.y) {
       a.transform.onViewPortResize(bScreenVisible);
       a.scale.range([height, 0]);
-      a.baseScale.range([height, 0]);
     }
   }
 
@@ -202,7 +201,6 @@ export function setupRender(
   const yAxes = axisManager.axes;
   for (const a of yAxes) {
     a.scale.range([height, 0]);
-    a.baseScale.range([height, 0]);
   }
   axisManager.updateScales(zoomIdentity);
 


### PR DESCRIPTION
## Summary
- simplify AxisModel update flow by cloning scale range and rescaling without a baseScale
- rescale X axis directly with transform.rescaleX
- drop baseScale usage from render workflow and update tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fcc20c10832bb842cd773eda5ba8