### PR TITLE
feat(chart): use nice Y scale

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect } from "vitest";
-import { scaleLinear } from "d3-scale";
 import type { Basis } from "../basis.ts";
 import type { IDataSource } from "./data.ts";
 import { ChartData } from "./data.ts";
@@ -294,8 +293,8 @@ describe("ChartData", () => {
     const range: Basis = [0, 2];
     const tree0 = cd.buildAxisTree(0);
     const tree1 = cd.buildAxisTree(1);
-    expect(cd.bAxisVisible(range, tree0)).toEqual([10, 50]);
-    expect(cd.bAxisVisible(range, tree1)).toEqual([20, 60]);
+    expect(cd.scaleY(range, tree0).domain()).toEqual([10, 50]);
+    expect(cd.scaleY(range, tree1).domain()).toEqual([20, 60]);
   });
 
   it("floors and ceils fractional bounds when computing temperature visibility", () => {
@@ -313,8 +312,8 @@ describe("ChartData", () => {
     const tree1 = cd.buildAxisTree(1);
 
     const fractionalRange: Basis = [0.49, 1.49];
-    expect(cd.bAxisVisible(fractionalRange, tree0)).toEqual([10, 50]);
-    expect(cd.bAxisVisible(fractionalRange, tree1)).toEqual([20, 60]);
+    expect(cd.scaleY(fractionalRange, tree0).domain()).toEqual([10, 50]);
+    expect(cd.scaleY(fractionalRange, tree1).domain()).toEqual([20, 60]);
   });
 
   it("handles fractional bounds in the middle of the dataset", () => {
@@ -332,8 +331,8 @@ describe("ChartData", () => {
     const tree1 = cd.buildAxisTree(1);
 
     const fractionalRange: Basis = [1.1, 1.7];
-    expect(cd.bAxisVisible(fractionalRange, tree0)).toEqual([30, 50]);
-    expect(cd.bAxisVisible(fractionalRange, tree1)).toEqual([40, 60]);
+    expect(cd.scaleY(fractionalRange, tree0).domain()).toEqual([30, 50]);
+    expect(cd.scaleY(fractionalRange, tree1).domain()).toEqual([40, 60]);
   });
 
   it("clamps bounds that extend past the data range", () => {
@@ -351,10 +350,10 @@ describe("ChartData", () => {
     const tree1 = cd.buildAxisTree(1);
 
     const outOfRange: Basis = [-0.5, 3.5];
-    expect(() => cd.bAxisVisible(outOfRange, tree0)).not.toThrow();
-    expect(() => cd.bAxisVisible(outOfRange, tree1)).not.toThrow();
-    expect(cd.bAxisVisible(outOfRange, tree0)).toEqual([10, 50]);
-    expect(cd.bAxisVisible(outOfRange, tree1)).toEqual([20, 60]);
+    expect(() => cd.scaleY(outOfRange, tree0)).not.toThrow();
+    expect(() => cd.scaleY(outOfRange, tree1)).not.toThrow();
+    expect(cd.scaleY(outOfRange, tree0).domain()).toEqual([10, 50]);
+    expect(cd.scaleY(outOfRange, tree1).domain()).toEqual([20, 60]);
   });
 
   it("clamps bounds completely to the left of the data range", () => {
@@ -372,10 +371,10 @@ describe("ChartData", () => {
     const tree1 = cd.buildAxisTree(1);
 
     const leftRange: Basis = [-5, -1];
-    expect(() => cd.bAxisVisible(leftRange, tree0)).not.toThrow();
-    expect(() => cd.bAxisVisible(leftRange, tree1)).not.toThrow();
-    expect(cd.bAxisVisible(leftRange, tree0)).toEqual([10, 10]);
-    expect(cd.bAxisVisible(leftRange, tree1)).toEqual([20, 20]);
+    expect(() => cd.scaleY(leftRange, tree0)).not.toThrow();
+    expect(() => cd.scaleY(leftRange, tree1)).not.toThrow();
+    expect(cd.scaleY(leftRange, tree0).domain()).toEqual([10, 10]);
+    expect(cd.scaleY(leftRange, tree1).domain()).toEqual([20, 20]);
   });
 
   it("clamps bounds completely to the right of the data range", () => {
@@ -393,10 +392,10 @@ describe("ChartData", () => {
     const tree1 = cd.buildAxisTree(1);
 
     const rightRange: Basis = [5, 10];
-    expect(() => cd.bAxisVisible(rightRange, tree0)).not.toThrow();
-    expect(() => cd.bAxisVisible(rightRange, tree1)).not.toThrow();
-    expect(cd.bAxisVisible(rightRange, tree0)).toEqual([50, 50]);
-    expect(cd.bAxisVisible(rightRange, tree1)).toEqual([60, 60]);
+    expect(() => cd.scaleY(rightRange, tree0)).not.toThrow();
+    expect(() => cd.scaleY(rightRange, tree1)).not.toThrow();
+    expect(cd.scaleY(rightRange, tree0).domain()).toEqual([50, 50]);
+    expect(cd.scaleY(rightRange, tree1).domain()).toEqual([60, 60]);
   });
 
   it("computes combined temperature basis and direct product", () => {
@@ -412,8 +411,7 @@ describe("ChartData", () => {
     );
     const tree0 = cd.buildAxisTree(0);
     const tree1 = cd.buildAxisTree(1);
-    const scale = scaleLinear<number, number>();
-    cd.combinedAxisDp(cd.bIndexFull, tree0, tree1, scale);
+    const scale = cd.combinedAxisDp(cd.bIndexFull, tree0, tree1);
     expect(scale.domain()).toEqual([-3, 10]);
   });
 

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -120,7 +120,7 @@ describe("RenderState.refresh", () => {
     state.refresh(data, zoomIdentity);
 
     expect(state.axes.y).toHaveLength(1);
-    expect(state.axes.y[0]!.scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y[0]!.scale.domain()).toEqual([0, 30]);
   });
 
   it("refreshes after data changes", () => {

--- a/svg-time-series/src/chart/render.utils.test.ts
+++ b/svg-time-series/src/chart/render.utils.test.ts
@@ -55,7 +55,7 @@ describe("createDimensions", () => {
   });
 });
 
-describe("updateScaleY", () => {
+describe("scaleY", () => {
   const makeSource = (data: number[][]): IDataSource => ({
     startTime: 0,
     timeStep: 1,
@@ -67,7 +67,7 @@ describe("updateScaleY", () => {
   it("respects the supplied index window", () => {
     const cd = new ChartData(makeSource([[10], [20], [40], [5]]));
     const tree = cd.buildAxisTree(0);
-    const scale = cd.updateScaleY([1, 2], tree);
+    const scale = cd.scaleY([1, 2], tree);
     expect(scale.domain()).toEqual([20, 40]);
   });
 });

--- a/svg-time-series/src/chart/render.yAxis.test.ts
+++ b/svg-time-series/src/chart/render.yAxis.test.ts
@@ -41,7 +41,7 @@ describe("setupRender Y-axis modes", () => {
     const data = new ChartData(source);
     const state = setupRender(svg, data);
     expect(state.axes.y).toHaveLength(1);
-    expect(state.axes.y[0]!.scale.domain()).toEqual([1, 30]);
+    expect(state.axes.y[0]!.scale.domain()).toEqual([0, 30]);
   });
 
   it("separates scales when series use different axes", () => {


### PR DESCRIPTION
## Summary
- consolidate Y-scale computations into a single helper returning a `nice()`d `scaleLinear`
- update axis handling to leverage new helper
- adjust tests for padded Y-axis domains

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0fcd6e69c832ba2a3ee095779351e