### PR TITLE
Cache segment trees to speed axis transforms

### DIFF
--- a/svg-time-series/bench/axisTransform.bench.ts
+++ b/svg-time-series/bench/axisTransform.bench.ts
@@ -1,0 +1,26 @@
+import { bench, describe } from "vitest";
+import { ChartData } from "../src/chart/data.ts";
+import type { IDataSource } from "../src/chart/data.ts";
+import { sizes, datasets } from "./timeSeriesData.ts";
+
+describe("axisTransform performance", () => {
+  sizes.forEach((size, idx) => {
+    const dataset = datasets[idx]!.map((d) => [d[1]]);
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: dataset.length,
+      seriesAxes: [0],
+      getSeries: (i) => dataset[i]![0]!,
+    };
+    const cd = new ChartData(source);
+    const dIndex: [number, number] = [0, size - 1];
+    bench(`cached size ${String(size)}`, () => {
+      cd.axisTransform(0, dIndex);
+    });
+    bench(`rebuild size ${String(size)}`, () => {
+      const tree = cd.buildAxisTree(0);
+      cd.updateScaleY(dIndex, tree);
+    });
+  });
+});

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -82,6 +82,23 @@ export class AxisManager {
     this.x = scale;
   }
 
+  appendData(...values: number[]): void {
+    this.data.append(...values);
+    this.axes.forEach((_, axisIdx) => {
+      const seriesIdxs = this.data.seriesByAxis[axisIdx] ?? [];
+      if (seriesIdxs.length === 0) {
+        return;
+      }
+      const mm = seriesIdxs
+        .map((j) => {
+          const v = values[j]!;
+          return Number.isFinite(v) ? { min: v, max: v } : minMaxIdentity;
+        })
+        .reduce(buildMinMax, minMaxIdentity);
+      this.data.updateTree(axisIdx, mm);
+    });
+  }
+
   updateScales(transform: ZoomTransform): void {
     this.data.assertAxisBounds(this.axes.length);
     this.x.domain(this.data.timeDomainFull());

--- a/svg-time-series/src/chart/render.integration.test.ts
+++ b/svg-time-series/src/chart/render.integration.test.ts
@@ -52,7 +52,7 @@ describe("RenderState.refresh integration", () => {
     const yNyBefore = state.axes.y[0]!.scale.domain().slice();
     const ySfBefore = state.axes.y[1]!.scale.domain().slice();
 
-    data.append(100, 200);
+    state.axisManager.appendData(100, 200);
     state.refresh(data, zoomIdentity);
 
     const yNyAfter = state.axes.y[0]!.scale.domain();

--- a/svg-time-series/src/chart/render.refresh.test.ts
+++ b/svg-time-series/src/chart/render.refresh.test.ts
@@ -167,7 +167,7 @@ describe("RenderState.refresh", () => {
 
     expect(state.axes.y[0]!.tree.query(0, 2)).toEqual({ min: 1, max: 3 });
 
-    data.append(4);
+    state.axisManager.appendData(4);
     state.refresh(data, zoomIdentity);
 
     expect(state.axes.y[0]!.tree.query(0, 2)).toEqual({ min: 2, max: 4 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -126,7 +126,7 @@ export class TimeSeriesChart {
   }
 
   public updateChartWithNewData(...values: number[]): void {
-    this.data.append(...values);
+    this.state.axisManager.appendData(...values);
     this.refreshAll();
   }
 


### PR DESCRIPTION
## Summary
- cache SegmentTree per axis in ChartData and update them on data append
- reuse cached trees in axisTransform and propagate updates via AxisManager
- add benchmark comparing cached axisTransform vs full rebuild

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbb90098832bbbe98cfa34d89778