### PR TITLE
fix: clean up brush on dispose

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -136,6 +136,8 @@ export class TimeSeriesChart {
       .on("mousemove", null)
       .on("mouseleave", null)
       .on(".zoomCursor", null);
+    this.brushBehavior.on("end", null);
+    this.brushLayer.on(".brush", null).remove();
     this.state.destroy();
     this.zoomArea.remove();
     this.legendController.destroy();

--- a/svg-time-series/test/dispose.test.ts
+++ b/svg-time-series/test/dispose.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+
+vi.mock("../src/utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
+vi.mock("../src/chart/zoomState.ts", () => {
+  return {
+    ZoomState: vi.fn().mockImplementation(() => ({
+      refresh: vi.fn(),
+      destroy: vi.fn(),
+      setScaleExtent: vi.fn(),
+      zoom: vi.fn(),
+      reset: vi.fn(),
+      updateExtents: vi.fn(),
+      zoomBehavior: { transform: vi.fn() },
+    })),
+  };
+});
+
+import { TimeSeriesChart, type IDataSource } from "../src/draw.ts";
+import { polyfillDom } from "../src/setupDom.ts";
+polyfillDom();
+
+function createLegend() {
+  return {
+    init: vi.fn(),
+    highlightIndex: vi.fn(),
+    refresh: vi.fn(),
+    clearHighlight: vi.fn(),
+    destroy: vi.fn(),
+  };
+}
+
+function createChart() {
+  const legend = createLegend();
+  const div = document.createElement("div");
+  Object.defineProperty(div, "clientWidth", { value: 100 });
+  Object.defineProperty(div, "clientHeight", { value: 50 });
+  const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  div.appendChild(svgEl);
+
+  const dataRows = [[1], [2], [3]];
+  const source: IDataSource = {
+    startTime: 0,
+    timeStep: 1,
+    length: dataRows.length,
+    seriesAxes: [0],
+    getSeries: (i, seriesIdx) => dataRows[i]![seriesIdx]!,
+  };
+
+  const chart = new TimeSeriesChart(
+    select(svgEl) as unknown as Selection<
+      SVGSVGElement,
+      unknown,
+      HTMLElement,
+      unknown
+    >,
+    source,
+    legend,
+  );
+
+  return { chart, svgEl };
+}
+
+describe("TimeSeriesChart dispose", () => {
+  it("removes zoom and brush elements", () => {
+    const { chart, svgEl } = createChart();
+
+    expect(svgEl.querySelector(".zoom-overlay")).not.toBeNull();
+    expect(svgEl.querySelector(".brush-layer")).not.toBeNull();
+
+    chart.dispose();
+
+    expect(svgEl.querySelector(".zoom-overlay")).toBeNull();
+    expect(svgEl.querySelector(".brush-layer")).toBeNull();
+  });
+});

--- a/svg-time-series/tsconfig.test.json
+++ b/svg-time-series/tsconfig.test.json
@@ -1,5 +1,5 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["src/**/*.ts", "../test/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "../test/**/*.ts"],
   "exclude": ["**/*.bench.ts"]
 }


### PR DESCRIPTION
## Summary
- clean up brush listeners and layer when disposing chart
- cover dispose behavior with regression test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0fba76068832b832fd355235c6b15