### PR TITLE
Only zoom X axis, auto-fit Y extent

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -27,7 +27,7 @@ describe("ViewportTransform", () => {
     // apply zoom: translate 10 and scale 2
     vt.onZoomPan(zoomIdentity.translate(10, 0).scale(2));
     expect(vt.fromScreenToModelX(70)).toBeCloseTo(3);
-    expect(vt.fromScreenToModelY(20)).toBeCloseTo(1);
+    expect(vt.fromScreenToModelY(20)).toBeCloseTo(2);
   });
 
   it("maps screen bases back to model bases through inverse transforms", () => {
@@ -53,7 +53,7 @@ describe("ViewportTransform", () => {
     const x = vt.fromScreenToModelX(70);
     const y = vt.fromScreenToModelY(20);
     expect(x).toBeCloseTo(3);
-    expect(y).toBeCloseTo(1);
+    expect(y).toBeCloseTo(2);
   });
 
   it("round-trips between screen and model coordinates", () => {

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -15,7 +15,9 @@ export class ViewportTransform {
 
   private updateScales() {
     this.scaleX = this.zoomTransform.rescaleX(this.baseScaleX);
-    this.scaleY = this.zoomTransform.rescaleY(this.baseScaleY);
+    // Ignore the zoom transform for the Y axis so that it always fits the data
+    // based on its current domain.
+    this.scaleY = this.baseScaleY.copy();
     this.updateComposedMatrix();
   }
 

--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -51,4 +51,34 @@ describe("AxisManager", () => {
     }).not.toThrow();
     expect(spy).toHaveBeenCalledWith(2);
   });
+
+  it("fits the Y domain to the visible data on zoom", () => {
+    const data = new ChartData({
+      startTime: 0,
+      timeStep: 1,
+      length: 10,
+      seriesAxes: [0],
+      getSeries: (i) => i,
+    });
+    const axisManager = new AxisManager(1, data);
+    axisManager.setXAxis(
+      scaleTime()
+        .domain([new Date(0), new Date(9)])
+        .range([0, 100]),
+    );
+    axisManager.axes[0]!.scale.range([100, 0]);
+
+    const t = zoomIdentity.scale(2);
+    axisManager.updateScales(t);
+
+    const indexScale = data.bIndexFromTransform(
+      t,
+      axisManager.x.range() as [number, number],
+    );
+    const expectedDomain = data
+      .axisTransform(0, indexScale.domain() as [number, number])
+      .scale.domain();
+
+    expect(axisManager.axes[0]!.scale.domain()).toEqual(expectedDomain);
+  });
 });

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -42,17 +42,16 @@ export class AxisModel {
     data: ChartData,
     axisIdx: number,
     dIndex: [number, number],
-    transform: ZoomTransform,
   ): void {
     const { tree, scale: scaleRaw } = data.axisTransform(axisIdx, dIndex);
     this.tree = tree;
     const scale = scaleRaw.copy().range(this.scale.range() as [number, number]);
-    const rescaled = transform.rescaleY(scale);
     this.transform.onReferenceViewWindowResize([
       data.bIndexFull,
       scale.domain() as [number, number],
     ]);
-    this.scale = rescaled.copy();
+    // Apply the scale directly so the Y axis always fits the visible data.
+    this.scale = scale.copy();
   }
 }
 
@@ -97,7 +96,6 @@ export class AxisManager {
         this.data,
         i,
         indexScale.domain() as [number, number],
-        transform,
       );
     });
   }


### PR DESCRIPTION
## Summary
- Prevent `ViewportTransform` from scaling the Y axis during zoom so it always fits data
- Remove Y rescaling from `AxisModel` to compute Y domain from visible data only
- Adjust tests and add coverage for Y-axis auto fitting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1039627ac832b8d736839c499999b