### PR TITLE
feat: throttle legend highlight updates

### DIFF
--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -28,6 +28,7 @@ function createLegend() {
   return {
     init: vi.fn(),
     highlightIndex: vi.fn(),
+    highlightIndexRaf: vi.fn(),
     refresh: vi.fn(),
     clearHighlight: vi.fn(),
     destroy: vi.fn(),
@@ -146,9 +147,10 @@ describe("TimeSeriesChart", () => {
 
     chart.onHover(5);
 
-    expect(legend.highlightIndex).toHaveBeenCalledWith(
+    expect(legend.highlightIndexRaf).toHaveBeenCalledWith(
       internal.data.length - 1,
     );
+    expect(legend.highlightIndex).not.toHaveBeenCalled();
   });
 
   it("forwards scale extent to zoom state", () => {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -186,7 +186,14 @@ export class TimeSeriesChart {
   public onHover = (x: number) => {
     let idx = Math.round(this.state.screenToModelX(x));
     idx = this.data.clampIndex(idx);
-    this.legendController.highlightIndex(idx);
+    const legend = this.legendController as ILegendController & {
+      highlightIndexRaf?: (idx: number) => void;
+    };
+    if (legend.highlightIndexRaf) {
+      legend.highlightIndexRaf(idx);
+    } else {
+      legend.highlightIndex(idx);
+    }
   };
 
   private refreshAll(): void {


### PR DESCRIPTION
## Summary
- batch legend DOM updates using `drawProc`
- add `highlightIndexRaf` and wrap legend refresh in rAF
- use throttled highlight in `TimeSeriesChart` hover handler

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1055169ac832b8bfbc194c9cc34b4