### PR TITLE
refactor: schedule resize refresh

### DIFF
--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -175,8 +175,12 @@ describe("chart interaction single-axis", () => {
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
 
-    zoom({ transform: { x: 10, k: 2 } } as Parameters<typeof zoom>[0]);
+    zoom({
+      transform: { x: 10, k: 2 },
+      sourceEvent: new Event("wheel"),
+    } as Parameters<typeof zoom>[0]);
     vi.runAllTimers();
+    zoom({ transform: { x: 10, k: 2 } } as Parameters<typeof zoom>[0]);
     vi.runAllTimers();
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -186,9 +186,14 @@ describe("chart interaction", () => {
 
     const event = {
       transform: { x: 10, k: 2 },
+      sourceEvent: new Event("wheel"),
     } as D3ZoomEvent<SVGRectElement, unknown>;
     zoom(event);
     vi.runAllTimers();
+    zoom({ transform: { x: 10, k: 2 } } as D3ZoomEvent<
+      SVGRectElement,
+      unknown
+    >);
     vi.runAllTimers();
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -36,6 +36,7 @@ polyfillDom();
 describe("TimeSeriesChart.resize", () => {
   it("updates axes, paths, and legend", () => {
     const renderSpy = vi.spyOn(SeriesRenderer.prototype, "draw");
+    vi.useFakeTimers();
 
     const div = document.createElement("div");
     Object.defineProperty(div, "clientWidth", { value: 100 });
@@ -75,12 +76,14 @@ describe("TimeSeriesChart.resize", () => {
     const chartInternal = chart as unknown as ChartInternal;
     const zoomRefreshSpy = vi.spyOn(chartInternal.zoomState, "refresh");
 
+    vi.runAllTimers();
     renderSpy.mockClear();
     axisInstances.forEach((a) => a.axisUp.mockClear());
     legend.refresh.mockClear();
     zoomRefreshSpy.mockClear();
 
     chart.resize({ width: 200, height: 150 });
+    vi.runAllTimers();
 
     axisInstances.forEach((a) => {
       expect(a.axisUp).toHaveBeenCalled();
@@ -88,6 +91,7 @@ describe("TimeSeriesChart.resize", () => {
     expect(renderSpy).toHaveBeenCalled();
     expect(legend.refresh).toHaveBeenCalled();
     expect(zoomRefreshSpy).toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("uses explicit dimensions for zoom extents and axes", () => {

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -8,14 +8,19 @@ import { select } from "d3-selection";
 vi.mock("./utils/domNodeTransform.ts", () => ({ updateNode: vi.fn() }));
 vi.mock("./chart/zoomState.ts", () => {
   return {
-    ZoomState: vi.fn().mockImplementation(() => ({
-      refresh: vi.fn(),
-      destroy: vi.fn(),
-      setScaleExtent: vi.fn(),
-      zoom: vi.fn(),
-      reset: vi.fn(),
-      updateExtents: vi.fn(),
-    })),
+    ZoomState: vi.fn().mockImplementation((...args: unknown[]) => {
+      const refreshChart = args[2] as () => void;
+      return {
+        refresh: vi.fn(() => {
+          refreshChart();
+        }),
+        destroy: vi.fn(),
+        setScaleExtent: vi.fn(),
+        zoom: vi.fn(),
+        reset: vi.fn(),
+        updateExtents: vi.fn(),
+      };
+    }),
   };
 });
 
@@ -129,10 +134,10 @@ describe("TimeSeriesChart", () => {
       { width: 200, height: 150 },
       zoomInstance,
     );
-    expect(refreshSpy).toHaveBeenCalled();
-    expect(drawSpy).toHaveBeenCalled();
-    expect(zoomRefreshSpy).toHaveBeenCalled();
-    expect(legendRefreshSpy).toHaveBeenCalled();
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(drawSpy).toHaveBeenCalledTimes(1);
+    expect(zoomRefreshSpy).toHaveBeenCalledTimes(1);
+    expect(legendRefreshSpy).toHaveBeenCalledTimes(1);
   });
 
   it("clamps hover index and forwards to legend", () => {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -100,11 +100,12 @@ export class TimeSeriesChart {
       this.state,
       () => {
         const t = zoomTransform(this.zoomArea.node()!);
+        this.state.seriesRenderer.draw(this.data.data);
         this.state.refresh(this.data, t);
+        this.legendController.refresh();
       },
       (event) => {
         zoomHandler(event);
-        this.legendController.refresh();
       },
       zoomOptions,
     );
@@ -173,14 +174,12 @@ export class TimeSeriesChart {
     const { width, height } = dimensions;
     this.svg.attr("width", width).attr("height", height);
     this.state.resize(dimensions, this.zoomState);
-    const t = zoomTransform(this.zoomArea.node()!);
-    this.state.refresh(this.data, t);
     this.brushBehavior.extent([
       [0, 0],
       [width, height],
     ]);
     this.brushLayer.call(this.brushBehavior);
-    this.refreshAll();
+    this.zoomState.refresh();
   };
 
   public onHover = (x: number) => {
@@ -190,9 +189,7 @@ export class TimeSeriesChart {
   };
 
   private refreshAll(): void {
-    this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
-    this.legendController.refresh();
   }
 
   private onBrushEnd = (event: D3BrushEvent<unknown>) => {


### PR DESCRIPTION
## Summary
- schedule a single refresh on resize via ZoomState
- draw chart within ZoomState refresh callback and remove direct legend refresh
- adjust interaction and resize tests for scheduled refresh behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10568d0ac832bb5cda94a95431116