### PR TITLE
feat: cache segment trees until new data arrives

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -524,4 +524,22 @@ describe("ChartData", () => {
       timestamp: 2,
     });
   });
+
+  it("reuses axis trees until new data arrives", () => {
+    const cd = new ChartData(
+      makeSource(
+        [
+          [0, 10],
+          [1, 20],
+        ],
+        [0, 1],
+      ),
+    );
+    const treeA = cd.buildAxisTree(0);
+    const treeB = cd.buildAxisTree(0);
+    expect(treeA).toBe(treeB);
+    cd.append(2, 30);
+    const treeC = cd.buildAxisTree(0);
+    expect(treeC).not.toBe(treeA);
+  });
 });


### PR DESCRIPTION
## Summary
- cache segment trees per axis so they rebuild only after new samples
- add regression test for segment tree caching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10702d7b0832bae42c66fc0b996c0