### PR TITLE
fix: use horizontal brush for zoom selection

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -1,7 +1,7 @@
 import type { Selection } from "d3-selection";
 import type { D3ZoomEvent } from "d3-zoom";
 import { zoomIdentity, zoomTransform } from "d3-zoom";
-import { brush, type BrushBehavior, type D3BrushEvent } from "d3-brush";
+import { brushX, type BrushBehavior, type D3BrushEvent } from "d3-brush";
 import { clearBrushSelection } from "./draw/brushUtils.ts";
 
 import { ChartData } from "./chart/data.ts";
@@ -61,7 +61,7 @@ export class TimeSeriesChart {
       .attr("fill", "none")
       .style("pointer-events", "all");
 
-    this.brushBehavior = brush()
+    this.brushBehavior = brushX()
       .extent([
         [0, 0],
         [width, height],
@@ -203,7 +203,7 @@ export class TimeSeriesChart {
     if (!event.selection) {
       return;
     }
-    let [[x0], [x1]] = event.selection as [[number, number], [number, number]];
+    let [x0, x1] = event.selection as [number, number];
     if (x0 === x1) {
       this.clearBrush();
       return;


### PR DESCRIPTION
## Summary
- use d3 `brushX` so zoom brush spans the chart vertically and selects only a horizontal interval
- adjust brush end logic to process `[x0, x1]` selections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10c537424832bb054d98f709c5723