### PR TITLE
feat: schedule pan zoom callbacks per frame

### DIFF
--- a/svg-time-series/src/chart/zoomScheduler.test.ts
+++ b/svg-time-series/src/chart/zoomScheduler.test.ts
@@ -39,11 +39,10 @@ describe("ZoomScheduler", () => {
     expect(zs.zoom({ x: 1, k: 2 } as unknown as ZoomTransform, null)).toBe(
       true,
     );
-    expect(apply).toHaveBeenCalledTimes(1);
-
     expect(zs.zoom({ x: 5, k: 3 } as unknown as ZoomTransform, null)).toBe(
       false,
     );
+    vi.runAllTimers();
     expect(apply).toHaveBeenCalledTimes(1);
   });
 

--- a/svg-time-series/src/chart/zoomState.destroy.test.ts
+++ b/svg-time-series/src/chart/zoomState.destroy.test.ts
@@ -22,10 +22,16 @@ vi.mock("d3-zoom", () => {
         selection: Selection<Element, unknown, Element, unknown>,
       ) => {
         selection.on("wheel.zoom", (event: Event) =>
-          behavior._handler?.(event),
+          behavior._handler?.({
+            transform: { x: 0, k: 1 },
+            sourceEvent: event,
+          }),
         );
         selection.on("pointerdown.zoom", (event: Event) =>
-          behavior._handler?.(event),
+          behavior._handler?.({
+            transform: { x: 0, k: 1 },
+            sourceEvent: event,
+          }),
         );
       };
       behavior.scaleExtent = () => behavior;
@@ -81,12 +87,14 @@ describe("ZoomState.destroy", () => {
     );
 
     rect.node()?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    vi.runAllTimers();
     expect(zoomCb).toHaveBeenCalled();
 
     zoomCb.mockClear();
     zs.destroy();
     rect.node()?.dispatchEvent(new Event("wheel", { bubbles: true }));
     rect.node()?.dispatchEvent(new Event("pointerdown", { bubbles: true }));
+    vi.runAllTimers();
     expect(zoomCb).not.toHaveBeenCalled();
   });
 

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -90,10 +90,9 @@ export class ZoomState {
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.state.applyZoomTransform(event.transform);
-    if (!this.zoomScheduler.zoom(event.transform, event.sourceEvent)) {
-      return;
-    }
-    this.zoomCallback(event);
+    this.zoomScheduler.zoom(event.transform, event.sourceEvent, event, (e) => {
+      this.zoomCallback(e as D3ZoomEvent<SVGRectElement, unknown>);
+    });
   };
 
   public refresh = () => {

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -127,6 +127,7 @@ describe("ZoomState.updateExtents clamp", () => {
 
     const initial = zoomIdentity.translate(-120, -80).scale(2);
     zs.zoomBehavior.transform(rect, initial);
+    vi.runAllTimers();
     const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     expect(applyZoomTransform).toHaveBeenCalledWith(initial);
     transformSpy.mockClear();
@@ -138,7 +139,7 @@ describe("ZoomState.updateExtents clamp", () => {
       rect,
       expect.objectContaining({ x: -50, y: -50, k: 2 }),
     );
-    expect(transformSpy).toHaveBeenCalledTimes(2);
+    expect(transformSpy).toHaveBeenCalledTimes(1);
     expect(zoomTransform(rect.node()!)).toMatchObject({ x: -50, y: -50, k: 2 });
   });
 });


### PR DESCRIPTION
## Summary
- queue pan/zoom callbacks in `ZoomScheduler` and fire once per animation frame
- delegate zoom callback handling to `ZoomScheduler` from `ZoomState`
- ensure tests expect a single callback per frame and add rapid event test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10cdb13d4832b88082fcd5181e5e3