### PR TITLE
fix: throttle axis transform updates to once per frame

### DIFF
--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -650,6 +650,7 @@ describe("ZoomState", () => {
       x: 0,
       y: 0,
     } as unknown as ZoomTransform);
+    vi.runAllTimers();
     expect(applyZoomTransform).toHaveBeenCalledWith({ k: 10, x: 0, y: 0 });
     const scaleSpy = vi.spyOn(zs.zoomBehavior, "scaleTo");
     scaleSpy.mockClear();
@@ -686,6 +687,7 @@ describe("ZoomState", () => {
       x: 0,
       y: 0,
     } as unknown as ZoomTransform);
+    vi.runAllTimers();
     expect(applyZoomTransform).toHaveBeenCalledWith({ k: 0.2, x: 0, y: 0 });
     const scaleSpy = vi.spyOn(zs.zoomBehavior, "scaleTo");
     scaleSpy.mockClear();

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -127,6 +127,7 @@ describe("ZoomState.updateExtents clamp", () => {
 
     const initial = zoomIdentity.translate(-120, -80).scale(2);
     zs.zoomBehavior.transform(rect, initial);
+    vi.runAllTimers();
     const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
     expect(applyZoomTransform).toHaveBeenCalledWith(initial);
     transformSpy.mockClear();


### PR DESCRIPTION
## Summary
- schedule axis transform application using drawProc to ensure at most one update per frame
- adjust related tests for scheduled updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a10bdb742c832bbc5963eeadc7766c