### PR TITLE
Avoid redraw during zoom

### DIFF
--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -34,7 +34,7 @@ import { SeriesRenderer } from "./seriesRenderer.ts";
 polyfillDom();
 
 describe("TimeSeriesChart.resize", () => {
-  it("updates axes, paths, and legend", () => {
+  it("updates axes and legend without redraw", () => {
     const renderSpy = vi.spyOn(SeriesRenderer.prototype, "draw");
     vi.useFakeTimers();
 
@@ -88,7 +88,7 @@ describe("TimeSeriesChart.resize", () => {
     axisInstances.forEach((a) => {
       expect(a.axisUp).toHaveBeenCalled();
     });
-    expect(renderSpy).toHaveBeenCalled();
+    expect(renderSpy).not.toHaveBeenCalled();
     expect(legend.refresh).toHaveBeenCalled();
     expect(zoomRefreshSpy).toHaveBeenCalled();
     vi.useRealTimers();

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -136,7 +136,7 @@ describe("TimeSeriesChart", () => {
       zoomInstance,
     );
     expect(refreshSpy).toHaveBeenCalledTimes(1);
-    expect(drawSpy).toHaveBeenCalledTimes(1);
+    expect(drawSpy).not.toHaveBeenCalled();
     expect(zoomRefreshSpy).toHaveBeenCalledTimes(1);
     expect(legendRefreshSpy).toHaveBeenCalledTimes(1);
   });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -100,7 +100,6 @@ export class TimeSeriesChart {
       this.state,
       () => {
         const t = zoomTransform(this.zoomArea.node()!);
-        this.state.seriesRenderer.draw(this.data.data);
         this.state.refresh(this.data, t);
         this.legendController.refresh();
       },
@@ -196,6 +195,7 @@ export class TimeSeriesChart {
   };
 
   private refreshAll(): void {
+    this.state.seriesRenderer.draw(this.data.data);
     this.zoomState.refresh();
   }
 


### PR DESCRIPTION
## Summary
- avoid redrawing series on every zoom frame
- refresh using existing transforms to handle zoom/pan
- adjust tests to expect redraws only when data changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a112b7f6d0832bb55be7588c1b64f2