### PR TITLE
fix: redraw chart during drag

### DIFF
--- a/svg-time-series/src/chart/zoomScheduler.test.ts
+++ b/svg-time-series/src/chart/zoomScheduler.test.ts
@@ -24,10 +24,11 @@ describe("ZoomScheduler", () => {
     vi.runAllTimers();
     expect(apply).toHaveBeenCalledWith({ x: 1, k: 2 });
     expect(zs.getCurrentTransform()).toBeNull();
+    expect(refresh).toHaveBeenCalledTimes(1);
 
     zs.refresh();
     vi.runAllTimers();
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
     expect(apply).toHaveBeenCalledTimes(1);
   });
 

--- a/svg-time-series/src/chart/zoomScheduler.ts
+++ b/svg-time-series/src/chart/zoomScheduler.ts
@@ -26,6 +26,7 @@ export class ZoomScheduler {
         const transform = this.currentPanZoomTransformState;
         this.currentPanZoomTransformState = null;
         this.applyTransform(transform);
+        this.refreshChart();
         const cb = this.callback;
         const event = this.callbackEvent ?? { transform };
         this.callback = null;

--- a/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
+++ b/svg-time-series/src/chart/zoomState.programmaticSameTransform.test.ts
@@ -90,7 +90,7 @@ describe("ZoomState programmatic transforms", () => {
 
     expect(transformSpy).toHaveBeenCalledTimes(2);
     expect(applyZoomTransform).toHaveBeenCalledWith(initial);
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;
     }

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -143,7 +143,7 @@ describe("ZoomState", () => {
     vi.runAllTimers();
 
     expect(applyZoomTransform).toHaveBeenCalledWith({ x: 5, k: 2 });
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenCalledTimes(1);
     const internalEvent = zoomCb.mock.calls.at(0)![0] as {
       transform: { x: number; k: number };
@@ -191,7 +191,7 @@ describe("ZoomState", () => {
       k: 3,
     });
     expect(applyZoomTransform).toHaveBeenCalledWith({ x: 2, k: 3 });
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenCalledTimes(1);
     const internalEvent = zoomCb.mock.calls.at(0)![0] as {
       transform: { x: number; k: number };
@@ -240,7 +240,7 @@ describe("ZoomState", () => {
 
     expect(applyZoomTransform).toHaveBeenCalledTimes(3);
     expect(applyZoomTransform).toHaveBeenLastCalledWith({ x: 2, k: 3 });
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
     expect(zoomCb).toHaveBeenCalledTimes(1);
     const cbEvent = zoomCb.mock.calls[0]![0] as {
       transform: { x: number; k: number };
@@ -297,7 +297,7 @@ describe("ZoomState", () => {
     });
     expect(applyZoomTransform).toHaveBeenCalledWith({ x: 3, k: 2 });
     expect(applyZoomTransform).toHaveBeenCalledWith({ x: 5, k: 4 });
-    expect(refresh).toHaveBeenCalledTimes(2);
+    expect(refresh).toHaveBeenCalledTimes(4);
   });
 
   it("applies forwarded zoom before subsequent zoom on target chart", () => {
@@ -558,7 +558,7 @@ describe("ZoomState", () => {
     expect(
       (zs as unknown as ZoomStateInternal).zoomScheduler.getCurrentTransform(),
     ).toBeNull();
-    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
   });
 
   it("updates zoom extents on resize", () => {

--- a/svg-time-series/src/chart/zoomState.transformState.test.ts
+++ b/svg-time-series/src/chart/zoomState.transformState.test.ts
@@ -85,6 +85,7 @@ describe("ZoomState transform state", () => {
 
     expect(transformSpy).toHaveBeenCalledWith(rect, { x: 1, k: 2 });
     expect(applyZoomTransform).toHaveBeenCalledWith({ x: 1, k: 2 });
+    expect(refresh).toHaveBeenCalledTimes(2);
     interface ZoomStateInternal {
       zoomScheduler: ZoomScheduler;
     }


### PR DESCRIPTION
## Summary
- ensure zoomed chart refreshes once per frame while dragging
- update tests for new zoom refresh behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a119e9018c832b8e7a493f6b644ea1