### PR TITLE
fix: skip zoom when brush range collapses

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -215,6 +215,10 @@ export class TimeSeriesChart {
     const m1 = this.data.clampIndex(this.state.screenToModelX(x1));
     const sx0 = this.state.xTransform.toScreenFromModelX(m0);
     const sx1 = this.state.xTransform.toScreenFromModelX(m1);
+    if (m0 === m1 || sx0 === sx1) {
+      this.clearBrush();
+      return;
+    }
     const { width } = this.state.getDimensions();
     const k = width / (sx1 - sx0);
     const t = zoomIdentity.scale(k).translate(-sx0, 0);


### PR DESCRIPTION
## Summary
- abort zoom brush when selected range maps to a single point
- skip zoom transform and clear brush when range collapses
- add regression test for collapsed brush selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11cde54c8832bbb0b4c647a5a9d82