### PR TITLE
refactor: preserve tuple types in mapArray

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -73,8 +73,11 @@ export class ViewportTransform {
     return this.scaleY.invert(y);
   }
 
-  private mapArray<T extends number[]>(b: T, fn: (n: number) => number): T {
-    return b.map(fn) as T;
+  private mapArray<T extends readonly number[]>(
+    b: T,
+    fn: (n: number) => number,
+  ): { [K in keyof T]: number } {
+    return b.map(fn) as { [K in keyof T]: number };
   }
 
   public fromScreenToModelBasisX(b: Basis): Basis {


### PR DESCRIPTION
## Summary
- use mapped tuple types in `mapArray` to retain tuple structure when transforming basis values

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11cc313a8832bba86fd2a97ac35c3