### PR TITLE
fix: clear callbacks on destroy

### DIFF
--- a/svg-time-series/src/chart/zoomScheduler.test.ts
+++ b/svg-time-series/src/chart/zoomScheduler.test.ts
@@ -68,4 +68,23 @@ describe("ZoomScheduler", () => {
     vi.runAllTimers();
     expect(apply).toHaveBeenCalledWith({ x: 5, k: 3 });
   });
+
+  it("does not invoke callbacks after destroy", () => {
+    const apply = vi.fn();
+    const refresh = vi.fn();
+    const cb = vi.fn();
+    const zs = new ZoomScheduler(apply, refresh);
+
+    expect(
+      zs.zoom({ x: 1, k: 2 } as unknown as ZoomTransform, {}, undefined, cb),
+    ).toBe(true);
+
+    zs.destroy();
+    vi.runAllTimers();
+    expect(cb).not.toHaveBeenCalled();
+
+    expect(zs.zoom({ x: 5, k: 3 } as unknown as ZoomTransform, {})).toBe(true);
+    vi.runAllTimers();
+    expect(cb).not.toHaveBeenCalled();
+  });
 });

--- a/svg-time-series/src/chart/zoomScheduler.ts
+++ b/svg-time-series/src/chart/zoomScheduler.ts
@@ -87,6 +87,8 @@ export class ZoomScheduler {
     this.cancelRefresh();
     this.currentPanZoomTransformState = null;
     this.pendingZoomBehaviorTransform = false;
+    this.callback = null;
+    this.callbackEvent = null;
   }
 
   public getCurrentTransform(): ZoomTransform | null {


### PR DESCRIPTION
## Summary
- reset pending callbacks and events when destroying a ZoomScheduler
- test that destroyed schedulers do not trigger callbacks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a199456700832b845bb2fe8894936d