### PR TITLE
feat: add optional legend raf highlighting

### DIFF
--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,6 +1,9 @@
 import { loadAndDraw } from "./common.ts";
 
 void loadAndDraw([0, 1]).then((charts) => {
+  charts.forEach((c) => {
+    c.interaction.onHover(0);
+  });
   const resetButton = document.getElementById("reset-zoom");
   resetButton?.addEventListener("click", () => {
     charts.forEach((c) => {

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,6 +1,9 @@
 import { loadAndDraw } from "./common.ts";
 
 void loadAndDraw([0, 0]).then((charts) => {
+  charts.forEach((c) => {
+    c.interaction.onHover(0);
+  });
   const resetButton = document.getElementById("reset-zoom");
   resetButton?.addEventListener("click", () => {
     charts.forEach((c) => {

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -19,6 +19,7 @@ export interface LegendContext {
 export interface ILegendController {
   init(context: LegendContext): void;
   highlightIndex(idx: number): void;
+  highlightIndexRaf?(idx: number): void;
   refresh(): void;
   clearHighlight(): void;
   destroy(): void;

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -184,9 +184,7 @@ export class TimeSeriesChart {
   public onHover = (x: number) => {
     let idx = Math.round(this.state.screenToModelX(x));
     idx = this.data.clampIndex(idx);
-    const legend = this.legendController as ILegendController & {
-      highlightIndexRaf?: (idx: number) => void;
-    };
+    const legend = this.legendController;
     if (legend.highlightIndexRaf) {
       legend.highlightIndexRaf(idx);
     } else {


### PR DESCRIPTION
## Summary
- allow legends to optionally handle RAF highlight updates
- drop cast in `onHover` and conditionally call `highlightIndexRaf`
- ensure demos highlight using requestAnimationFrame

## Testing
- `npm run format`
- `git commit -am "chore(samples): highlight demos via raf"`


------
https://chatgpt.com/codex/tasks/task_e_68a1988efd50832bb5fdd7706da0d895