### PR TITLE
refactor: separate chart and zoom resizing

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -16,7 +16,6 @@ import { createDimensions } from "./render/utils.ts";
 import { SeriesRenderer } from "./seriesRenderer.ts";
 import { createSeries } from "./series.ts";
 import type { LegendContext, LegendSeriesInfo } from "./legend.ts";
-import type { ZoomState } from "./zoomState.ts";
 
 function createYAxis(
   orientation: Orientation,
@@ -128,18 +127,23 @@ export class RenderState {
     this.axes.y.length = 0;
   }
 
-  public resize(dimensions: Dimensions, zoomState: ZoomState): void {
+  public resize(
+    dimensions: Dimensions,
+    zoomOverlay: Selection<SVGRectElement, unknown, HTMLElement, unknown>,
+  ): void {
     const { width, height } = dimensions;
     const bScreenXVisible: Basis = [0, width];
     const bScreenYVisible: Basis = [height, 0];
     const bScreenVisible: [Basis, Basis] = [bScreenXVisible, bScreenYVisible];
 
+    this.dimensions.width = width;
+    this.dimensions.height = height;
+    zoomOverlay.attr("width", width).attr("height", height);
+
     this.axes.x.scale.range([0, width]);
     this.axes.x.axis.setScale(this.axes.x.scale);
     this.axisManager.setXAxis(this.axes.x.scale);
     this.screenXBasis = bScreenXVisible;
-
-    zoomState.updateExtents(dimensions);
 
     this.xTransform.onViewPortResize(bScreenVisible);
     for (const a of this.axes.y) {

--- a/svg-time-series/src/chart/resize.test.ts
+++ b/svg-time-series/src/chart/resize.test.ts
@@ -157,6 +157,10 @@ describe("TimeSeriesChart.resize", () => {
     expect(chartInternal.state.dimensions).toEqual({ width: 250, height: 120 });
     expect(resizeSpy).toHaveBeenCalled();
 
+    const overlay = svgEl.querySelector(".zoom-overlay");
+    expect(overlay?.getAttribute("width")).toBe("250");
+    expect(overlay?.getAttribute("height")).toBe("120");
+
     expect(chartInternal.state.axes.x.scale.range()).toEqual([0, 250]);
     expect(chartInternal.state.axes.y[0]!.scale.range()).toEqual([120, 0]);
   });

--- a/svg-time-series/src/chart/zoomState.test.ts
+++ b/svg-time-series/src/chart/zoomState.test.ts
@@ -593,9 +593,7 @@ describe("ZoomState", () => {
 
     zs.updateExtents({ width: 20, height: 30 });
 
-    expect(rect.attr("width")).toBe("20");
-    expect(rect.attr("height")).toBe("30");
-    expect(setDimensions).toHaveBeenCalledWith({ width: 20, height: 30 });
+    expect(setDimensions).not.toHaveBeenCalled();
     expect(scaleSpy).toHaveBeenCalledWith([1, 40]);
     expect(translateSpy).toHaveBeenCalledWith([
       [0, 0],

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -111,10 +111,6 @@ export class ZoomState {
   };
 
   public updateExtents = (dimensions: { width: number; height: number }) => {
-    this.state.setDimensions(dimensions);
-    this.zoomArea
-      .attr("width", dimensions.width)
-      .attr("height", dimensions.height);
     this.zoomBehavior.scaleExtent(this.scaleExtent).translateExtent([
       [0, 0],
       [dimensions.width, dimensions.height],

--- a/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsClamp.test.ts
@@ -133,8 +133,8 @@ describe("ZoomState.updateExtents clamp", () => {
     transformSpy.mockClear();
 
     zs.updateExtents({ width: 50, height: 50 });
-    expect(setDimensions).toHaveBeenCalledWith({ width: 50, height: 50 });
 
+    expect(setDimensions).not.toHaveBeenCalled();
     expect(transformSpy).toHaveBeenCalledWith(
       rect,
       expect.objectContaining({ x: -50, y: -50, k: 2 }),

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -118,33 +118,41 @@ describe("TimeSeriesChart", () => {
       zoomState: {
         refresh: ReturnType<typeof vi.fn>;
         setScaleExtent: ReturnType<typeof vi.fn>;
+        updateExtents: ReturnType<typeof vi.fn>;
       };
+      zoomArea: Selection<SVGRectElement, unknown, HTMLElement, unknown>;
     };
     const zoomInstance = internal.zoomState;
     const resizeSpy = vi.spyOn(internal.state, "resize");
     const refreshSpy = vi.spyOn(internal.state, "refresh");
     const drawSpy = vi.spyOn(internal.state.seriesRenderer, "draw");
     const zoomRefreshSpy = vi.spyOn(zoomInstance, "refresh");
+    const updateExtentsSpy = vi.spyOn(zoomInstance, "updateExtents");
     const legendRefreshSpy = vi.spyOn(legend, "refresh");
 
     resizeSpy.mockClear();
     refreshSpy.mockClear();
     drawSpy.mockClear();
     zoomRefreshSpy.mockClear();
+    updateExtentsSpy.mockClear();
     legendRefreshSpy.mockClear();
 
     chart.resize({ width: 200, height: 150 });
 
     expect(svgEl.getAttribute("width")).toBe("200");
     expect(svgEl.getAttribute("height")).toBe("150");
-    expect(resizeSpy).toHaveBeenCalledWith(
-      { width: 200, height: 150 },
-      zoomInstance,
-    );
+    expect(resizeSpy).toHaveBeenCalledTimes(1);
+    expect(resizeSpy.mock.calls[0]![0]).toEqual({ width: 200, height: 150 });
+    expect(resizeSpy.mock.calls[0]![1]).toBe(internal.zoomArea);
+    expect(updateExtentsSpy).toHaveBeenCalledWith({ width: 200, height: 150 });
     expect(refreshSpy).toHaveBeenCalledTimes(1);
     expect(drawSpy).not.toHaveBeenCalled();
     expect(zoomRefreshSpy).toHaveBeenCalledTimes(1);
     expect(legendRefreshSpy).toHaveBeenCalledTimes(1);
+
+    const overlay = internal.zoomArea.node()!;
+    expect(overlay.getAttribute("width")).toBe("200");
+    expect(overlay.getAttribute("height")).toBe("150");
   });
 
   it("clamps hover index and forwards to legend", () => {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -172,7 +172,8 @@ export class TimeSeriesChart {
   public resize = (dimensions: { width: number; height: number }) => {
     const { width, height } = dimensions;
     this.svg.attr("width", width).attr("height", height);
-    this.state.resize(dimensions, this.zoomState);
+    this.state.resize(dimensions, this.zoomArea);
+    this.zoomState.updateExtents(dimensions);
     this.brushBehavior.extent([
       [0, 0],
       [width, height],


### PR DESCRIPTION
## Summary
- update render state to own dimensions and resize the zoom overlay
- keep zoomState.updateExtents focused on zoom behavior
- resize charts by calling render and zoom updates sequentially with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c251dcc0832baed89ee080f5d62e