### PR TITLE
refactor axis scale calculations using zoom

### DIFF
--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -70,15 +70,15 @@ describe("AxisManager", () => {
 
     const t = zoomIdentity.scale(2);
     axisManager.updateScales(t);
-
-    const indexScale = data.bIndexFromTransform(
+    const dIndexVisible = data.dIndexFromTransform(
       t,
       axisManager.x.range() as [number, number],
     );
-    const expectedDomain = data
-      .axisTransform(0, indexScale.domain() as [number, number])
-      .scale.domain();
-
+    const { scale: baseScaleRaw } = data.axisTransform(0, dIndexVisible);
+    const baseScale = baseScaleRaw.range(
+      axisManager.axes[0]!.scale.range() as [number, number],
+    );
+    const expectedDomain = t.rescaleY(baseScale).domain();
     expect(axisManager.axes[0]!.scale.domain()).toEqual(expectedDomain);
   });
 });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -63,7 +63,7 @@ export class ChartData {
   public readonly indexToTime: ScaleLinear<number, number>;
   /**
    * Persistent mapping from data index to screen range. The domain never
-   * changes, and the range is updated on demand in `bIndexFromTransform` to
+   * changes, and the range is updated on demand in `dIndexFromTransform` to
    * avoid reconstructing the scale for every call.
    */
   private readonly indexScale: ScaleLinear<number, number>;
@@ -148,12 +148,12 @@ export class ChartData {
     return this.bIndexFull.map((i) => new Date(toTime(i))) as [Date, Date];
   }
 
-  bIndexFromTransform(
+  dIndexFromTransform(
     transform: ZoomTransform,
     range: [number, number],
-  ): ScaleLinear<number, number> {
+  ): [number, number] {
     this.indexScale.range(range);
-    return transform.rescaleX(this.indexScale);
+    return transform.rescaleX(this.indexScale).domain() as [number, number];
   }
 
   /**


### PR DESCRIPTION
## Summary
- update AxisManager to encapsulate Y-scale updates in AxisModel
- add ChartData.dIndexFromTransform to derive visible index range
- adjust AxisManager tests for new helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1add58288832b8d4f40c07e1459c4