### PR TITLE
feat: constrain zoom translation

### DIFF
--- a/svg-time-series/src/chart/zoomState.constrainTranslation.test.ts
+++ b/svg-time-series/src/chart/zoomState.constrainTranslation.test.ts
@@ -6,10 +6,34 @@ import { zoomIdentity } from "d3-zoom";
 import { constrainTranslation } from "./zoomState.ts";
 
 describe("constrainTranslation", () => {
-  it("clamps translation to bounds", () => {
+  it("clamps translation when panned beyond left/top", () => {
+    const current = zoomIdentity.translate(30, 40).scale(2);
+    const constrained = constrainTranslation(current, 50, 50);
+    expect(constrained).toMatchObject({ x: 0, y: 0, k: 2 });
+  });
+
+  it("clamps translation when panned beyond right/bottom", () => {
     const current = zoomIdentity.translate(-120, -80).scale(2);
     const constrained = constrainTranslation(current, 50, 50);
     expect(constrained).toMatchObject({ x: -50, y: -50, k: 2 });
+  });
+
+  it("returns original transform when already inside bounds", () => {
+    const current = zoomIdentity.translate(-20, -30).scale(2);
+    const constrained = constrainTranslation(current, 50, 50);
+    expect(constrained).toBe(current);
+  });
+
+  it("returns original transform at left/top boundary", () => {
+    const current = zoomIdentity.translate(0, 0).scale(2);
+    const constrained = constrainTranslation(current, 50, 50);
+    expect(constrained).toBe(current);
+  });
+
+  it("returns original transform at right/bottom boundary", () => {
+    const current = zoomIdentity.translate(-50, -50).scale(2);
+    const constrained = constrainTranslation(current, 50, 50);
+    expect(constrained).toBe(current);
   });
 
   it("returns original transform when no adjustment needed", () => {


### PR DESCRIPTION
## Summary
- rewrite constrainTranslation to clamp left/top and right/bottom overscroll and center small content
- document algorithm steps for maintainability
- add boundary-focused unit tests for constrainTranslation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1c279caec832ba93c860ee7ab7cd9