### PR TITLE
Validate update value count in TimeSeriesChart

### DIFF
--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -107,6 +107,24 @@ describe("TimeSeriesChart", () => {
     expect(drawSpy).toHaveBeenCalledWith(internal.data.data);
   });
 
+  it("throws when provided fewer values than series count", () => {
+    const { chart } = createChart();
+    expect(() => {
+      chart.updateChartWithNewData();
+    }).toThrow(
+      "TimeSeriesChart.updateChartWithNewData expected 1 values, received 0",
+    );
+  });
+
+  it("throws when provided more values than series count", () => {
+    const { chart } = createChart();
+    expect(() => {
+      chart.updateChartWithNewData(10, 20);
+    }).toThrow(
+      "TimeSeriesChart.updateChartWithNewData expected 1 values, received 2",
+    );
+  });
+
   it("resizes svg and refreshes render state", () => {
     const { chart, svgEl, legend } = createChart();
     const internal = chart as unknown as {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -126,6 +126,13 @@ export class TimeSeriesChart {
   }
 
   public updateChartWithNewData(...values: number[]): void {
+    if (values.length !== this.data.seriesCount) {
+      throw new Error(
+        `TimeSeriesChart.updateChartWithNewData expected ${String(
+          this.data.seriesCount,
+        )} values, received ${String(values.length)}`,
+      );
+    }
     this.data.append(...values);
     this.refreshAll();
   }


### PR DESCRIPTION
## Summary
- check value count matches series count before appending new data
- add tests for mismatched update arrays

## Testing
- `git commit -am "feat: validate update values"`

------
https://chatgpt.com/codex/tasks/task_e_68a1c29815ec832bba3b64b02fec32a1