### PR TITLE
refactor: reuse requestAnimationFrame callback

### DIFF
--- a/svg-time-series/src/utils/drawProc.ts
+++ b/svg-time-series/src/utils/drawProc.ts
@@ -7,15 +7,17 @@ export function drawProc<F extends (...args: unknown[]) => void>(
   let rafId: number | null = null;
   let latestParams: Parameters<F> | null = null;
 
+  const flush = () => {
+    rafId = null;
+    if (latestParams) {
+      f(...latestParams);
+    }
+  };
+
   const wrapped = (...params: Parameters<F>) => {
     latestParams = params;
     if (rafId === null) {
-      rafId = requestAnimationFrame(() => {
-        rafId = null;
-        if (latestParams) {
-          f(...latestParams);
-        }
-      });
+      rafId = requestAnimationFrame(flush);
     }
   };
 


### PR DESCRIPTION
## Summary
- hoist `requestAnimationFrame` callback in `drawProc` so the same function is reused across invocations, reducing allocation churn

## Testing
- `npm test`
- `NODE_OPTIONS=--expose-gc npx tsx bench-drawProc-gc.ts` *(before/after memory allocation)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c287c0c0832ba193388996caa535