### PR TITLE
Cache series path data to avoid redundant DOM updates

### DIFF
--- a/svg-time-series/src/chart/seriesRenderer.test.ts
+++ b/svg-time-series/src/chart/seriesRenderer.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
 import type { Line } from "d3-shape";
 import { SeriesRenderer } from "./seriesRenderer.ts";
@@ -50,5 +50,27 @@ describe("SeriesRenderer", () => {
     renderer.draw([]);
 
     expect(path.getAttribute("d")).toBe("");
+  });
+
+  it("skips DOM updates when data is unchanged", () => {
+    const renderer = new SeriesRenderer();
+    const data: number[][] = [
+      [0, 1],
+      [2, 3],
+    ];
+
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    const view = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    const line = (() => "same") as unknown as Line<number[]>;
+
+    const series: Series = { axisIdx: 0, path, view, line };
+    renderer.series = [series];
+
+    const spy = vi.spyOn(path, "setAttribute");
+
+    renderer.draw(data);
+    renderer.draw(data);
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/svg-time-series/src/chart/seriesRenderer.ts
+++ b/svg-time-series/src/chart/seriesRenderer.ts
@@ -4,9 +4,16 @@ export class SeriesRenderer {
   /** Ordered collection of series to render. */
   public series: Series[] = [];
 
+  /** Cache of the last rendered `d` attribute for each series. */
+  private readonly lastD = new WeakMap<Series, string>();
+
   public draw(dataArr: number[][]): void {
     for (const s of this.series) {
-      s.path.setAttribute("d", s.line(dataArr) ?? "");
+      const d = s.line(dataArr) ?? "";
+      if (this.lastD.get(s) !== d) {
+        s.path.setAttribute("d", d);
+        this.lastD.set(s, d);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- cache last rendered path `d` string per series
- update SVG path only when data changes
- add unit test verifying repeated draws skip `setAttribute`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ccc1a780832bafe5a36593de7101