### PR TITLE
refactor: simplify axis domain handling

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -21,24 +21,6 @@ export class AxisModel {
     this.tree = new SegmentTree([minMaxIdentity], buildMinMax, minMaxIdentity);
   }
 
-  get min(): number {
-    return this.scale.domain()[0]!;
-  }
-
-  set min(v: number) {
-    const [, max] = this.scale.domain();
-    this.scale.domain([v, max!]);
-  }
-
-  get max(): number {
-    return this.scale.domain()[1]!;
-  }
-
-  set max(v: number) {
-    const [min] = this.scale.domain();
-    this.scale.domain([min!, v]);
-  }
-
   updateFromData(
     tree: SegmentTree<IMinMax>,
     baseScaleRaw: ScaleLinear<number, number>,
@@ -46,9 +28,9 @@ export class AxisModel {
     fullIndex: Basis,
   ): void {
     this.tree = tree;
-    const baseScale = baseScaleRaw.range(
-      this.scale.range() as [number, number],
-    );
+    const baseScale = baseScaleRaw
+      .copy()
+      .range(this.scale.range() as [number, number]);
     this.transform.onReferenceViewWindowResize([
       fullIndex,
       baseScale.domain() as [number, number],
@@ -82,12 +64,12 @@ export class AxisManager {
 
   updateScales(transform: ZoomTransform): void {
     this.data.assertAxisBounds(this.axes.length);
-    this.x.domain(this.data.timeDomainFull());
+    const baseX = this.x.copy().domain(this.data.timeDomainFull()).nice();
     const dIndexVisible = this.data.dIndexFromTransform(
       transform,
-      this.x.range() as [number, number],
+      baseX.range() as [number, number],
     );
-    this.x = transform.rescaleX(this.x).copy();
+    this.x = transform.rescaleX(baseX).copy();
     this.axes.forEach((a, i) => {
       const idxs = this.data.seriesByAxis[i] ?? [];
       if (idxs.length === 0) {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -207,15 +207,16 @@ export function setupRender(
     a.scale.range([height, 0]);
   }
   axisManager.updateScales(zoomIdentity);
-
-  const referenceBasis: [Basis, Basis] = [data.bIndexFull, [0, 1]];
   for (const a of yAxes) {
     a.transform.onViewPortResize(screenBasis);
-    a.transform.onReferenceViewWindowResize(referenceBasis);
+    a.transform.onReferenceViewWindowResize([
+      data.bIndexFull,
+      a.scale.domain() as [number, number],
+    ]);
   }
   const xTransform = new ViewportTransform();
   xTransform.onViewPortResize(screenBasis);
-  xTransform.onReferenceViewWindowResize(referenceBasis);
+  xTransform.onReferenceViewWindowResize([data.bIndexFull, [0, 1]]);
 
   const series = createSeries(svg, data.seriesAxes);
   const seriesRenderer = new SeriesRenderer();


### PR DESCRIPTION
## Summary
- simplify `AxisModel` by removing `min`/`max` accessors and updating from data via `scale.copy()` and `transform.rescaleY`
- update `AxisManager.updateScales` to clone and rescale domains directly
- initialize render transforms using axis scale domains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cdb19918832b88748c8b3dcc7fce