### PR TITLE
refactor: derive DOM matrices from d3 scales

### DIFF
--- a/svg-time-series/src/setupDom.ts
+++ b/svg-time-series/src/setupDom.ts
@@ -12,6 +12,8 @@ async function polyfillDom(): Promise<void> {
   ) {
     (globalObj as { window?: unknown }).window ??= globalObj;
     await import("geometry-polyfill");
+    (globalObj as { SVGMatrix?: typeof globalThis.DOMMatrix }).SVGMatrix ??=
+      globalObj.DOMMatrix!;
   }
   if (typeof SVGSVGElement !== "undefined") {
     const proto = SVGSVGElement.prototype as unknown as {


### PR DESCRIPTION
## Summary
- replace manual matrix math with conversions from d3 scales and zoom transforms
- compose viewport matrices using d3-derived DOMMatrix helpers
- polyfill SVGMatrix for DOMMatrix.fromMatrix usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cdaa25d8832b9d2d24404c2f8ead