### PR TITLE
Avoid redundant x transform recomputation

### DIFF
--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -66,6 +66,7 @@ export class RenderState {
   public dimensions: Dimensions;
   public series: Series[];
   public seriesRenderer: SeriesRenderer;
+  private prevBIndexFull: Basis;
 
   constructor(
     axisManager: AxisManager,
@@ -76,6 +77,7 @@ export class RenderState {
     dimensions: Dimensions,
     series: Series[],
     seriesRenderer: SeriesRenderer,
+    bIndexFull: Basis,
   ) {
     this.axisManager = axisManager;
     this.axes = axes;
@@ -85,10 +87,15 @@ export class RenderState {
     this.dimensions = dimensions;
     this.series = series;
     this.seriesRenderer = seriesRenderer;
+    this.prevBIndexFull = [...bIndexFull] as Basis;
   }
 
   public refresh(data: ChartData, transform: ZoomTransform): void {
-    this.xTransform.onReferenceViewWindowResize([data.bIndexFull, [0, 1]]);
+    const [b0, b1] = data.bIndexFull;
+    if (b0 !== this.prevBIndexFull[0] || b1 !== this.prevBIndexFull[1]) {
+      this.xTransform.onReferenceViewWindowResize([data.bIndexFull, [0, 1]]);
+      this.prevBIndexFull = [b0, b1] as Basis;
+    }
 
     this.axisManager.setData(data);
     this.axisManager.updateScales(transform);
@@ -251,5 +258,6 @@ export function setupRender(
     dimensions,
     series,
     seriesRenderer,
+    data.bIndexFull,
   );
 }

--- a/svg-time-series/test/refresh.test.ts
+++ b/svg-time-series/test/refresh.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import { select, type Selection } from "d3-selection";
+import { zoomIdentity } from "d3-zoom";
+
+import { ChartData } from "../src/chart/data.ts";
+import { setupRender } from "../src/chart/render.ts";
+import { polyfillDom } from "../src/setupDom.ts";
+
+vi.mock("../src/utils/domNodeTransform.ts", () => ({
+  updateNode: vi.fn(),
+}));
+
+await polyfillDom();
+
+function createData() {
+  const dataRows = [[1], [2], [3]];
+  return new ChartData({
+    startTime: 0,
+    timeStep: 1,
+    length: dataRows.length,
+    seriesAxes: [0],
+    getSeries: (i, j) => dataRows[i]![j]!,
+  });
+}
+
+describe("RenderState.refresh", () => {
+  it("avoids recomputing transform for constant data", () => {
+    const data = createData();
+    const div = document.createElement("div");
+    Object.defineProperty(div, "clientWidth", { value: 100 });
+    Object.defineProperty(div, "clientHeight", { value: 50 });
+    const svgEl = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    div.appendChild(svgEl);
+
+    const state = setupRender(
+      select(svgEl) as unknown as Selection<
+        SVGSVGElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+      data,
+    );
+
+    const spy = vi.spyOn(state.xTransform, "onReferenceViewWindowResize");
+
+    state.refresh(data, zoomIdentity);
+    state.refresh(data, zoomIdentity);
+
+    expect(spy).not.toHaveBeenCalled();
+
+    state.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- track previous data index range in RenderState to skip unnecessary xTransform recomputation
- add test ensuring repeated refresh with constant data doesn't trigger transform update

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1cccefad0832ba217b16d6525296d