### PR TITLE
Handle missing zoom area in updateExtents

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -107,8 +107,8 @@ export class ZoomState {
   };
 
   public setScaleExtent = (extent: [number, number]) => {
-    const node = this.zoomAreaNode;
-    if (!node) {
+    const node = this.zoomArea.node();
+    if (!node || !this.zoomAreaNode) {
       return;
     }
     this.scaleExtent = ZoomState.validateScaleExtent(extent);
@@ -122,8 +122,8 @@ export class ZoomState {
   };
 
   public updateExtents = (dimensions: { width: number; height: number }) => {
-    const node = this.zoomAreaNode;
-    if (!node) {
+    const node = this.zoomArea.node();
+    if (!node || !this.zoomAreaNode) {
       return;
     }
     this.zoomBehavior.scaleExtent(this.scaleExtent).translateExtent([

--- a/svg-time-series/src/chart/zoomState.updateExtentsRemovedSvg.test.ts
+++ b/svg-time-series/src/chart/zoomState.updateExtentsRemovedSvg.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { select, type Selection } from "d3-selection";
+import type { RenderState } from "./render.ts";
+import { ZoomState } from "./zoomState.ts";
+
+describe("ZoomState.updateExtents removed element", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("exits early when the zoom area element is removed", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const state = {
+      dimensions: { width: 10, height: 10 },
+      axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
+    } as unknown as RenderState;
+
+    const zs = new ZoomState(
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+      state,
+      vi.fn(),
+    );
+
+    rect.remove();
+    zs["zoomArea"] = select(svg).select<SVGRectElement>(
+      "rect",
+    ) as unknown as Selection<SVGRectElement, unknown, HTMLElement, unknown>;
+
+    const transformSpy = vi.spyOn(zs.zoomBehavior, "transform");
+
+    expect(() => {
+      zs.updateExtents({ width: 20, height: 20 });
+    }).not.toThrow();
+    expect(transformSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- guard ZoomState against missing zoom area nodes
- test updateExtents after removing SVG element

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d5d28bd0832b93fafb21865be7cd