### PR TITLE
refactor: use accessor for legend length

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -60,7 +60,7 @@ describe("LegendController", () => {
     const lc = new LegendController(legendDiv);
     lc.init({
       getPoint: data.getPoint.bind(data),
-      length: data.length,
+      getLength: () => data.length,
       series: state.series.map((s) => ({
         path: s.path,
         transform: state.axes.y[s.axisIdx]!.transform,
@@ -113,7 +113,7 @@ describe("LegendController", () => {
     const lc = new LegendController(legendDiv);
     lc.init({
       getPoint: data.getPoint.bind(data),
-      length: data.length,
+      getLength: () => data.length,
       series: state.series.map((s) => ({
         path: s.path,
         transform: state.axes.y[s.axisIdx]!.transform,
@@ -154,7 +154,7 @@ describe("LegendController", () => {
     const lc = new LegendController(legendDiv);
     lc.init({
       getPoint: data.getPoint.bind(data),
-      length: data.length,
+      getLength: () => data.length,
       series: state.series.map((s) => ({
         path: s.path,
         transform: state.axes.y[s.axisIdx]!.transform,

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -79,7 +79,7 @@ export class LegendController implements ILegendController {
 
   public highlightIndex(idx: number): void {
     const clamped = Math.round(
-      Math.min(Math.max(idx, 0), this.context.length - 1),
+      Math.min(Math.max(idx, 0), this.context.getLength() - 1),
     );
     if (clamped === this.lastHighlightedIdx) {
       return;
@@ -91,7 +91,7 @@ export class LegendController implements ILegendController {
 
   public highlightIndexRaf(idx: number): void {
     const clamped = Math.round(
-      Math.min(Math.max(idx, 0), this.context.length - 1),
+      Math.min(Math.max(idx, 0), this.context.getLength() - 1),
     );
     if (clamped === this.lastHighlightedIdx) {
       return;

--- a/svg-time-series/src/chart/legend.ts
+++ b/svg-time-series/src/chart/legend.ts
@@ -12,7 +12,7 @@ export interface LegendPoint {
 
 export interface LegendContext {
   getPoint(idx: number): LegendPoint;
-  length: number;
+  getLength(): number;
   series: readonly LegendSeriesInfo[];
 }
 

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -244,7 +244,7 @@ export class RenderState {
   public createLegendContext(data: ChartData): LegendContext {
     return {
       getPoint: (idx) => data.getPoint(idx),
-      length: data.length,
+      getLength: () => data.length,
       series: this.getLegendSeriesInfo(),
     };
   }


### PR DESCRIPTION
## Summary
- expose legend data length via `getLength()` instead of a fixed property
- have render state provide dynamic length to legend context
- update legend controller and tests to call new accessor

## Testing
- `npm run format`
- `git commit -am "refactor: use accessor for legend length"`


------
https://chatgpt.com/codex/tasks/task_e_68a1d5b99b00832b906080324bc4652b