### PR TITLE
fix: safeguard SVG root in node transform

### DIFF
--- a/svg-time-series/src/setupDom.ts
+++ b/svg-time-series/src/setupDom.ts
@@ -2,6 +2,7 @@ interface DOMGlobals {
   DOMMatrix?: typeof globalThis.DOMMatrix;
   DOMPoint?: typeof globalThis.DOMPoint;
   window?: unknown;
+  SVGSVGElement?: typeof globalThis.SVGSVGElement;
 }
 
 async function polyfillDom(): Promise<void> {
@@ -15,8 +16,20 @@ async function polyfillDom(): Promise<void> {
     (globalObj as { SVGMatrix?: typeof globalThis.DOMMatrix }).SVGMatrix ??=
       globalObj.DOMMatrix!;
   }
-  if (typeof SVGSVGElement !== "undefined") {
-    const proto = SVGSVGElement.prototype as unknown as {
+  if (typeof globalObj.SVGSVGElement === "undefined") {
+    class SVGSVGElementPolyfill {
+      createSVGMatrix() {
+        return new DOMMatrix();
+      }
+    }
+    (
+      globalObj as {
+        SVGSVGElement: typeof globalThis.SVGSVGElement;
+      }
+    ).SVGSVGElement =
+      SVGSVGElementPolyfill as unknown as typeof globalThis.SVGSVGElement;
+  } else {
+    const proto = globalObj.SVGSVGElement.prototype as unknown as {
       createSVGMatrix?: () => DOMMatrix;
     };
     proto.createSVGMatrix ??= () => new DOMMatrix();

--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -73,6 +73,20 @@ describe("updateNode", () => {
     expect(last.e).toBeCloseTo(5);
     expect(last.f).toBeCloseTo(6);
   });
+
+  it("throws when node is detached from SVG root", () => {
+    const node = {
+      transform: { baseVal: new FakeTransformList() },
+      ownerSVGElement: null,
+    } as unknown as SVGGraphicsElement & {
+      transform: { baseVal: FakeTransformList };
+      ownerSVGElement: null;
+    };
+    const matrix = new FakeSVGMatrix();
+    expect(() => {
+      updateNode(node, matrix as unknown as SVGMatrix);
+    }).toThrow(/SVG root not found/);
+  });
 });
 
 describe("domMatrixToSVGMatrix", () => {

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -25,12 +25,10 @@ export function domMatrixToSVGMatrix(
 
 export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
   const svgTransformList = n.transform.baseVal;
-  const svg = (
-    typeof SVGSVGElement !== "undefined" && n instanceof SVGSVGElement
-      ? n
-      : n.ownerSVGElement
-  )!;
-
+  const svg = n instanceof SVGSVGElement ? n : n.ownerSVGElement;
+  if (!svg) {
+    throw new Error("Cannot update transform: SVG root not found");
+  }
   const matrix = domMatrixToSVGMatrix(svg, m);
   const t = svgTransformList.createSVGTransformFromMatrix(matrix);
   svgTransformList.initialize(t);


### PR DESCRIPTION
## Summary
- safely resolve the SVG root in `updateNode` and throw when missing
- polyfill `SVGSVGElement` for non-browser environments
- test `updateNode` with both attached and detached nodes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d5c2d6d0832baeca894a143f4ddf