### PR TITLE
fix: reset brush on enable

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -56,6 +56,12 @@ vi.mock("../axis.ts", () => ({
   },
 }));
 
+vi.mock("../draw/brushUtils.ts", () => ({
+  clearBrushSelection: vi.fn(),
+}));
+
+import { clearBrushSelection } from "../draw/brushUtils.ts";
+
 let zoomReset: Mock;
 let legendRefresh: Mock;
 let zoomOptions: unknown;
@@ -198,6 +204,40 @@ describe("interaction.resetZoom", () => {
     expect(zoomReset).toHaveBeenCalled();
     expect(transform.onZoomPan).toHaveBeenCalledWith({ x: 0, k: 1 });
     expect(legendRefresh).toHaveBeenCalled();
+  });
+});
+
+describe("interaction.enableBrush", () => {
+  it("clears selected time window", () => {
+    const { interaction, chart } = createChart([
+      [10, 20],
+      [30, 40],
+    ]);
+    const internal = chart as unknown as {
+      onBrushEnd: (e: D3BrushEvent<unknown>) => void;
+      state: {
+        screenToModelX: (x: number) => number;
+        xTransform: { toScreenFromModelX: (x: number) => number };
+      };
+      zoomState: {
+        zoomBehavior: { transform: (n: unknown, t: unknown) => void };
+      };
+    };
+    internal.zoomState.zoomBehavior = { transform: vi.fn() };
+    internal.state.screenToModelX = (x: number) => x;
+    (
+      internal.state.xTransform as { toScreenFromModelX: (x: number) => number }
+    ).toScreenFromModelX = (x: number) => x;
+    internal.onBrushEnd({
+      selection: [0, 10],
+    } as unknown as D3BrushEvent<unknown>);
+    expect(interaction.getSelectedTimeWindow()).not.toBeNull();
+
+    (clearBrushSelection as Mock).mockClear();
+    interaction.enableBrush();
+
+    expect(clearBrushSelection).toHaveBeenCalled();
+    expect(interaction.getSelectedTimeWindow()).toBeNull();
   });
 });
 

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -163,6 +163,8 @@ export class TimeSeriesChart {
   };
 
   public enableBrush = () => {
+    this.clearBrush();
+    this.selectedTimeWindow = null;
     this.brushLayer.style("display", null);
   };
 


### PR DESCRIPTION
## Summary
- clear existing brush selection when enabling brush
- ensure selected time window resets on enabling brush
- add regression test for brushing enablement

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d5d8058c832b9baa8d268b8c4293