### PR TITLE
refactor: simplify workspace typecheck scripts

### DIFF
--- a/samples/package.json
+++ b/samples/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "test": "echo \"Error: no test specified\" && exit 1",
     "bench": "echo \"No benchmarks defined\""
   },

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "bench": "npm run bench:segment-tree",
     "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts --run",
     "test": "vitest run --reporter=dot"

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -38,7 +38,7 @@
     "prepare": "npm run build",
     "build": "tsc && vite build",
     "lint": "eslint src",
-    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",
     "bench": "vitest bench bench/*.bench.ts",
     "test": "vitest run --reporter=dot"


### PR DESCRIPTION
## Summary
- streamline typecheck scripts in `svg-time-series`, `segment-tree-rmq`, and `samples` workspaces to use the test-specific tsconfig
- no changes to tsconfig files were needed as they already include source and test paths

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a1dae51088832b8a21016331e40b10