### PR TITLE
refactor(segment-tree-rmq): rewrite query loop

### DIFF
--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -68,25 +68,30 @@ export class SegmentTree<T> {
    */
   query(start: number, endInclusive: number): T {
     this.assertValidRange(start, endInclusive);
+    // Move the indices to the leaf level. The right index is made exclusive
+    // by adding 1 so the loop can naturally terminate when `left === right`.
     let left = start + this.size;
-    let right = endInclusive + this.size;
+    let right = endInclusive + this.size + 1;
     let result = this.identity;
 
+    // Traverse the tree upwards, shrinking the interval [left, right) until
+    // there are no segments left to process.
     while (left < right) {
+      // If `left` is a right child, it represents a disjoint segment that
+      // should be included in the result. Move to the next segment after it.
       if (left & 1) {
         result = this.op(result, this.tree[left]!);
         left++;
       }
-      if (!(right & 1)) {
-        result = this.op(result, this.tree[right]!);
+      // If `right` is a right boundary, the segment to the immediate left is
+      // part of the range. Include it and shift the boundary left.
+      if (right & 1) {
         right--;
+        result = this.op(result, this.tree[right]!);
       }
+      // Move both indices to their parents to continue with the next level.
       left >>= 1;
       right >>= 1;
-    }
-
-    if (left === right) {
-      result = this.op(result, this.tree[left]!);
     }
 
     return result;

--- a/segment-tree-rmq/src/segmentTree.objects.test.ts
+++ b/segment-tree-rmq/src/segmentTree.objects.test.ts
@@ -26,6 +26,7 @@ describe("SegmentTree with custom objects", () => {
 
     expect(tree.query(0, data.length - 1)).toEqual({ min: 1, max: 7 });
     expect(tree.query(1, 3)).toEqual({ min: 2, max: 6 });
+    expect(tree.query(2, 2)).toEqual({ min: 2, max: 5 });
 
     tree.update(2, { min: 0, max: 8 });
     expect(tree.query(0, data.length - 1)).toEqual({ min: 0, max: 8 });

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -9,6 +9,7 @@ describe("Segment Tree Tests", () => {
     const tree = new SegmentTree(data, sumOperator, identity);
 
     expect(tree.query(0, 0)).toBe(1);
+    expect(tree.query(3, 3)).toBe(4);
     expect(tree.query(7, 7)).toBe(8);
   });
 


### PR DESCRIPTION
## Summary
- simplify `query` with classic range loop that uses an exclusive right bound
- cover single-element queries in the middle and object segment trees

## Testing
- `npm test -w segment-tree-rmq`


------
https://chatgpt.com/codex/tasks/task_e_68a1e27f1f68832b980ab726951cdb2d