### PR TITLE
refactor: simplify DOM node transform

### DIFF
--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -1,138 +1,22 @@
 import { describe, it, expect } from "vitest";
 import { polyfillDom } from "../setupDom.ts";
-import {
-  updateNode,
-  isSVGMatrix,
-  domMatrixToSVGMatrix,
-} from "./domNodeTransform.ts";
+import { updateNode } from "./domNodeTransform.ts";
+
 await polyfillDom();
 
-class FakeSVGMatrix {
-  constructor(
-    public a = 1,
-    public b = 0,
-    public c = 0,
-    public d = 1,
-    public e = 0,
-    public f = 0,
-  ) {}
-}
+class FakeNode {
+  attributes: Record<string, string> = {};
 
-class FakeSVGSVGElement {
-  createSVGMatrix() {
-    return new FakeSVGMatrix();
+  setAttribute(name: string, value: string) {
+    this.attributes[name] = value;
   }
-}
-
-interface FakeTransform {
-  matrix: FakeSVGMatrix;
-}
-
-class FakeTransformList {
-  last?: FakeSVGMatrix;
-
-  createSVGTransformFromMatrix(matrix: unknown): FakeTransform {
-    if (!(matrix instanceof FakeSVGMatrix)) {
-      throw new TypeError("parameter 1 is not of type 'SVGMatrix'");
-    }
-    return { matrix };
-  }
-
-  initialize(t: FakeTransform): void {
-    this.last = t.matrix;
-  }
-}
-
-function createNode() {
-  const svg = new FakeSVGSVGElement();
-  return {
-    transform: { baseVal: new FakeTransformList() },
-    ownerSVGElement: svg,
-  } as unknown as SVGGraphicsElement & {
-    transform: { baseVal: FakeTransformList };
-    ownerSVGElement: FakeSVGSVGElement;
-  };
 }
 
 describe("updateNode", () => {
-  it("applies matrix to transform list", () => {
-    const node = createNode();
-    const matrix = new FakeSVGMatrix();
-    matrix.e = 10;
-    matrix.f = 20;
-    updateNode(node, matrix as unknown as SVGMatrix);
-    expect(node.transform.baseVal.last).toBe(matrix);
-  });
-
-  it("converts DOMMatrix to SVGMatrix", () => {
-    const node = createNode();
-    const domMatrix = new DOMMatrix().translate(5, 6);
-    updateNode(node, domMatrix as unknown as DOMMatrix);
-    const last = node.transform.baseVal.last as FakeSVGMatrix;
-    expect(last).toBeInstanceOf(FakeSVGMatrix);
-    expect(last.e).toBeCloseTo(5);
-    expect(last.f).toBeCloseTo(6);
-  });
-
-  it("throws when node is detached from SVG root", () => {
-    const node = {
-      transform: { baseVal: new FakeTransformList() },
-      ownerSVGElement: null,
-    } as unknown as SVGGraphicsElement & {
-      transform: { baseVal: FakeTransformList };
-      ownerSVGElement: null;
-    };
-    const matrix = new FakeSVGMatrix();
-    expect(() => {
-      updateNode(node, matrix as unknown as SVGMatrix);
-    }).toThrow(/SVG root not found/);
-  });
-});
-
-describe("domMatrixToSVGMatrix", () => {
-  it("returns same matrix for SVGMatrix", () => {
-    const svg = new FakeSVGSVGElement();
-    const matrix = svg.createSVGMatrix();
-    const result = domMatrixToSVGMatrix(
-      svg as unknown as SVGSVGElement,
-      matrix as unknown as DOMMatrix,
-    );
-    expect(result).toBe(matrix);
-  });
-
-  it("converts DOMMatrix to SVGMatrix", () => {
-    const svg = new FakeSVGSVGElement();
-    const domMatrix = new DOMMatrix().translate(5, 6);
-    const result = domMatrixToSVGMatrix(
-      svg as unknown as SVGSVGElement,
-      domMatrix as unknown as DOMMatrix,
-    );
-    expect(result).toBeInstanceOf(FakeSVGMatrix);
-    expect(result.e).toBeCloseTo(5);
-    expect(result.f).toBeCloseTo(6);
-  });
-});
-
-describe("isSVGMatrix", () => {
-  it("returns true for SVGMatrix", () => {
-    const svg = new FakeSVGSVGElement();
-    const matrix = svg.createSVGMatrix();
-    expect(
-      isSVGMatrix(
-        matrix as unknown as DOMMatrix,
-        svg as unknown as SVGSVGElement,
-      ),
-    ).toBe(true);
-  });
-
-  it("returns false for DOMMatrix", () => {
-    const svg = new FakeSVGSVGElement();
-    const domMatrix = new DOMMatrix();
-    expect(
-      isSVGMatrix(
-        domMatrix as unknown as DOMMatrix,
-        svg as unknown as SVGSVGElement,
-      ),
-    ).toBe(false);
+  it("applies matrix transform as attribute string", () => {
+    const node = new FakeNode();
+    const matrix = new DOMMatrix().translate(5, 6);
+    updateNode(node as unknown as SVGGraphicsElement, matrix);
+    expect(node.attributes["transform"]).toBe("matrix(1,0,0,1,5,6)");
   });
 });

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -1,35 +1,4 @@
-export function isSVGMatrix(
-  matrix: DOMMatrix,
-  svg: SVGSVGElement,
-): matrix is SVGMatrix {
-  return matrix.constructor === svg.createSVGMatrix().constructor;
-}
-
-export function domMatrixToSVGMatrix(
-  svg: SVGSVGElement,
-  m: DOMMatrix,
-): SVGMatrix {
-  if (isSVGMatrix(m, svg)) {
-    return m;
-  }
-  const sm = svg.createSVGMatrix();
-  const dm = m as DOMMatrix;
-  sm.a = dm.a;
-  sm.b = dm.b;
-  sm.c = dm.c;
-  sm.d = dm.d;
-  sm.e = dm.e;
-  sm.f = dm.f;
-  return sm;
-}
-
 export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
-  const svgTransformList = n.transform.baseVal;
-  const svg = n instanceof SVGSVGElement ? n : n.ownerSVGElement;
-  if (!svg) {
-    throw new Error("Cannot update transform: SVG root not found");
-  }
-  const matrix = domMatrixToSVGMatrix(svg, m);
-  const t = svgTransformList.createSVGTransformFromMatrix(matrix);
-  svgTransformList.initialize(t);
+  const components = [m.a, m.b, m.c, m.d, m.e, m.f].join(",");
+  n.setAttribute("transform", `matrix(${components})`);
 }

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -19,22 +19,15 @@ describe("viewZoomTransform helpers", () => {
   });
 
   it("updates SVG node transform with a matrix", () => {
-    const calls: DOMMatrix[] = [];
-    const baseVal = {
-      createSVGTransformFromMatrix: (m: DOMMatrix) => ({ m }),
-      initialize(t: { m: DOMMatrix }) {
-        calls.push(t.m);
-      },
-    };
+    const calls: string[] = [];
     const node = {
-      transform: { baseVal },
-      ownerSVGElement: {
-        createSVGMatrix: () => new DOMMatrix(),
+      setAttribute(_name: string, value: string) {
+        calls.push(value);
       },
     } as unknown as SVGGraphicsElement;
     const matrix = new DOMMatrix([1, 0, 0, 1, 2, 3]);
 
     updateNode(node, matrix);
-    expect(calls[0]).toBe(matrix);
+    expect(calls[0]).toBe("matrix(1,0,0,1,2,3)");
   });
 });


### PR DESCRIPTION
## Summary
- simplify DOM matrix handling by setting the `transform` attribute directly
- update tests to expect transform strings

## Testing
- `npm run format`
- `git commit -am "refactor: simplify DOM node transform"`


------
https://chatgpt.com/codex/tasks/task_e_68a1e26d5498832b8a197f4190103a6b