### PR TITLE
fix: refresh chart after updating scale extent

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -119,6 +119,7 @@ export class ZoomState {
     if (clampedK !== current.k) {
       this.zoomBehavior.scaleTo(this.zoomArea, clampedK);
     }
+    this.refreshChart();
   };
 
   public updateExtents = (dimensions: { width: number; height: number }) => {

--- a/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
+++ b/svg-time-series/src/chart/zoomState.validateScaleExtent.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect } from "vitest";
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import type { Selection } from "d3-selection";
+import { select } from "d3-selection";
+import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
 
 describe("ZoomState.validateScaleExtent", () => {
@@ -49,5 +55,32 @@ describe("ZoomState.validateScaleExtent", () => {
 
   it("returns extent when valid", () => {
     expect(ZoomState.validateScaleExtent([1, 2])).toEqual([1, 2]);
+  });
+});
+
+describe("ZoomState.setScaleExtent", () => {
+  it("refreshes the chart after updating scale extent", () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = select(svg).append("rect");
+    const refreshChart = vi.fn();
+    const state = {
+      dimensions: { width: 100, height: 100 },
+      axisRenders: [],
+      applyZoomTransform: vi.fn(),
+      setDimensions: vi.fn(),
+    } as unknown as RenderState;
+    const zs = new ZoomState(
+      rect as unknown as Selection<
+        SVGRectElement,
+        unknown,
+        HTMLElement,
+        unknown
+      >,
+      state,
+      refreshChart,
+    );
+    refreshChart.mockClear();
+    zs.setScaleExtent([0.5, 5]);
+    expect(refreshChart).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- refresh chart after updating scale extent
- test refresh triggered when setting scale extent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e28fd3b0832b98f3dde88204e7b9