### PR TITLE
chore: drop redundant import lint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -54,7 +54,6 @@ export default config(
     },
   },
   ...configs.strictTypeChecked,
-  importPlugin.flatConfigs.recommended,
   importPlugin.flatConfigs.typescript,
   prettierConfig,
   {


### PR DESCRIPTION
## Summary
- remove import plugin's recommended config from ESLint setup
- retain TypeScript-specific import rules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1e923de2c832bb60954ab845f8888