### PR TITLE
refactor: centralize zoom area node guard

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -29,6 +29,10 @@ export class ZoomState {
   private zoomScheduler: ZoomScheduler;
   private scaleExtent: [number, number];
   private zoomAreaNode: SVGRectElement | null;
+  private getZoomAreaNode(): SVGRectElement | null {
+    const node = this.zoomArea.node();
+    return node && this.zoomAreaNode ? node : null;
+  }
 
   public static validateScaleExtent(extent: unknown): [number, number] {
     const error = () =>
@@ -107,8 +111,8 @@ export class ZoomState {
   };
 
   public setScaleExtent = (extent: [number, number]) => {
-    const node = this.zoomArea.node();
-    if (!node || !this.zoomAreaNode) {
+    const node = this.getZoomAreaNode();
+    if (!node) {
       return;
     }
     this.scaleExtent = ZoomState.validateScaleExtent(extent);
@@ -123,8 +127,8 @@ export class ZoomState {
   };
 
   public updateExtents = (dimensions: { width: number; height: number }) => {
-    const node = this.zoomArea.node();
-    if (!node || !this.zoomAreaNode) {
+    const node = this.getZoomAreaNode();
+    if (!node) {
       return;
     }
     this.zoomBehavior.scaleExtent(this.scaleExtent).translateExtent([


### PR DESCRIPTION
## Summary
- add helper to safely fetch zoom area node
- reuse helper in zoom extent updates

## Testing
- `npm run format`
- `git commit -am "refactor: centralize zoom area node guard"`

------
https://chatgpt.com/codex/tasks/task_e_68a1f7cfa4b8832b95d01ab47ecca3a3