### PR TITLE
refactor: restrict buildAxisTree axis to 0 or 1

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -468,11 +468,6 @@ describe("ChartData", () => {
     expect(tree.query(0, 2)).toEqual({ min: 1, max: 3 });
   });
 
-  it("throws when building axis tree with invalid axis index", () => {
-    const cd = new ChartData(makeSource([[0], [1]], [0]));
-    expect(() => cd.buildAxisTree(2)).toThrow(/axis.*0 or 1/);
-  });
-
   describe("single-axis", () => {
     it("handles data without second series", () => {
       const source: IDataSource = {

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -146,12 +146,7 @@ export class ChartData {
     });
   }
 
-  buildAxisTree(axis: number): SegmentTree<IMinMax> {
-    if (axis !== 0 && axis !== 1) {
-      throw new Error(
-        `ChartData.buildAxisTree axis must be 0 or 1; received ${String(axis)}`,
-      );
-    }
+  buildAxisTree(axis: 0 | 1): SegmentTree<IMinMax> {
     return this.axes[axis].buildTree();
   }
 


### PR DESCRIPTION
## Summary
- restrict ChartData.buildAxisTree to accept axis 0 or 1 instead of number
- drop runtime axis validation and adjust tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f7fc5fa4832b8e0e537e2784da8a