### PR TITLE
feat: guard SVGMatrix detection

### DIFF
--- a/svg-time-series/src/utils/domNodeTransform.test.ts
+++ b/svg-time-series/src/utils/domNodeTransform.test.ts
@@ -6,6 +6,9 @@ await polyfillDom();
 
 class FakeNode {
   attributes: Record<string, string> = {};
+  ownerSVGElement = new (globalThis.SVGSVGElement as unknown as {
+    new (): SVGSVGElement;
+  })();
 
   setAttribute(name: string, value: string) {
     this.attributes[name] = value;

--- a/svg-time-series/src/utils/domNodeTransform.ts
+++ b/svg-time-series/src/utils/domNodeTransform.ts
@@ -1,4 +1,48 @@
+function isSVGMatrix(
+  matrix: DOMMatrix,
+  svg: SVGSVGElement,
+): matrix is SVGMatrix {
+  const prototypeMatrix = (
+    svg as unknown as { createSVGMatrix: () => DOMMatrix }
+  ).createSVGMatrix();
+  const hasSVGMatrix =
+    typeof SVGMatrix !== "undefined" && !(prototypeMatrix instanceof DOMMatrix);
+  if (!hasSVGMatrix) {
+    return false;
+  }
+  if (matrix instanceof DOMMatrix) {
+    return false;
+  }
+  return "a" in matrix && "b" in matrix;
+}
+
+export function domMatrixToSVGMatrix(
+  svg: SVGSVGElement,
+  m: DOMMatrix,
+): SVGMatrix {
+  if (isSVGMatrix(m, svg)) {
+    return m;
+  }
+  const sm = (
+    svg as unknown as { createSVGMatrix: () => DOMMatrix }
+  ).createSVGMatrix();
+  sm.multiplySelf(m);
+  return sm as unknown as SVGMatrix;
+}
+
 export function updateNode(n: SVGGraphicsElement, m: DOMMatrix) {
-  const components = [m.a, m.b, m.c, m.d, m.e, m.f].join(",");
+  const svg = n instanceof SVGSVGElement ? n : n.ownerSVGElement;
+  if (!svg) {
+    throw new Error("Cannot update transform: SVG root not found");
+  }
+  const matrix = domMatrixToSVGMatrix(svg, m);
+  const components = [
+    matrix.a,
+    matrix.b,
+    matrix.c,
+    matrix.d,
+    matrix.e,
+    matrix.f,
+  ].join(",");
   n.setAttribute("transform", `matrix(${components})`);
 }

--- a/svg-time-series/src/viewZoomTransform.test.ts
+++ b/svg-time-series/src/viewZoomTransform.test.ts
@@ -24,6 +24,9 @@ describe("viewZoomTransform helpers", () => {
       setAttribute(_name: string, value: string) {
         calls.push(value);
       },
+      ownerSVGElement: new (globalThis.SVGSVGElement as unknown as {
+        new (): SVGSVGElement;
+      })(),
     } as unknown as SVGGraphicsElement;
     const matrix = new DOMMatrix([1, 0, 0, 1, 2, 3]);
 


### PR DESCRIPTION
## Summary
- Safely detect SVGMatrix instances without relying on constructor comparisons
- Convert DOMMatrix to SVGMatrix via `multiplySelf` and update transforms through a single helper
- Provide SVG roots in tests to satisfy new guard logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f810b5fc832bbccae8da765f40d7