### PR TITLE
feat: update chart data update signature

### DIFF
--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -39,7 +39,7 @@ onCsv((data: [number, number][]) => {
   let j = 0;
   animateBench(() => {
     const point = data[j % data.length];
-    chart.updateChartWithNewData(point[0], point[1]);
+    chart.updateChartWithNewData([point[0], point[1]]);
     j++;
   });
 

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -71,7 +71,7 @@ export function drawCharts(
   setInterval(function () {
     const newData = data[j % data.length];
     charts.forEach((c) => {
-      c.updateChartWithNewData(newData[0], newData[1]);
+      c.updateChartWithNewData([newData[0], newData[1]]);
     });
     j++;
   }, 5000);

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -213,7 +213,7 @@ describe("chart interaction single-axis", () => {
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData(50);
+    chart.updateChartWithNewData([50]);
     vi.runAllTimers();
 
     onHover(1);

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -238,7 +238,7 @@ describe("chart interaction", () => {
     const { onHover, svgEl, legend, chart } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData(50, 60);
+    chart.updateChartWithNewData([50, 60]);
     vi.runAllTimers();
 
     onHover(1);

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -101,7 +101,7 @@ describe("TimeSeriesChart", () => {
     appendSpy.mockClear();
     drawSpy.mockClear();
 
-    chart.updateChartWithNewData(10);
+    chart.updateChartWithNewData([10]);
 
     expect(appendSpy).toHaveBeenCalledWith(10);
     expect(drawSpy).toHaveBeenCalledWith(internal.data.data);
@@ -110,7 +110,7 @@ describe("TimeSeriesChart", () => {
   it("throws when provided fewer values than series count", () => {
     const { chart } = createChart();
     expect(() => {
-      chart.updateChartWithNewData();
+      chart.updateChartWithNewData([]);
     }).toThrow(
       "TimeSeriesChart.updateChartWithNewData expected 1 values, received 0",
     );
@@ -119,7 +119,7 @@ describe("TimeSeriesChart", () => {
   it("throws when provided more values than series count", () => {
     const { chart } = createChart();
     expect(() => {
-      chart.updateChartWithNewData(10, 20);
+      chart.updateChartWithNewData([10, 20]);
     }).toThrow(
       "TimeSeriesChart.updateChartWithNewData expected 1 values, received 2",
     );

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -126,7 +126,7 @@ export class TimeSeriesChart {
     };
   }
 
-  public updateChartWithNewData(...values: number[]): void {
+  public updateChartWithNewData(values: number[]): void {
     if (values.length !== this.data.seriesCount) {
       throw new Error(
         `TimeSeriesChart.updateChartWithNewData expected ${String(


### PR DESCRIPTION
## Summary
- refactor `updateChartWithNewData` to accept an array of numbers
- validate value count against series count with clear error messages
- update call sites and tests to use the array-based API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20ac9d774832b821d0afb5651f840