### PR TITLE
feat: output compiled library to dist

### DIFF
--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -11,7 +11,7 @@
   "files": [
     "dist/*"
   ],
-  "main": "src/draw.ts",
+  "main": "dist/draw.js",
   "type": "module",
   "dependencies": {
     "d3-brush": "^3.0.0",
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",

--- a/svg-time-series/vite.config.ts
+++ b/svg-time-series/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => {
     build: {
       lib: {
         entry: "src/draw.ts",
-        fileName: "index",
+        fileName: "draw",
         formats: ["es"],
       },
       rollupOptions: {


### PR DESCRIPTION
## Summary
- point `main` field to compiled entry and use dist as publication files
- generate library bundle as `dist/draw.js`

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a20a989aec832baae1522fd3dac2b6