### PR TITLE
fix: clone selected time window

### DIFF
--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -266,4 +266,17 @@ describe("TimeSeriesChart", () => {
     expect(clearBrushSelection).toHaveBeenCalled();
     expect(chart.getSelectedTimeWindow()).toBeNull();
   });
+
+  it("returns a cloned selected time window", () => {
+    const { chart } = createChart();
+    (
+      chart as unknown as { selectedTimeWindow: [number, number] }
+    ).selectedTimeWindow = [1, 2];
+    const window1 = chart.getSelectedTimeWindow();
+    expect(window1).toEqual([1, 2]);
+    if (window1) {
+      window1[0] = 100;
+    }
+    expect(chart.getSelectedTimeWindow()).toEqual([1, 2]);
+  });
 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -175,7 +175,9 @@ export class TimeSeriesChart {
   };
 
   public getSelectedTimeWindow = (): [number, number] | null => {
-    return this.selectedTimeWindow;
+    return this.selectedTimeWindow
+      ? ([...this.selectedTimeWindow] as [number, number])
+      : null;
   };
 
   public resize = (dimensions: { width: number; height: number }) => {


### PR DESCRIPTION
## Summary
- clone selected time window before returning it
- add regression test for selected time window mutation

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a20ab11b5c832ba335251a3c37fb42