### PR TITLE
build(segment-tree-rmq): publish compiled outputs

### DIFF
--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -4,13 +4,13 @@
   "description": "Generic segment tree implementation for range queries",
   "license": "WTFPL",
   "files": [
-    "src/*"
+    "dist/*"
   ],
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.json",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "bench": "npm run bench:segment-tree",

--- a/segment-tree-rmq/tsconfig.json
+++ b/segment-tree-rmq/tsconfig.json
@@ -5,7 +5,9 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "noEmit": false,
+    "allowImportingTsExtensions": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.test.ts"]

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -36,7 +36,7 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "tsc && vite build",
+    "build": "npm run build -w segment-tree-rmq && tsc && vite build",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- publish built files from dist and point entry fields to them
- allow emitting compiled JS and declarations

## Testing
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a20aa02890832b977e6baeb6bd5676