### PR TITLE
Validate numeric inputs in updateChartWithNewData

### DIFF
--- a/svg-time-series/src/chart/validation.test.ts
+++ b/svg-time-series/src/chart/validation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { assertPositiveInteger, assertFiniteNumber } from "./validation.ts";
+import {
+  assertPositiveInteger,
+  assertFiniteNumber,
+  assertFiniteOrNaN,
+} from "./validation.ts";
 
 describe("assertPositiveInteger", () => {
   it("throws for non-positive or fractional values", () => {
@@ -40,6 +44,29 @@ describe("assertFiniteNumber", () => {
   it("succeeds for finite numbers", () => {
     expect(() => {
       assertFiniteNumber(123, "value");
+    }).not.toThrow();
+  });
+});
+
+describe("assertFiniteOrNaN", () => {
+  it("throws for non-number or infinite values", () => {
+    expect(() => {
+      assertFiniteOrNaN(undefined as unknown as number, "value");
+    }).toThrow(/finite number or NaN/);
+    expect(() => {
+      assertFiniteOrNaN(Infinity, "value");
+    }).toThrow(/finite number or NaN/);
+    expect(() => {
+      assertFiniteOrNaN("foo" as unknown as number, "value");
+    }).toThrow(/finite number or NaN/);
+  });
+
+  it("succeeds for finite numbers and NaN", () => {
+    expect(() => {
+      assertFiniteOrNaN(5, "value");
+    }).not.toThrow();
+    expect(() => {
+      assertFiniteOrNaN(NaN, "value");
     }).not.toThrow();
   });
 });

--- a/svg-time-series/src/chart/validation.ts
+++ b/svg-time-series/src/chart/validation.ts
@@ -28,3 +28,15 @@ export function assertPositiveFinite(
     throw new Error(`${name} must be a finite, positive number`);
   }
 }
+
+export function assertFiniteOrNaN(
+  value: unknown,
+  name: string,
+): asserts value is number {
+  if (
+    typeof value !== "number" ||
+    !(Number.isFinite(value) || Number.isNaN(value))
+  ) {
+    throw new Error(`${name} must be a finite number or NaN`);
+  }
+}

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -125,6 +125,26 @@ describe("TimeSeriesChart", () => {
     );
   });
 
+  it("throws for invalid value types", () => {
+    const { chart } = createChart();
+    expect(() => {
+      chart.updateChartWithNewData([undefined as unknown as number]);
+    }).toThrow(/values\[0\] must be a finite number or NaN/);
+    expect(() => {
+      chart.updateChartWithNewData([Infinity]);
+    }).toThrow(/values\[0\] must be a finite number or NaN/);
+    expect(() => {
+      chart.updateChartWithNewData(["oops" as unknown as number]);
+    }).toThrow(/values\[0\] must be a finite number or NaN/);
+  });
+
+  it("accepts NaN values", () => {
+    const { chart } = createChart();
+    expect(() => {
+      chart.updateChartWithNewData([NaN]);
+    }).not.toThrow();
+  });
+
   it("resizes svg and refreshes render state", () => {
     const { chart, svgEl, legend } = createChart();
     const internal = chart as unknown as {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -11,6 +11,7 @@ import type { RenderState } from "./chart/render.ts";
 import type { ILegendController } from "./chart/legend.ts";
 import { ZoomState } from "./chart/zoomState.ts";
 import type { IZoomStateOptions } from "./chart/zoomState.ts";
+import { assertFiniteOrNaN } from "./chart/validation.ts";
 
 export type { IDataSource } from "./chart/data.ts";
 export type { IMinMax } from "./chart/axisData.ts";
@@ -133,6 +134,9 @@ export class TimeSeriesChart {
           this.data.seriesCount,
         )} values, received ${String(values.length)}`,
       );
+    }
+    for (let i = 0; i < values.length; i++) {
+      assertFiniteOrNaN(values[i], `values[${String(i)}]`);
     }
     this.data.append(...values);
     this.refreshAll();


### PR DESCRIPTION
## Summary
- add `assertFiniteOrNaN` helper to allow NaN while rejecting non-numeric or infinite values
- verify each incoming value in `updateChartWithNewData` and throw descriptive errors
- test validation for invalid and NaN data points

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21049d0f0832b8ddf7e54c08c7aa3