### PR TITLE
refactor: simplify index clamping

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -173,14 +173,8 @@ describe("ChartData", () => {
         [0, 1],
       ),
     );
-    expect(cd.getPoint(1_000_000)).toEqual({
-      values: [50, 60],
-      timestamp: 2,
-    });
-    expect(cd.getPoint(-1_000_000)).toEqual({
-      values: [10, 20],
-      timestamp: 0,
-    });
+    expect(cd.clampIndex(1_000_000)).toBe(cd.length - 1);
+    expect(cd.clampIndex(-1_000_000)).toBe(0);
   });
 
   it("converts time to index and back", () => {

--- a/svg-time-series/src/chart/dataWindow.ts
+++ b/svg-time-series/src/chart/dataWindow.ts
@@ -97,6 +97,7 @@ export class DataWindow {
    * Exposed for shared bounds checking across components.
    */
   public clampIndex(idx: number): number {
-    return this.indexScale.invert(this.indexScale(idx));
+    const max = this.window.length - 1;
+    return Math.max(0, Math.min(idx, max));
   }
 }


### PR DESCRIPTION
## Summary
- simplify index clamping with Math.min/Math.max
- cover extreme index clamping in unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21037c9a4832bbf9ff1d1d5f2cda2