### PR TITLE
refactor: extract axis manager helpers

### DIFF
--- a/svg-time-series/src/chart/axisManager.helpers.test.ts
+++ b/svg-time-series/src/chart/axisManager.helpers.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from "vitest";
+import { scaleTime } from "d3-scale";
+import { zoomIdentity } from "d3-zoom";
+
+import { polyfillDom } from "../setupDom.ts";
+import { AxisModel, createBaseXScale, updateAxisModel } from "./axisManager.ts";
+import { ChartData } from "./data.ts";
+
+await polyfillDom();
+
+const makeChartData = (): ChartData =>
+  new ChartData({
+    startTime: 0,
+    timeStep: 1,
+    length: 10,
+    seriesAxes: [0],
+    getSeries: (i) => i,
+  });
+
+describe("createBaseXScale", () => {
+  it("uses the full time domain without mutating the input", () => {
+    const data = makeChartData();
+    const x = scaleTime()
+      .domain([new Date(5), new Date(6)])
+      .range([0, 1]);
+    const base = createBaseXScale(x, data.window);
+    expect(base.domain()).toEqual(data.window.timeDomainFull());
+    expect(x.domain()).toEqual([new Date(5), new Date(6)]);
+  });
+});
+
+describe("updateAxisModel", () => {
+  it("updates the axis when series data exists", () => {
+    const data = makeChartData();
+    const axis = new AxisModel();
+    axis.scale.range([100, 0]);
+    const x = scaleTime()
+      .domain([new Date(0), new Date(9)])
+      .range([0, 100]);
+    const baseX = createBaseXScale(x, data.window);
+    const t = zoomIdentity.scale(2);
+    const dIndexVisible = data.dIndexFromTransform(
+      t,
+      baseX.range() as [number, number],
+    );
+    updateAxisModel(axis, 0, data, t, dIndexVisible);
+    const { scale: baseScaleRaw } = data.axisTransform(0, dIndexVisible);
+    const expectedDomain = t
+      .rescaleY(baseScaleRaw.range(axis.scale.range() as [number, number]))
+      .domain();
+    expect(axis.scale.domain()).toEqual(expectedDomain);
+  });
+
+  it("skips axes without series", () => {
+    const data = makeChartData();
+    const axis = new AxisModel();
+    const spy = vi.spyOn(axis, "updateFromData");
+    updateAxisModel(axis, 1, data, zoomIdentity, [0, 1]);
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -7,6 +7,7 @@ import { SegmentTree } from "segment-tree-rmq";
 import type { MyAxis } from "../axis.ts";
 import { ViewportTransform } from "../ViewportTransform.ts";
 import type { ChartData } from "./data.ts";
+import type { DataWindow } from "./dataWindow.ts";
 import type { IMinMax } from "./axisData.ts";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
 
@@ -45,6 +46,34 @@ export interface AxisRenderState {
   g: Selection<SVGGElement, unknown, HTMLElement, unknown>;
 }
 
+export function createBaseXScale(
+  x: ScaleTime<number, number>,
+  window: DataWindow,
+): ScaleTime<number, number> {
+  return x.copy().domain(window.timeDomainFull()).nice();
+}
+
+export function updateAxisModel(
+  axisModel: AxisModel,
+  axisIdx: number,
+  data: ChartData,
+  transform: ZoomTransform,
+  dIndexVisible: [number, number],
+): void {
+  const idxs = data.seriesByAxis[axisIdx] ?? [];
+  if (idxs.length === 0) {
+    return;
+  }
+  const { tree, scale: baseScaleRaw } =
+    data.axes[axisIdx]!.axisTransform(dIndexVisible);
+  axisModel.updateFromData(
+    tree,
+    baseScaleRaw,
+    transform,
+    data.window.bIndexFull,
+  );
+}
+
 export class AxisManager {
   public axes: AxisModel[] = [];
   public x!: ScaleTime<number, number>;
@@ -65,28 +94,14 @@ export class AxisManager {
 
   updateScales(transform: ZoomTransform): void {
     this.data.assertAxisBounds(this.axes.length);
-    const baseX = this.x
-      .copy()
-      .domain(this.data.window.timeDomainFull())
-      .nice();
+    const baseX = createBaseXScale(this.x, this.data.window);
     const dIndexVisible = this.data.window.dIndexFromTransform(
       transform,
       baseX.range() as [number, number],
     );
     this.x = transform.rescaleX(baseX).copy();
     this.axes.forEach((a, i) => {
-      const idxs = this.data.seriesByAxis[i] ?? [];
-      if (idxs.length === 0) {
-        return;
-      }
-      const { tree, scale: baseScaleRaw } =
-        this.data.axes[i]!.axisTransform(dIndexVisible);
-      a.updateFromData(
-        tree,
-        baseScaleRaw,
-        transform,
-        this.data.window.bIndexFull,
-      );
+      updateAxisModel(a, i, this.data, transform, dIndexVisible);
     });
   }
 }


### PR DESCRIPTION
## Summary
- extract `createBaseXScale` and `updateAxisModel` helpers
- refactor `updateScales` to use helpers
- add unit tests for axis manager helpers

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2105a16e8832b9c128effdeb543c1