### PR TITLE
build(segment-tree-rmq): publish dist artifacts

### DIFF
--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -4,17 +4,18 @@
   "description": "Generic segment tree implementation for range queries",
   "license": "WTFPL",
   "files": [
-    "src/*"
+    "dist/*"
   ],
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.json",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
     "bench": "npm run bench:segment-tree",
     "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts --run",
-    "test": "vitest run --reporter=dot"
+    "test": "vitest run --reporter=dot",
+    "prepare": "npm run build"
   }
 }

--- a/segment-tree-rmq/tsconfig.json
+++ b/segment-tree-rmq/tsconfig.json
@@ -5,7 +5,9 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "noEmit": false,
+    "allowImportingTsExtensions": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["**/*.test.ts"]


### PR DESCRIPTION
## Summary
- publish only compiled artifacts from segment-tree-rmq
- compile TypeScript to `dist/` with emitted declarations

## Testing
- `npm run format`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a211d8dfc0832bb467ee48a5bf8df4