### PR TITLE
fix: use axis scale for brush window

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -216,7 +216,7 @@ describe("interaction.enableBrush", () => {
       onBrushEnd: (e: D3BrushEvent<unknown>) => void;
       state: {
         screenToModelX: (x: number) => number;
-        xTransform: { toScreenFromModelX: (x: number) => number };
+        axes: { x: { scale: (x: number) => number } };
       };
       zoomState: {
         zoomBehavior: { transform: (n: unknown, t: unknown) => void };
@@ -224,9 +224,9 @@ describe("interaction.enableBrush", () => {
     };
     internal.zoomState.zoomBehavior = { transform: vi.fn() };
     internal.state.screenToModelX = (x: number) => x;
-    (
-      internal.state.xTransform as { toScreenFromModelX: (x: number) => number }
-    ).toScreenFromModelX = (x: number) => x;
+    (internal.state.axes.x as { scale: (x: number) => number }).scale = (
+      x: number,
+    ) => x;
     internal.onBrushEnd({
       selection: [0, 10],
     } as unknown as D3BrushEvent<unknown>);
@@ -250,7 +250,7 @@ describe("interaction.disableBrush", () => {
       onBrushEnd: (e: D3BrushEvent<unknown>) => void;
       state: {
         screenToModelX: (x: number) => number;
-        xTransform: { toScreenFromModelX: (x: number) => number };
+        axes: { x: { scale: (x: number) => number } };
       };
       zoomState: {
         zoomBehavior: { transform: (n: unknown, t: unknown) => void };
@@ -258,9 +258,9 @@ describe("interaction.disableBrush", () => {
     };
     internal.zoomState.zoomBehavior = { transform: vi.fn() };
     internal.state.screenToModelX = (x: number) => x;
-    (
-      internal.state.xTransform as { toScreenFromModelX: (x: number) => number }
-    ).toScreenFromModelX = (x: number) => x;
+    (internal.state.axes.x as { scale: (x: number) => number }).scale = (
+      x: number,
+    ) => x;
     internal.onBrushEnd({
       selection: [0, 10],
     } as unknown as D3BrushEvent<unknown>);

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -267,15 +267,13 @@ describe("TimeSeriesChart", () => {
     const internal = chart as unknown as {
       state: {
         screenToModelX: ReturnType<typeof vi.fn>;
-        xTransform: { toScreenFromModelX: ReturnType<typeof vi.fn> };
+        axes: { x: { scale: ReturnType<typeof vi.fn> } };
       };
       zoomState: { zoomBehavior: { transform: ReturnType<typeof vi.fn> } };
       onBrushEnd: (event: D3BrushEvent<unknown>) => void;
     };
     vi.spyOn(internal.state, "screenToModelX").mockReturnValue(0);
-    vi.spyOn(internal.state.xTransform, "toScreenFromModelX").mockReturnValue(
-      10,
-    );
+    vi.spyOn(internal.state.axes.x, "scale").mockReturnValue(10);
     const transformSpy = vi.spyOn(internal.zoomState.zoomBehavior, "transform");
 
     internal.onBrushEnd({

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -227,8 +227,8 @@ export class TimeSeriesChart {
     }
     const m0 = this.data.clampIndex(this.state.screenToModelX(x0));
     const m1 = this.data.clampIndex(this.state.screenToModelX(x1));
-    const sx0 = this.state.xTransform.toScreenFromModelX(m0);
-    const sx1 = this.state.xTransform.toScreenFromModelX(m1);
+    const sx0 = this.state.axes.x.scale(m0);
+    const sx1 = this.state.axes.x.scale(m1);
     if (m0 === m1 || sx0 === sx1) {
       this.clearBrush();
       return;
@@ -237,9 +237,8 @@ export class TimeSeriesChart {
     const k = width / (sx1 - sx0);
     const t = zoomIdentity.scale(k).translate(-sx0, 0);
     this.zoomState.zoomBehavior.transform(this.zoomArea, t);
-    const startIdx = this.data.startIndex;
-    const t0 = this.data.startTime + (startIdx + m0) * this.data.timeStep;
-    const t1 = this.data.startTime + (startIdx + m1) * this.data.timeStep;
+    const t0 = +this.data.indexToTime(m0);
+    const t1 = +this.data.indexToTime(m1);
     this.clearBrush();
     this.selectedTimeWindow = [t0, t1];
   };


### PR DESCRIPTION
## Summary
- use x-axis scale for brush selection instead of viewport transform
- compute selected time window via `indexToTime`
- update tests for new scale-based logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a217480244832bb37173f44226738f