### PR TITLE
refactor: replace extent with math

### DIFF
--- a/svg-time-series/src/chart/axisData.ts
+++ b/svg-time-series/src/chart/axisData.ts
@@ -21,16 +21,17 @@ function scaleYRange(
   const startIdx = Math.floor(Math.min(i0, i1));
   const endIdx = Math.ceil(Math.max(i0, i1));
   const { min, max } = tree.query(startIdx, endIdx);
-  let [y0, y1] = extent([min, max]) as [number | undefined, number | undefined];
+  let y0 = Math.min(min, max);
+  let y1 = Math.max(min, max);
   if (!Number.isFinite(y0) || !Number.isFinite(y1)) {
     y0 = 0;
     y1 = 1;
   } else if (y0 === y1) {
     const epsilon = 0.5;
-    y0 = (y0 as number) - epsilon;
-    y1 = (y1 as number) + epsilon;
+    y0 -= epsilon;
+    y1 += epsilon;
   }
-  return [y0!, y1!];
+  return [y0, y1];
 }
 
 export function scaleY(

--- a/svg-time-series/src/chart/minMax.test.ts
+++ b/svg-time-series/src/chart/minMax.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { extent } from "d3-array";
 import { buildMinMax, minMaxIdentity } from "./minMax.ts";
 
 describe("buildMinMax", () => {
@@ -12,5 +13,47 @@ describe("buildMinMax", () => {
     const range = { min: -4, max: 7 } as const;
     expect(buildMinMax(range, minMaxIdentity)).toEqual(range);
     expect(buildMinMax(minMaxIdentity, range)).toEqual(range);
+  });
+});
+
+describe("Math.min/Math.max replacement for extent", () => {
+  const cases: Array<[string, number, number]> = [
+    ["normal inputs", 2, 10],
+    ["equal inputs", 5, 5],
+    ["non-finite inputs", Number.NaN, Number.POSITIVE_INFINITY],
+  ];
+
+  const oldRange = (min: number, max: number): [number, number] => {
+    let [y0, y1] = extent([min, max]) as [
+      number | undefined,
+      number | undefined,
+    ];
+    if (!Number.isFinite(y0) || !Number.isFinite(y1)) {
+      y0 = 0;
+      y1 = 1;
+    } else if (y0 === y1) {
+      const epsilon = 0.5;
+      y0 = (y0 as number) - epsilon;
+      y1 = (y1 as number) + epsilon;
+    }
+    return [y0!, y1!];
+  };
+
+  const newRange = (min: number, max: number): [number, number] => {
+    let y0 = Math.min(min, max);
+    let y1 = Math.max(min, max);
+    if (!Number.isFinite(y0) || !Number.isFinite(y1)) {
+      y0 = 0;
+      y1 = 1;
+    } else if (y0 === y1) {
+      const epsilon = 0.5;
+      y0 -= epsilon;
+      y1 += epsilon;
+    }
+    return [y0, y1];
+  };
+
+  it.each(cases)("matches extent for %s", (_name, min, max) => {
+    expect(newRange(min, max)).toEqual(oldRange(min, max));
   });
 });


### PR DESCRIPTION
## Summary
- refactor axisData to compute min/max without d3-array extent
- test Math.min/Math.max behavior matches extent for normal, equal, and non-finite inputs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a21c94d038832ba12c94d86d0b3fd9