### PR TITLE
refactor enableBrush brush reset and add test

### DIFF
--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -262,6 +262,21 @@ describe("TimeSeriesChart", () => {
     expect(rectNode.classList.contains("cursor-grabbing")).toBe(false);
   });
 
+  it("enabling brush clears selection and resets time window", () => {
+    const { chart } = createChart();
+    const internal = chart as unknown as {
+      clearBrush: ReturnType<typeof vi.fn>;
+      selectedTimeWindow: [number, number] | null;
+    };
+    internal.selectedTimeWindow = [1, 2];
+    const clearBrushSpy = vi.spyOn(internal, "clearBrush");
+
+    chart.enableBrush();
+
+    expect(clearBrushSpy).toHaveBeenCalled();
+    expect(chart.getSelectedTimeWindow()).toBeNull();
+  });
+
   it("clears brush and skips zoom when selection collapses", () => {
     const { chart } = createChart();
     const internal = chart as unknown as {

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -169,7 +169,6 @@ export class TimeSeriesChart {
 
   public enableBrush = () => {
     this.clearBrush();
-    this.selectedTimeWindow = null;
     this.brushLayer.style("display", null);
   };
 


### PR DESCRIPTION
## Summary
- avoid redundant `selectedTimeWindow` reset in `enableBrush`
- add unit test confirming `enableBrush` clears selection and resets time window

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21c88cd7c832ba0205b7183c72a19