### PR TITLE
test: add dom utilities and refactor tests

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -3,7 +3,6 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { JSDOM } from "jsdom";
 import { select } from "d3-selection";
 import type { Selection } from "d3-selection";
 
@@ -11,6 +10,7 @@ import type { IDataSource } from "../svg-time-series/src/chart/data.ts";
 import { ChartData } from "../svg-time-series/src/chart/data.ts";
 import { setupRender } from "../svg-time-series/src/chart/render.ts";
 import * as domNode from "../svg-time-series/src/utils/domNodeTransform.ts";
+import { createDiv } from "../test/domUtils.ts";
 import { polyfillDom } from "../test/setupDom.ts";
 
 import { LegendController } from "./LegendController.ts";
@@ -18,21 +18,13 @@ import { LegendController } from "./LegendController.ts";
 await polyfillDom();
 
 function createSvgAndLegend() {
-  const dom = new JSDOM(
-    `<div id="c"><svg></svg></div><div id="l"><div class="chart-legend__time"></div><div class="chart-legend__green_value"></div><div class="chart-legend__blue_value"></div></div>`,
-    {
-      pretendToBeVisual: true,
-      contentType: "text/html",
-    },
+  const { dom } = createDiv(
+    '<div id="c"><svg></svg></div><div id="l"><div class="chart-legend__time"></div><div class="chart-legend__green_value"></div><div class="chart-legend__blue_value"></div></div>',
   );
-  (
-    globalThis as unknown as { HTMLElement: typeof dom.window.HTMLElement }
-  ).HTMLElement = dom.window.HTMLElement;
-  const div = dom.window.document.getElementById("c") as HTMLDivElement;
-  Object.defineProperty(div, "clientWidth", { value: 100 });
-  Object.defineProperty(div, "clientHeight", { value: 100 });
-
-  const svg = select<HTMLDivElement, unknown>(div).select(
+  const container = dom.window.document.getElementById("c") as HTMLDivElement;
+  Object.defineProperty(container, "clientWidth", { value: 100 });
+  Object.defineProperty(container, "clientHeight", { value: 100 });
+  const svg = select<HTMLDivElement, unknown>(container).select(
     "svg",
   ) as unknown as Selection<SVGSVGElement, unknown, HTMLElement, unknown>;
   const legendDiv = select(

--- a/svg-time-series/src/axis.test.ts
+++ b/svg-time-series/src/axis.test.ts
@@ -1,18 +1,15 @@
 import { describe, it, expect } from "vitest";
-import { JSDOM } from "jsdom";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import { scaleLinear } from "d3-scale";
+import { createSvg } from "../../test/domUtils.ts";
 import { MyAxis, Orientation } from "./axis.ts";
 
 const NS = "http://www.w3.org/2000/svg";
 
 function createGroup() {
-  const dom = new JSDOM(`<svg xmlns="${NS}"></svg>`, {
-    contentType: "image/svg+xml",
-  });
-  const svg = dom.window.document.querySelector<SVGSVGElement>("svg")!;
-  const g = dom.window.document.createElementNS(NS, "g");
+  const { svg } = createSvg();
+  const g = svg.ownerDocument.createElementNS(NS, "g");
   svg.appendChild(g);
   return { g };
 }

--- a/test/domUtils.ts
+++ b/test/domUtils.ts
@@ -1,0 +1,23 @@
+import { JSDOM } from "jsdom";
+
+const NS = "http://www.w3.org/2000/svg";
+
+export function createDiv(innerHTML = "") {
+  const dom = new JSDOM(`<div>${innerHTML}</div>`, {
+    pretendToBeVisual: true,
+    contentType: "text/html",
+  });
+  (
+    globalThis as unknown as { HTMLElement: typeof dom.window.HTMLElement }
+  ).HTMLElement = dom.window.HTMLElement;
+  const div = dom.window.document.querySelector<HTMLDivElement>("div")!;
+  return { dom, div };
+}
+
+export function createSvg() {
+  const dom = new JSDOM(`<svg xmlns="${NS}"></svg>`, {
+    contentType: "image/svg+xml",
+  });
+  const svg = dom.window.document.querySelector<SVGSVGElement>("svg")!;
+  return { dom, svg };
+}


### PR DESCRIPTION
## Summary
- add shared DOM helpers for tests
- refactor LegendController and axis tests to use DOM helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21b469f70832b808565bb78b807bd