### PR TITLE
feat(segment-tree-rmq): add half-open range query

### DIFF
--- a/segment-tree-rmq/README.md
+++ b/segment-tree-rmq/README.md
@@ -22,8 +22,11 @@ import { SegmentTree } from "segment-tree-rmq";
 const data = [5, 3, 8, 6, 2, 7];
 const tree = new SegmentTree(data, (a, b) => Math.min(a, b), Infinity);
 
-// Query the minimum value in the range [1, 4]
+// Query the minimum value in the inclusive range [1, 4]
 console.log(tree.query(1, 4)); // 2
+
+// Query using a half-open range [1, 5)
+console.log(tree.queryRange(1, 5)); // 2
 
 // Update a value and query again
 tree.update(3, 1);

--- a/segment-tree-rmq/src/index.ts
+++ b/segment-tree-rmq/src/index.ts
@@ -96,4 +96,29 @@ export class SegmentTree<T> {
 
     return result;
   }
+
+  /**
+   * Queries the half-open range [start, endExclusive) in the tree.
+   *
+   * Both indices are zero-based and the end index is exclusive.
+   *
+   * @param start - Start index (inclusive).
+   * @param endExclusive - End index (exclusive).
+   */
+  queryRange(start: number, endExclusive: number): T {
+    if (!Number.isInteger(start) || !Number.isInteger(endExclusive)) {
+      throw new Error("Index must be an integer");
+    }
+    if (start < 0 || endExclusive > this.size) {
+      throw new Error("Index is out of range");
+    }
+    if (start > endExclusive) {
+      throw new Error("Range is not valid");
+    }
+    if (start === endExclusive) {
+      return this.identity;
+    }
+
+    return this.query(start, endExclusive - 1);
+  }
 }

--- a/segment-tree-rmq/src/segmentTree.test.ts
+++ b/segment-tree-rmq/src/segmentTree.test.ts
@@ -194,4 +194,28 @@ describe("Segment Tree Tests", () => {
     tree.update(1, 9);
     expect(tree.query(0, 5)).toBe(9);
   });
+
+  it("should return the identity for empty ranges", () => {
+    const data = [1, 2, 3];
+    const sumOperator = (a: number, b: number) => a + b;
+    const identity = 0;
+    const tree = new SegmentTree(data, sumOperator, identity);
+
+    expect(tree.queryRange(0, 0)).toBe(identity);
+    expect(tree.queryRange(2, 2)).toBe(identity);
+    expect(tree.queryRange(3, 3)).toBe(identity);
+  });
+
+  it("queryRange should match query for equivalent non-empty ranges", () => {
+    const data = [1, 2, 3, 4, 5];
+    const sumOperator = (a: number, b: number) => a + b;
+    const identity = 0;
+    const tree = new SegmentTree(data, sumOperator, identity);
+
+    for (let start = 0; start < data.length; start++) {
+      for (let end = start + 1; end <= data.length; end++) {
+        expect(tree.queryRange(start, end)).toBe(tree.query(start, end - 1));
+      }
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add `queryRange` for [start, end) queries with validation
- document `queryRange` usage
- cover empty ranges and equivalence with existing `query` in tests

## Testing
- `npm --workspace segment-tree-rmq test`


------
https://chatgpt.com/codex/tasks/task_e_68a21a849f14832b8ca679dfa8d83e7e