### PR TITLE
test: check legend cleanup on destroy

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -201,4 +201,38 @@ describe("LegendController", () => {
     vi.useRealTimers();
     lc.destroy();
   });
+
+  it("removes highlight dots and ignores highlightIndex after destroy", () => {
+    const { svg, legendDiv } = createSvgAndLegend();
+    const source: IDataSource = {
+      startTime: 0,
+      timeStep: 1,
+      length: 2,
+      getSeries: (i) => [10, 20][i]!,
+      seriesAxes: [0],
+    };
+    const data = new ChartData(source);
+    const state = setupRender(svg, data);
+    select<SVGPathElement, unknown>(state.series[0]!.path).attr(
+      "stroke",
+      "green",
+    );
+    const lc = new LegendController(legendDiv);
+    lc.init({
+      getPoint: data.getPoint.bind(data),
+      getLength: () => data.length,
+      series: state.series.map((s) => ({
+        path: s.path,
+        transform: state.axes.y[s.axisIdx]!.transform,
+      })),
+    });
+
+    expect(svg.selectAll("circle").size()).toBe(2);
+    lc.destroy();
+    expect(svg.selectAll("circle").size()).toBe(0);
+    expect(() => {
+      lc.highlightIndex(0);
+    }).not.toThrow();
+    expect(svg.selectAll("circle").size()).toBe(0);
+  });
 });

--- a/samples/LegendController.ts
+++ b/samples/LegendController.ts
@@ -29,6 +29,7 @@ export class LegendController implements ILegendController {
   private context!: LegendContext;
   private scheduleUpdate: () => void;
   private cancelUpdate: () => void;
+  private destroyed = false;
 
   constructor(
     legend: Selection<HTMLElement, unknown, HTMLElement, unknown>,
@@ -78,6 +79,9 @@ export class LegendController implements ILegendController {
   }
 
   public highlightIndex(idx: number): void {
+    if (this.destroyed) {
+      return;
+    }
     const clamped = Math.round(
       Math.min(Math.max(idx, 0), this.context.getLength() - 1),
     );
@@ -90,6 +94,9 @@ export class LegendController implements ILegendController {
   }
 
   public highlightIndexRaf(idx: number): void {
+    if (this.destroyed) {
+      return;
+    }
     const clamped = Math.round(
       Math.min(Math.max(idx, 0), this.context.getLength() - 1),
     );
@@ -102,10 +109,16 @@ export class LegendController implements ILegendController {
   }
 
   public refresh(): void {
+    if (this.destroyed) {
+      return;
+    }
     this.scheduleUpdate();
   }
 
   public clearHighlight(): void {
+    if (this.destroyed) {
+      return;
+    }
     this.legendTime.text("");
     this.legendGreen.text("");
     this.legendBlue.text("");
@@ -119,6 +132,9 @@ export class LegendController implements ILegendController {
   }
 
   private update() {
+    if (this.destroyed) {
+      return;
+    }
     const { values, timestamp } = this.context.getPoint(
       this.highlightedDataIdx,
     ) as { values?: number[]; timestamp?: number };
@@ -190,5 +206,6 @@ export class LegendController implements ILegendController {
     this.cancelUpdate();
     this.highlightedGreenDot.remove();
     this.highlightedBlueDot.remove();
+    this.destroyed = true;
   }
 }


### PR DESCRIPTION
## Summary
- ensure LegendController ignores highlight requests after being destroyed
- add regression test for destroy cleanup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a21b416d80832ba5124f4a6c53481f