### PR TITLE
refactor: use scale invert for screen→model X

### DIFF
--- a/svg-time-series/src/chart/dataWindow.ts
+++ b/svg-time-series/src/chart/dataWindow.ts
@@ -76,7 +76,10 @@ export class DataWindow {
   }
 
   timeToIndex(time: Date): number {
-    return +this.indexToTime.invert(time);
+    const raw =
+      (time.getTime() - this.startTime) / this.timeStep -
+      this.window.startIndex;
+    return this.clampIndex(raw);
   }
 
   timeDomainFull(): [Date, Date] {

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -106,7 +106,7 @@ function createChart(data: Array<[number]>) {
 
   const source: IDataSource = {
     startTime: 0,
-    timeStep: 1,
+    timeStep: 1000,
     length: data.length,
     seriesAxes: [0],
     getSeries: (i) => data[i]![0],
@@ -125,6 +125,10 @@ function createChart(data: Array<[number]>) {
     () => {},
     () => {},
   );
+  const internal = chart as unknown as {
+    state: { screenToModelX: (x: number) => Date };
+  };
+  internal.state.screenToModelX = (x: number) => new Date(x * 1000);
 
   return { onHover: chart.onHover, legendController };
 }

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -215,7 +215,7 @@ describe("interaction.enableBrush", () => {
     const internal = chart as unknown as {
       onBrushEnd: (e: D3BrushEvent<unknown>) => void;
       state: {
-        screenToModelX: (x: number) => number;
+        screenToModelX: (x: number) => Date;
         xTransform: { toScreenFromModelX: (x: number) => number };
       };
       zoomState: {
@@ -223,7 +223,7 @@ describe("interaction.enableBrush", () => {
       };
     };
     internal.zoomState.zoomBehavior = { transform: vi.fn() };
-    internal.state.screenToModelX = (x: number) => x;
+    internal.state.screenToModelX = (x: number) => new Date(x);
     (
       internal.state.xTransform as { toScreenFromModelX: (x: number) => number }
     ).toScreenFromModelX = (x: number) => x;
@@ -249,7 +249,7 @@ describe("interaction.disableBrush", () => {
     const internal = chart as unknown as {
       onBrushEnd: (e: D3BrushEvent<unknown>) => void;
       state: {
-        screenToModelX: (x: number) => number;
+        screenToModelX: (x: number) => Date;
         xTransform: { toScreenFromModelX: (x: number) => number };
       };
       zoomState: {
@@ -257,7 +257,7 @@ describe("interaction.disableBrush", () => {
       };
     };
     internal.zoomState.zoomBehavior = { transform: vi.fn() };
-    internal.state.screenToModelX = (x: number) => x;
+    internal.state.screenToModelX = (x: number) => new Date(x);
     (
       internal.state.xTransform as { toScreenFromModelX: (x: number) => number }
     ).toScreenFromModelX = (x: number) => x;

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -133,7 +133,7 @@ function createChart(
 
   const source: IDataSource = {
     startTime: 0,
-    timeStep: 1,
+    timeStep: 1000,
     length: data.length,
     seriesAxes: [0, 1],
     getSeries: (i, seriesIdx) => data[i]![seriesIdx]!,
@@ -159,6 +159,10 @@ function createChart(
     () => {},
     () => {},
   );
+  const internal = chart as unknown as {
+    state: { screenToModelX: (x: number) => Date };
+  };
+  internal.state.screenToModelX = (x: number) => new Date(x * 1000);
 
   return {
     zoom: chart.zoom,
@@ -230,7 +234,7 @@ describe("chart interaction", () => {
     const { onHover, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
-    onHover(1);
+    onHover(2);
     vi.runAllTimers();
 
     expect(
@@ -260,7 +264,7 @@ describe("chart interaction", () => {
     chart.updateChartWithNewData([50, 60]);
     vi.runAllTimers();
 
-    onHover(1);
+    onHover(2);
     vi.runAllTimers();
 
     expect(
@@ -292,9 +296,9 @@ describe("chart interaction", () => {
     vi.runAllTimers();
 
     expect(legend.querySelector(".chart-legend__time")!.textContent).toBe(
-      "ts:1",
+      "ts:1000",
     );
-    expect(formatter).toHaveBeenCalledWith(1);
+    expect(formatter).toHaveBeenCalledWith(1000);
   });
 
   it("throws when data contains Infinity", () => {

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -234,8 +234,8 @@ export class RenderState {
     }));
   }
 
-  public screenToModelX(x: number): number {
-    return this.xTransform.fromScreenToModelX(x);
+  public screenToModelX(x: number): Date {
+    return this.axes.x.scale.invert(x);
   }
 
   public createLegendContext(data: ChartData): LegendContext {

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -200,7 +200,7 @@ describe("TimeSeriesChart", () => {
       state: { screenToModelX: ReturnType<typeof vi.fn> };
       data: { length: number };
     };
-    vi.spyOn(internal.state, "screenToModelX").mockReturnValue(10);
+    vi.spyOn(internal.state, "screenToModelX").mockReturnValue(new Date(10));
 
     chart.onHover(5);
 
@@ -272,7 +272,7 @@ describe("TimeSeriesChart", () => {
       zoomState: { zoomBehavior: { transform: ReturnType<typeof vi.fn> } };
       onBrushEnd: (event: D3BrushEvent<unknown>) => void;
     };
-    vi.spyOn(internal.state, "screenToModelX").mockReturnValue(0);
+    vi.spyOn(internal.state, "screenToModelX").mockReturnValue(new Date(0));
     vi.spyOn(internal.state.xTransform, "toScreenFromModelX").mockReturnValue(
       10,
     );

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -198,8 +198,9 @@ export class TimeSeriesChart {
   };
 
   public onHover = (x: number) => {
-    let idx = Math.round(this.state.screenToModelX(x));
-    idx = this.data.clampIndex(idx);
+    const idx = this.data.clampIndex(
+      Math.round(this.data.timeToIndex(this.state.screenToModelX(x))),
+    );
     const legend = this.legendController;
     if (legend.highlightIndexRaf) {
       legend.highlightIndexRaf(idx);
@@ -225,8 +226,12 @@ export class TimeSeriesChart {
     if (x1 < x0) {
       [x0, x1] = [x1, x0];
     }
-    const m0 = this.data.clampIndex(this.state.screenToModelX(x0));
-    const m1 = this.data.clampIndex(this.state.screenToModelX(x1));
+    const m0 = this.data.clampIndex(
+      this.data.timeToIndex(this.state.screenToModelX(x0)),
+    );
+    const m1 = this.data.clampIndex(
+      this.data.timeToIndex(this.state.screenToModelX(x1)),
+    );
     const sx0 = this.state.xTransform.toScreenFromModelX(m0);
     const sx1 = this.state.xTransform.toScreenFromModelX(m1);
     if (m0 === m1 || sx0 === sx1) {
@@ -237,9 +242,8 @@ export class TimeSeriesChart {
     const k = width / (sx1 - sx0);
     const t = zoomIdentity.scale(k).translate(-sx0, 0);
     this.zoomState.zoomBehavior.transform(this.zoomArea, t);
-    const startIdx = this.data.startIndex;
-    const t0 = this.data.startTime + (startIdx + m0) * this.data.timeStep;
-    const t1 = this.data.startTime + (startIdx + m1) * this.data.timeStep;
+    const t0 = this.data.indexToTime(m0).getTime();
+    const t1 = this.data.indexToTime(m1).getTime();
     this.clearBrush();
     this.selectedTimeWindow = [t0, t1];
   };


### PR DESCRIPTION
## Summary
- derive model x values using the axis scale instead of ViewportTransform
- compute hover and brush indices via ChartData time/index helpers
- centralize time→index math in DataWindow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a217423ab4832b99f4a891967202e4