### PR TITLE
fix: correct matrix usage in ViewWindowTransform sample

### DIFF
--- a/samples/ViewWindowTransform.ts
+++ b/samples/ViewWindowTransform.ts
@@ -34,11 +34,11 @@
   }
 
   public fromScreenToModel(p: SVGPoint) {
-    return p.matrixTransform(this.GeneralMatrix);
+    return p.matrixTransform(this.GeneralMatrixInversed);
   }
 
   public fromModelToScreen(p: SVGPoint) {
-    return p.matrixTransform(this.GeneralMatrixInversed);
+    return p.matrixTransform(this.GeneralMatrix);
   }
 
   private updateVO() {


### PR DESCRIPTION
## Summary
- swap matrices in `ViewWindowTransform.fromScreenToModel` and `.fromModelToScreen` so screen coordinates use the inverse matrix

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a22da7d734832b8e15b7ce4c191601