### PR TITLE
fix: map index to time with linear scale

### DIFF
--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -109,7 +109,7 @@ export class ChartData {
 
   indexToTime(idx: number): Date {
     assertFiniteNumber(idx, "ChartData.indexToTime idx");
-    return this.window.indexToTime(idx);
+    return new Date(this.window.indexToTime(idx));
   }
 
   timeToIndex(time: Date): number {


### PR DESCRIPTION
## Summary
- replace UTC time scale with linear mapping from index to timestamp
- convert mapped values to `Date` objects before exposing them

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a247d2637c832b82cb7dcae769fc84