### PR TITLE
test: assert no highlight with missing values

### DIFF
--- a/samples/LegendController.test.ts
+++ b/samples/LegendController.test.ts
@@ -113,9 +113,17 @@ describe("LegendController", () => {
       })),
     });
 
+    const updateSpy = vi.spyOn(domNode, "updateNode");
+    const circleCount = svg.selectAll("circle").size();
+
     expect(() => {
       lc.highlightIndex(1);
     }).not.toThrow();
+
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(svg.selectAll("circle").size()).toBe(circleCount);
+
+    updateSpy.mockRestore();
     lc.destroy();
   });
 


### PR DESCRIPTION
## Summary
- enhance LegendController missing values test to spy on `updateNode`
- ensure no highlight circle is added when `values` array missing and `updateNode` not invoked

## Testing
- `npm test samples/LegendController.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a36de9c8c8832bb24d410bc5ec514a