### PR TITLE
test: assert legend destroyed on chart dispose

### DIFF
--- a/svg-time-series/test/dispose.test.ts
+++ b/svg-time-series/test/dispose.test.ts
@@ -26,10 +26,10 @@ await polyfillDom();
 
 function createLegend() {
   return {
-    init: vi.fn(),
-    highlightIndex: vi.fn(),
-    refresh: vi.fn(),
-    clearHighlight: vi.fn(),
+    init() {},
+    highlightIndex() {},
+    refresh() {},
+    clearHighlight() {},
     destroy: vi.fn(),
   };
 }
@@ -62,12 +62,12 @@ function createChart() {
     legend,
   );
 
-  return { chart, svgEl };
+  return { chart, svgEl, legend };
 }
 
 describe("TimeSeriesChart dispose", () => {
   it("removes zoom and brush elements", () => {
-    const { chart, svgEl } = createChart();
+    const { chart, svgEl, legend } = createChart();
 
     expect(svgEl.querySelector(".zoom-overlay")).not.toBeNull();
     expect(svgEl.querySelector(".brush-layer")).not.toBeNull();
@@ -76,5 +76,6 @@ describe("TimeSeriesChart dispose", () => {
 
     expect(svgEl.querySelector(".zoom-overlay")).toBeNull();
     expect(svgEl.querySelector(".brush-layer")).toBeNull();
+    expect(legend.destroy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Return legend from `createChart` helper and verify it's destroyed during chart disposal
- Simplify legend test stub to only include needed methods

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36deee658832b9b6ef1ada799cf0a