### PR TITLE
refactor: assert non-degenerate viewport

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -108,6 +108,20 @@ describe("ViewportTransform", () => {
     expect(t2).toBeCloseTo(50);
   });
 
+  it("throws when the x range collapses", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 0], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
+    expect(() => vt.fromScreenToModelX(0)).toThrow(/degenerate/);
+  });
+
+  it("throws when the y range collapses", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 100], [50, 50]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
+    expect(() => vt.fromScreenToModelY(0)).toThrow(/degenerate/);
+  });
+
   it("throws a helpful error when scale is zero", () => {
     const vt = new ViewportTransform();
 
@@ -115,7 +129,7 @@ describe("ViewportTransform", () => {
     vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
     vt.onZoomPan(zoomIdentity.scale(0));
-    expect(() => vt.fromScreenToModelX(10)).toThrow(/not invertible/);
+    expect(() => vt.fromScreenToModelX(10)).toThrow(/degenerate/);
   });
 
   it("throws a helpful error when scale is near zero", () => {
@@ -125,6 +139,6 @@ describe("ViewportTransform", () => {
     vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
     vt.onZoomPan(zoomIdentity.scale(1e-15));
-    expect(() => vt.fromScreenToModelX(10)).toThrow(/not invertible/);
+    expect(() => vt.fromScreenToModelX(10)).toThrow(/degenerate/);
   });
 });

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -50,43 +50,48 @@ export class ViewportTransform {
     return this;
   }
 
-  private assertInvertible(scale: ScaleLinear<number, number>) {
-    const k = this.zoomTransform.k;
+  private assertNonDegenerate(scale: ScaleLinear<number, number>) {
+    const m = this.composedMatrix;
+    const det = m.a * m.d - m.b * m.c;
     const [d0, d1] = scale.domain() as [number, number];
+    const [r0, r1] = scale.range() as [number, number];
     if (
-      !Number.isFinite(k) ||
-      Math.abs(k) < ViewportTransform.DET_EPSILON ||
+      !Number.isFinite(det) ||
+      Math.abs(det) < ViewportTransform.DET_EPSILON ||
       !Number.isFinite(d0) ||
       !Number.isFinite(d1) ||
-      Math.abs(d1 - d0) < ViewportTransform.DET_EPSILON
+      Math.abs(d1 - d0) < ViewportTransform.DET_EPSILON ||
+      !Number.isFinite(r0) ||
+      !Number.isFinite(r1) ||
+      Math.abs(r1 - r0) < ViewportTransform.DET_EPSILON
     ) {
       throw new Error(
-        "ViewportTransform: composed matrix is not invertible (determinant is zero)",
+        "ViewportTransform: transformation is degenerate (determinant is zero)",
       );
     }
   }
 
   public fromScreenToModelX(x: number) {
-    this.assertInvertible(this.scaleX);
+    this.assertNonDegenerate(this.scaleX);
     return this.scaleX.invert(x);
   }
 
   public fromScreenToModelY(y: number) {
-    this.assertInvertible(this.scaleY);
+    this.assertNonDegenerate(this.scaleY);
     return this.scaleY.invert(y);
   }
 
   public fromScreenToModelBasisX(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertInvertible(this.scaleX);
+    this.assertNonDegenerate(this.scaleX);
     return [this.scaleX.invert(b[0]), this.scaleX.invert(b[1])];
   }
 
   public fromScreenToModelBasisY(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertInvertible(this.scaleY);
+    this.assertNonDegenerate(this.scaleY);
     return [this.scaleY.invert(b[0]), this.scaleY.invert(b[1])];
   }
 
@@ -107,7 +112,7 @@ export class ViewportTransform {
   public toScreenFromModelBasisY(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertInvertible(this.scaleY);
+    this.assertNonDegenerate(this.scaleY);
     return [this.scaleY(b[0]), this.scaleY(b[1])];
   }
 


### PR DESCRIPTION
## Summary
- rename assertInvertible to assertNonDegenerate and compute determinant from composed matrix
- detect collapsed axis ranges and update call sites
- cover degenerate ranges in viewport transform tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a36f2fa8d4832bb6038cdaeaa8dc8a