### PR TITLE
chore(samples): watch library source

### DIFF
--- a/samples/vite.config.ts
+++ b/samples/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from "vite";
+import path from "path";
 
 export default defineConfig({
   root: ".",
   server: {
     port: 5173,
+    fs: {
+      allow: [".."],
+    },
+  },
+  resolve: {
+    alias: {
+      "svg-time-series": path.resolve(__dirname, "../svg-time-series/src"),
+    },
   },
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary
- ensure samples Vite dev server watches svg-time-series source files by aliasing the package to its src and allowing parent directory traversal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a23084d564832b998bc6db64a49e59