### PR TITLE
fix: refresh chart only when scale unchanged in setScaleExtent

### DIFF
--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -76,8 +76,9 @@ export class ZoomState {
       const clampedK = Math.max(min, Math.min(max, current.k));
       if (clampedK !== current.k) {
         this.zoomBehavior.scaleTo(this.zoomArea, clampedK);
+      } else {
+        this.refreshChart();
       }
-      this.refreshChart();
     };
 
     this.updateExtents = (dimensions: { width: number; height: number }) => {


### PR DESCRIPTION
## Summary
- refresh the chart only when no scale adjustment occurs in setScaleExtent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a387618a54832bbe5d5f83e70ca63f