### PR TITLE
fix: assert nondegenerate scale in ViewportTransform X-axis methods

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -96,6 +96,7 @@ export class ViewportTransform {
   }
 
   public toScreenFromModelX(x: number) {
+    this.assertNonDegenerate(this.scaleX);
     return this.scaleX(x);
   }
 
@@ -106,6 +107,7 @@ export class ViewportTransform {
   public toScreenFromModelBasisX(
     b: readonly [number, number],
   ): [number, number] {
+    this.assertNonDegenerate(this.scaleX);
     return [this.scaleX(b[0]), this.scaleX(b[1])];
   }
 


### PR DESCRIPTION
## Summary
- ensure X-axis screen conversion asserts non-degenerate scale
- mirror Y-axis checks in ViewportTransform

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3875757f4832bb58e931f6c625591