### PR TITLE
refactor: cache axis scales on render state

### DIFF
--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -44,6 +44,8 @@ export class AxisModel {
 export interface AxisRenderState {
   axis: MyAxis;
   g: Selection<SVGGElement, unknown, HTMLElement, unknown>;
+  lastDomain: [number | Date, number | Date];
+  lastRange: [number, number];
 }
 
 export function createBaseXScale(


### PR DESCRIPTION
## Summary
- cache axis domain and range per render
- drop render-level domain/range arrays and use per-axis caches
- update refresh logic to reuse AxisRenderState cache

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a387501a60832ba072c5c09c0b686a