### PR TITLE
fix: handle non-finite hover index

### DIFF
--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -200,6 +200,10 @@ export class TimeSeriesChart {
     let idx = Math.round(this.state.screenToModelX(x));
     idx = this.data.clampIndex(idx);
     const legend = this.legendController;
+    if (!Number.isFinite(idx)) {
+      legend.clearHighlight();
+      return;
+    }
     if (legend.highlightIndexRaf) {
       legend.highlightIndexRaf(idx);
     } else {


### PR DESCRIPTION
## Summary
- guard onHover against non-finite indices and clear legend when needed

## Testing
- `git commit -am "fix: handle non-finite hover index"`


------
https://chatgpt.com/codex/tasks/task_e_68a38743a624832b93eea602800ab6a0