### PR TITLE
refactor: persist index range scale

### DIFF
--- a/svg-time-series/src/chart/axisManager.helpers.test.ts
+++ b/svg-time-series/src/chart/axisManager.helpers.test.ts
@@ -39,10 +39,8 @@ describe("updateAxisModel", () => {
       .range([0, 100]);
     const baseX = createBaseXScale(x, data.window);
     const t = zoomIdentity.scale(2);
-    const dIndexVisible = data.dIndexFromTransform(
-      t,
-      baseX.range() as [number, number],
-    );
+    data.window.onViewPortResize(baseX.range() as [number, number]);
+    const dIndexVisible = data.dIndexFromTransform(t);
     updateAxisModel(axis, 0, data, t, dIndexVisible);
     const { scale: baseScaleRaw } = data.axisTransform(0, dIndexVisible);
     const expectedDomain = t

--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -70,10 +70,7 @@ describe("AxisManager", () => {
 
     const t = zoomIdentity.scale(2);
     axisManager.updateScales(t);
-    const dIndexVisible = data.dIndexFromTransform(
-      t,
-      axisManager.x.range() as [number, number],
-    );
+    const dIndexVisible = data.dIndexFromTransform(t);
     const { scale: baseScaleRaw } = data.axisTransform(0, dIndexVisible);
     const baseScale = baseScaleRaw.range(
       axisManager.axes[0]!.scale.range() as [number, number],

--- a/svg-time-series/src/chart/axisManager.ts
+++ b/svg-time-series/src/chart/axisManager.ts
@@ -92,15 +92,13 @@ export class AxisManager {
 
   setXAxis(scale: ScaleTime<number, number>): void {
     this.x = scale;
+    this.data.window.onViewPortResize(scale.range() as [number, number]);
   }
 
   updateScales(transform: ZoomTransform): void {
     this.data.assertAxisBounds(this.axes.length);
     const baseX = createBaseXScale(this.x, this.data.window);
-    const dIndexVisible = this.data.window.dIndexFromTransform(
-      transform,
-      baseX.range() as [number, number],
-    );
+    const dIndexVisible = this.data.window.dIndexFromTransform(transform);
     this.x = transform.rescaleX(baseX).copy();
     this.axes.forEach((a, i) => {
       updateAxisModel(a, i, this.data, transform, dIndexVisible);

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -121,11 +121,8 @@ export class ChartData {
     return this.window.timeDomainFull();
   }
 
-  dIndexFromTransform(
-    transform: ZoomTransform,
-    range: [number, number],
-  ): [number, number] {
-    return this.window.dIndexFromTransform(transform, range);
+  dIndexFromTransform(transform: ZoomTransform): [number, number] {
+    return this.window.dIndexFromTransform(transform);
   }
 
   /**

--- a/svg-time-series/src/chart/dataWindow.ts
+++ b/svg-time-series/src/chart/dataWindow.ts
@@ -15,6 +15,7 @@ export class DataWindow {
    * sliding window to avoid recreating the scale on every query.
    */
   public readonly indexToTime: ScaleLinear<number, number>;
+  private readonly indexToRange: ScaleLinear<number, number>;
   public readonly bIndexFull: readonly [number, number];
 
   constructor(initialData: number[][], startTime: number, timeStep: number) {
@@ -29,6 +30,9 @@ export class DataWindow {
         this.startTime,
         this.startTime + (this.window.length - 1) * this.timeStep,
       ]);
+    this.indexToRange = scaleLinear<number, number>()
+      .domain(this.bIndexFull)
+      .range([0, 1]);
   }
 
   append(...values: number[]): void {
@@ -67,14 +71,12 @@ export class DataWindow {
     return this.bIndexFull.map((i) => new Date(toTime(i))) as [Date, Date];
   }
 
-  dIndexFromTransform(
-    transform: ZoomTransform,
-    range: [number, number],
-  ): [number, number] {
-    const indexScale = scaleLinear<number, number>()
-      .domain(this.bIndexFull)
-      .range(range);
-    return transform.rescaleX(indexScale).domain() as [number, number];
+  onViewPortResize(range: [number, number]): void {
+    this.indexToRange.range(range);
+  }
+
+  dIndexFromTransform(transform: ZoomTransform): [number, number] {
+    return transform.rescaleX(this.indexToRange).domain() as [number, number];
   }
 
   /**


### PR DESCRIPTION
## Summary
- maintain reusable index-to-pixel scale in DataWindow
- update viewport resize plumbing to keep index range in sync
- simplify dIndexFromTransform and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38ed4b094832bac868a1af948411a