### PR TITLE
feat: guard y scale on model to screen

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -122,6 +122,20 @@ describe("ViewportTransform", () => {
     expect(() => vt.fromScreenToModelY(0)).toThrow(/degenerate/);
   });
 
+  it("throws when the y domain collapses", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [5, 5]);
+    expect(() => vt.toScreenFromModelY(5)).toThrow(/degenerate/);
+  });
+
+  it("throws when the y range collapses in toScreenFromModelY", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 100], [50, 50]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
+    expect(() => vt.toScreenFromModelY(0)).toThrow(/degenerate/);
+  });
+
   it("throws a helpful error when scale is zero", () => {
     const vt = new ViewportTransform();
 

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -101,6 +101,7 @@ export class ViewportTransform {
   }
 
   public toScreenFromModelY(y: number) {
+    this.assertNonDegenerate(this.scaleY);
     return this.scaleY(y);
   }
 


### PR DESCRIPTION
## Summary
- ensure y axis check in toScreenFromModelY
- test y-domain and y-range collapse handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3906a9518832b8c4f07dfac386ff5