### PR TITLE
Refactor ViewportTransform degenerate checks to use scale data

### DIFF
--- a/svg-time-series/src/ViewportTransform.test.ts
+++ b/svg-time-series/src/ViewportTransform.test.ts
@@ -132,13 +132,13 @@ describe("ViewportTransform", () => {
     expect(() => vt.fromScreenToModelX(10)).toThrow(/degenerate/);
   });
 
-  it("throws a helpful error when scale is near zero", () => {
+  it("handles scale near zero without treating it as degenerate", () => {
     const vt = new ViewportTransform();
 
     vt.onViewPortResize([0, 100], [0, 100]);
     vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
     vt.onZoomPan(zoomIdentity.scale(1e-15));
-    expect(() => vt.fromScreenToModelX(10)).toThrow(/degenerate/);
+    expect(() => vt.fromScreenToModelX(10)).not.toThrow();
   });
 });

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -10,7 +10,7 @@ export class ViewportTransform {
   private zoomTransform: ZoomTransform = zoomIdentity;
   private composedMatrix: DOMMatrix = new DOMMatrix();
 
-  private static readonly DET_EPSILON = 1e-12;
+  private static readonly EPSILON = 1e-12;
 
   private updateScales() {
     this.scaleX = this.zoomTransform.rescaleX(this.baseScaleX);
@@ -51,23 +51,17 @@ export class ViewportTransform {
   }
 
   private assertNonDegenerate(scale: ScaleLinear<number, number>) {
-    const m = this.composedMatrix;
-    const det = m.a * m.d - m.b * m.c;
     const [d0, d1] = scale.domain() as [number, number];
     const [r0, r1] = scale.range() as [number, number];
     if (
-      !Number.isFinite(det) ||
-      Math.abs(det) < ViewportTransform.DET_EPSILON ||
       !Number.isFinite(d0) ||
       !Number.isFinite(d1) ||
-      Math.abs(d1 - d0) < ViewportTransform.DET_EPSILON ||
+      Math.abs(d1 - d0) < ViewportTransform.EPSILON ||
       !Number.isFinite(r0) ||
       !Number.isFinite(r1) ||
-      Math.abs(r1 - r0) < ViewportTransform.DET_EPSILON
+      Math.abs(r1 - r0) < ViewportTransform.EPSILON
     ) {
-      throw new Error(
-        "ViewportTransform: transformation is degenerate (determinant is zero)",
-      );
+      throw new Error("ViewportTransform: scale is degenerate");
     }
   }
 

--- a/svg-time-series/test/viewportTransform.test.ts
+++ b/svg-time-series/test/viewportTransform.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { ViewportTransform } from "../src/ViewportTransform.ts";
+import { polyfillDom } from "../src/setupDom.ts";
+
+await polyfillDom();
+
+describe("ViewportTransform degeneracy", () => {
+  it("throws only for degenerate X domain", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 0], [0, 10]);
+
+    expect(() => vt.fromScreenToModelY(50)).not.toThrow();
+    expect(() => vt.fromScreenToModelX(50)).toThrow();
+  });
+
+  it("throws only for degenerate Y domain", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 100], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 0]);
+
+    expect(() => vt.fromScreenToModelX(50)).not.toThrow();
+    expect(() => vt.fromScreenToModelY(50)).toThrow();
+  });
+
+  it("throws only for degenerate X range", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 0], [0, 100]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
+
+    expect(() => vt.fromScreenToModelY(50)).not.toThrow();
+    expect(() => vt.toScreenFromModelX(5)).toThrow();
+  });
+
+  it("throws only for degenerate Y range", () => {
+    const vt = new ViewportTransform();
+    vt.onViewPortResize([0, 100], [0, 0]);
+    vt.onReferenceViewWindowResize([0, 10], [0, 10]);
+
+    expect(() => vt.fromScreenToModelX(5)).not.toThrow();
+    expect(() => vt.fromScreenToModelY(50)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- refine `assertNonDegenerate` to validate scale's domain and range only
- expand tests with per-axis degenerate scenarios
- update existing tests for new non-degenerate handling of near-zero zoom

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a390600f48832bb005b0311277fbe4