### PR TITLE
refactor: compute viewport scales on demand

### DIFF
--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -5,23 +5,12 @@ import { scalesToDomMatrix } from "./utils/domMatrix.ts";
 export class ViewportTransform {
   private baseScaleX = scaleLinear();
   private baseScaleY = scaleLinear();
-  private scaleX = this.baseScaleX;
-  private scaleY = this.baseScaleY;
   private zoomTransform: ZoomTransform = zoomIdentity;
   private composedMatrix: DOMMatrix = new DOMMatrix();
-
-  private static readonly DET_EPSILON = 1e-12;
-
-  private updateScales() {
-    this.scaleX = this.zoomTransform.rescaleX(this.baseScaleX);
-    // Ignore the zoom transform for the Y axis so that it always fits the data
-    // based on its current domain.
-    this.scaleY = this.baseScaleY.copy();
-    this.updateComposedMatrix();
-  }
-
-  private updateComposedMatrix() {
-    this.composedMatrix = scalesToDomMatrix(this.scaleX, this.scaleY);
+  private updateMatrix() {
+    const scaleX = this.zoomTransform.rescaleX(this.baseScaleX);
+    const scaleY = this.zoomTransform.rescaleY(this.baseScaleY.copy());
+    this.composedMatrix = scalesToDomMatrix(scaleX, scaleY);
   }
 
   public onViewPortResize(
@@ -30,7 +19,7 @@ export class ViewportTransform {
   ): this {
     this.baseScaleX = this.baseScaleX.copy().range(viewX as [number, number]);
     this.baseScaleY = this.baseScaleY.copy().range(viewY as [number, number]);
-    this.updateScales();
+    this.updateMatrix();
     return this;
   }
 
@@ -40,82 +29,93 @@ export class ViewportTransform {
   ): this {
     this.baseScaleX = this.baseScaleX.copy().domain(refX as [number, number]);
     this.baseScaleY = this.baseScaleY.copy().domain(refY as [number, number]);
-    this.updateScales();
+    this.updateMatrix();
     return this;
   }
 
   public onZoomPan(t: ZoomTransform): this {
     this.zoomTransform = t;
-    this.updateScales();
+    this.updateMatrix();
     return this;
   }
 
-  private assertNonDegenerate(scale: ScaleLinear<number, number>) {
-    const m = this.composedMatrix;
-    const det = m.a * m.d - m.b * m.c;
+  private assertFiniteScale(scale: ScaleLinear<number, number>) {
     const [d0, d1] = scale.domain() as [number, number];
     const [r0, r1] = scale.range() as [number, number];
     if (
-      !Number.isFinite(det) ||
-      Math.abs(det) < ViewportTransform.DET_EPSILON ||
       !Number.isFinite(d0) ||
       !Number.isFinite(d1) ||
-      Math.abs(d1 - d0) < ViewportTransform.DET_EPSILON ||
       !Number.isFinite(r0) ||
-      !Number.isFinite(r1) ||
-      Math.abs(r1 - r0) < ViewportTransform.DET_EPSILON
+      !Number.isFinite(r1)
     ) {
       throw new Error(
-        "ViewportTransform: transformation is degenerate (determinant is zero)",
+        "ViewportTransform: scale domain or range contains non-finite values",
       );
     }
   }
 
+  private currentScaleX() {
+    return this.zoomTransform.rescaleX(this.baseScaleX);
+  }
+
+  private currentScaleY() {
+    return this.zoomTransform.rescaleY(this.baseScaleY.copy());
+  }
+
   public fromScreenToModelX(x: number) {
-    this.assertNonDegenerate(this.scaleX);
-    return this.scaleX.invert(x);
+    const scale = this.currentScaleX();
+    this.assertFiniteScale(scale);
+    return scale.invert(x);
   }
 
   public fromScreenToModelY(y: number) {
-    this.assertNonDegenerate(this.scaleY);
-    return this.scaleY.invert(y);
+    const scale = this.currentScaleY();
+    this.assertFiniteScale(scale);
+    return scale.invert(y);
   }
 
   public fromScreenToModelBasisX(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertNonDegenerate(this.scaleX);
-    return [this.scaleX.invert(b[0]), this.scaleX.invert(b[1])];
+    const scale = this.currentScaleX();
+    this.assertFiniteScale(scale);
+    return [scale.invert(b[0]), scale.invert(b[1])];
   }
 
   public fromScreenToModelBasisY(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertNonDegenerate(this.scaleY);
-    return [this.scaleY.invert(b[0]), this.scaleY.invert(b[1])];
+    const scale = this.currentScaleY();
+    this.assertFiniteScale(scale);
+    return [scale.invert(b[0]), scale.invert(b[1])];
   }
 
   public toScreenFromModelX(x: number) {
-    this.assertNonDegenerate(this.scaleX);
-    return this.scaleX(x);
+    const scale = this.currentScaleX();
+    this.assertFiniteScale(scale);
+    return scale(x);
   }
 
   public toScreenFromModelY(y: number) {
-    return this.scaleY(y);
+    const scale = this.currentScaleY();
+    this.assertFiniteScale(scale);
+    return scale(y);
   }
 
   public toScreenFromModelBasisX(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertNonDegenerate(this.scaleX);
-    return [this.scaleX(b[0]), this.scaleX(b[1])];
+    const scale = this.currentScaleX();
+    this.assertFiniteScale(scale);
+    return [scale(b[0]), scale(b[1])];
   }
 
   public toScreenFromModelBasisY(
     b: readonly [number, number],
   ): [number, number] {
-    this.assertNonDegenerate(this.scaleY);
-    return [this.scaleY(b[0]), this.scaleY(b[1])];
+    const scale = this.currentScaleY();
+    this.assertFiniteScale(scale);
+    return [scale(b[0]), scale(b[1])];
   }
 
   public get matrix(): DOMMatrix {


### PR DESCRIPTION
## Summary
- compute viewport DOM matrix from `zoomTransform.rescaleX`/`rescaleY` on demand
- drop degenerate determinant checks and validate scale domain/range values
- clarify tests for uniform Y-axis scaling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a38ef5843c832baf26b5ebbe9b6bd5