### PR TITLE
refactor: centralize zoom transform computation

### DIFF
--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -98,6 +98,7 @@ vi.mock("./zoomState.ts", () => ({
     destroy = vi.fn();
     zoom = vi.fn();
     setScaleExtent = vi.fn();
+    zoomToTimeWindow = vi.fn();
     constructor(
       _zoomArea: unknown,
       state: {

--- a/svg-time-series/src/chart/zoomState.methods.test.ts
+++ b/svg-time-series/src/chart/zoomState.methods.test.ts
@@ -8,7 +8,7 @@ import type { RenderState } from "./render.ts";
 import { ZoomState } from "./zoomState.ts";
 
 describe("ZoomState class methods", () => {
-  it("defines setScaleExtent and updateExtents on the prototype", () => {
+  it("defines setScaleExtent, updateExtents, and zoomToTimeWindow on the prototype", () => {
     const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     const rect = select(svg).append("rect");
     const state = {
@@ -33,5 +33,7 @@ describe("ZoomState class methods", () => {
     expect(zs.setScaleExtent).toBe(ZoomState.prototype.setScaleExtent);
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(zs.updateExtents).toBe(ZoomState.prototype.updateExtents);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(zs.zoomToTimeWindow).toBe(ZoomState.prototype.zoomToTimeWindow);
   });
 });

--- a/svg-time-series/src/chart/zoomState.ts
+++ b/svg-time-series/src/chart/zoomState.ts
@@ -112,6 +112,10 @@ export class ZoomState {
     this.zoomBehavior.transform(this.zoomArea, zoomIdentity);
   };
 
+  public zoomToTimeWindow(transform: ZoomTransform): void {
+    this.zoomBehavior.transform(this.zoomArea, transform);
+  }
+
   public destroy = () => {
     this.destroyed = true;
     this.zoomScheduler.destroy();

--- a/svg-time-series/src/chart/zoomUtils.ts
+++ b/svg-time-series/src/chart/zoomUtils.ts
@@ -1,3 +1,7 @@
+import { zoomIdentity, type ZoomTransform } from "d3-zoom";
+import type { ChartData } from "./data.ts";
+import type { RenderState } from "./render.ts";
+
 export function validateScaleExtent(extent: unknown): [number, number] {
   const error = () =>
     new Error(
@@ -30,4 +34,32 @@ export function validateScaleExtent(extent: unknown): [number, number] {
   }
 
   return [min, max];
+}
+
+export function computeZoomTransform(
+  data: ChartData,
+  state: RenderState,
+  start: Date | number,
+  end: Date | number,
+): { transform: ZoomTransform; timeWindow: [number, number] } | null {
+  const startDate = typeof start === "number" ? new Date(start) : start;
+  const endDate = typeof end === "number" ? new Date(end) : end;
+  let m0 = data.timeToIndex(startDate);
+  let m1 = data.timeToIndex(endDate);
+  m0 = data.clampIndex(m0);
+  m1 = data.clampIndex(m1);
+  if (m1 < m0) {
+    [m0, m1] = [m1, m0];
+  }
+  const sx0 = state.axes.x.scale(m0);
+  const sx1 = state.axes.x.scale(m1);
+  if (m0 === m1 || sx0 === sx1) {
+    return null;
+  }
+  const { width } = state.getDimensions();
+  const k = width / (sx1 - sx0);
+  const transform = zoomIdentity.scale(k).translate(-sx0, 0);
+  const t0 = +data.indexToTime(m0);
+  const t1 = +data.indexToTime(m1);
+  return { transform, timeWindow: [t0, t1] };
 }


### PR DESCRIPTION
## Summary
- extract computeZoomTransform helper for index-to-transform conversion
- add ZoomState.zoomToTimeWindow to apply precomputed transforms
- delegate TimeSeriesChart.zoomToTimeWindow to new helper and ZoomState

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3a807b0e0832ba6028f2829fc3f78