### PR TITLE
chore: destructure configs import

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,15 @@
 // @ts-check
 
-import { config, configs } from "typescript-eslint";
+const {
+  config,
+  configs: { disableTypeChecked, strictTypeChecked },
+} = await import("typescript-eslint");
 import prettierConfig from "eslint-config-prettier";
 import vitest from "@vitest/eslint-plugin";
 import globals from "globals";
 import importPlugin from "eslint-plugin-import";
 import n from "eslint-plugin-n";
 
-const disableTypeChecked = configs.disableTypeChecked;
 const nRecommended = n.configs["flat/recommended"];
 const nodeOverride = {
   ...disableTypeChecked,
@@ -53,7 +55,7 @@ export default config(
       },
     },
   },
-  ...configs.strictTypeChecked,
+  ...strictTypeChecked,
   importPlugin.flatConfigs.typescript,
   prettierConfig,
   {
@@ -77,7 +79,7 @@ export default config(
     {
       files: ["scripts/**", "**/*.config.*"],
       ...nRecommended,
-      ...configs.disableTypeChecked,
+      ...disableTypeChecked,
       settings: {
         node: { version: ">=20.11.0" },
       },


### PR DESCRIPTION
## Summary
- destructure `disableTypeChecked` and `strictTypeChecked` directly from `typescript-eslint` in the ESLint config
- remove extra `disableTypeChecked` constant and update references

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a39b875cf4832b9686b47894bd3ac8