### PR TITLE
feat: expose dispose on interaction API

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ You can change the allowed zoom range at runtime by calling
 chart.interaction.setScaleExtent([1, 80]);
 ```
 
+To remove event listeners and DOM nodes when the chart is no longer needed,
+call `chart.interaction.dispose()`.
+
 ## Secrets of Speed
 
 - No legacy

--- a/svg-time-series/README.md
+++ b/svg-time-series/README.md
@@ -51,6 +51,9 @@ const chart = new TimeSeriesChart(
 );
 ```
 
+When the chart is no longer needed, release its resources by calling
+`chart.interaction.dispose()`.
+
 `getSeries` returns a value for the requested series index. Any number of
 series may be provided, but each must be assigned to either the left or right Y
 axis by specifying 0 or 1 in `seriesAxes`. Axis index `0` corresponds to the

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -422,7 +422,7 @@ describe("chart interaction", () => {
     zoomRect.dispatchEvent(new MouseEvent("mousemove"));
     expect(mouseMoveHandler).toHaveBeenCalledTimes(1);
 
-    chart.dispose();
+    chart.interaction.dispose();
 
     expect(destroySpy).toHaveBeenCalled();
 

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -235,7 +235,7 @@ describe("TimeSeriesChart", () => {
     expect(mouseMove).toHaveBeenCalled();
 
     mouseMove.mockClear();
-    chart.dispose();
+    chart.interaction.dispose();
     rectNode.dispatchEvent(new MouseEvent("mousemove"));
 
     expect(mouseMove).not.toHaveBeenCalled();

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -28,6 +28,7 @@ export interface IPublicInteraction {
   disableBrush: () => void;
   zoomToTimeWindow: (start: Date | number, end: Date | number) => void;
   getSelectedTimeWindow: () => [number, number] | null;
+  dispose: () => void;
 }
 
 export class TimeSeriesChart {
@@ -42,6 +43,7 @@ export class TimeSeriesChart {
   private selectedTimeWindow: [number, number] | null = null;
   private zoomHandler: (event: D3ZoomEvent<SVGRectElement, unknown>) => void;
   private zoomOptions: IZoomStateOptions | undefined;
+  private readonly publicInteraction: IPublicInteraction;
 
   constructor(
     svg: Selection<SVGSVGElement, unknown, HTMLElement, unknown>,
@@ -117,10 +119,8 @@ export class TimeSeriesChart {
 
     this.refreshAll();
     this.onHover(width - 1);
-  }
 
-  public get interaction(): IPublicInteraction {
-    return {
+    this.publicInteraction = {
       zoom: this.zoom,
       onHover: this.onHover,
       resetZoom: this.resetZoom,
@@ -129,7 +129,12 @@ export class TimeSeriesChart {
       disableBrush: this.disableBrush,
       zoomToTimeWindow: this.zoomToTimeWindow,
       getSelectedTimeWindow: this.getSelectedTimeWindow,
+      dispose: this.dispose,
     };
+  }
+
+  public get interaction(): IPublicInteraction {
+    return this.publicInteraction;
   }
 
   public updateChartWithNewData(values: number[]): void {
@@ -175,7 +180,7 @@ export class TimeSeriesChart {
     this.onHover(width - 1);
   }
 
-  public dispose() {
+  public dispose = () => {
     this.zoomState.destroy();
     this.zoomArea
       .on("mousemove", null)
@@ -186,7 +191,7 @@ export class TimeSeriesChart {
     this.state.destroy();
     this.zoomArea.remove();
     this.legendController.destroy();
-  }
+  };
 
   public zoom = (event: D3ZoomEvent<SVGRectElement, unknown>) => {
     this.zoomState.zoom(event);

--- a/svg-time-series/test/dispose.test.ts
+++ b/svg-time-series/test/dispose.test.ts
@@ -72,7 +72,7 @@ describe("TimeSeriesChart dispose", () => {
     expect(svgEl.querySelector(".zoom-overlay")).not.toBeNull();
     expect(svgEl.querySelector(".brush-layer")).not.toBeNull();
 
-    chart.dispose();
+    chart.interaction.dispose();
 
     expect(svgEl.querySelector(".zoom-overlay")).toBeNull();
     expect(svgEl.querySelector(".brush-layer")).toBeNull();


### PR DESCRIPTION
## Summary
- cache public interaction object and include a dispose method
- document disposing the chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4341e1558832b8b1afe93d200b206