### PR TITLE
refactor demos to share init helper

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -129,3 +129,37 @@ export function loadAndDraw(
     });
   });
 }
+
+export function initDemo(seriesAxes: number[]): Promise<TimeSeriesChart[]> {
+  return loadAndDraw(seriesAxes).then((charts) => {
+    charts.forEach((c) => {
+      c.interaction.onHover(0);
+    });
+    const resetButton = document.getElementById("reset-zoom");
+    resetButton?.addEventListener("click", () => {
+      charts.forEach((c) => {
+        c.interaction.resetZoom();
+      });
+    });
+
+    const brushButton = document.getElementById("toggle-brush");
+    if (brushButton) {
+      let brushEnabled = false;
+      brushButton.addEventListener("click", () => {
+        brushEnabled = !brushEnabled;
+        charts.forEach((c) => {
+          if (brushEnabled) {
+            c.interaction.enableBrush();
+          } else {
+            c.interaction.disableBrush();
+          }
+        });
+        brushButton.textContent = brushEnabled
+          ? "Disable Brush"
+          : "Enable Brush";
+      });
+    }
+
+    return charts;
+  });
+}

--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,29 +1,3 @@
-import { loadAndDraw } from "./common.ts";
+import { initDemo } from "./common.ts";
 
-void loadAndDraw([0, 1]).then((charts) => {
-  charts.forEach((c) => {
-    c.interaction.onHover(0);
-  });
-  const resetButton = document.getElementById("reset-zoom");
-  resetButton?.addEventListener("click", () => {
-    charts.forEach((c) => {
-      c.interaction.resetZoom();
-    });
-  });
-
-  const brushButton = document.getElementById("toggle-brush");
-  if (brushButton) {
-    let brushEnabled = false;
-    brushButton.addEventListener("click", () => {
-      brushEnabled = !brushEnabled;
-      charts.forEach((c) => {
-        if (brushEnabled) {
-          c.interaction.enableBrush();
-        } else {
-          c.interaction.disableBrush();
-        }
-      });
-      brushButton.textContent = brushEnabled ? "Disable Brush" : "Enable Brush";
-    });
-  }
-});
+void initDemo([0, 1]);

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,29 +1,3 @@
-import { loadAndDraw } from "./common.ts";
+import { initDemo } from "./common.ts";
 
-void loadAndDraw([0, 0]).then((charts) => {
-  charts.forEach((c) => {
-    c.interaction.onHover(0);
-  });
-  const resetButton = document.getElementById("reset-zoom");
-  resetButton?.addEventListener("click", () => {
-    charts.forEach((c) => {
-      c.interaction.resetZoom();
-    });
-  });
-
-  const brushButton = document.getElementById("toggle-brush");
-  if (brushButton) {
-    let brushEnabled = false;
-    brushButton.addEventListener("click", () => {
-      brushEnabled = !brushEnabled;
-      charts.forEach((c) => {
-        if (brushEnabled) {
-          c.interaction.enableBrush();
-        } else {
-          c.interaction.disableBrush();
-        }
-      });
-      brushButton.textContent = brushEnabled ? "Disable Brush" : "Enable Brush";
-    });
-  }
-});
+void initDemo([0, 0]);


### PR DESCRIPTION
## Summary
- add `initDemo` helper in `samples/demos/common.ts` to handle chart loading and controls
- simplify `demo1.ts` and `demo2.ts` to call the new helper

## Testing
- `npm run typecheck --workspaces --if-present`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4339f11e4832bad12a1769401a5b9