### PR TITLE
Handle demo data load errors with async initialization

### DIFF
--- a/samples/demos/demo1.ts
+++ b/samples/demos/demo1.ts
@@ -1,3 +1,7 @@
 import { initDemo } from "./common.ts";
 
-void initDemo([0, 1]);
+async function init(): Promise<void> {
+  await initDemo([0, 1]);
+}
+
+void init();

--- a/samples/demos/demo2.ts
+++ b/samples/demos/demo2.ts
@@ -1,3 +1,7 @@
 import { initDemo } from "./common.ts";
 
-void initDemo([0, 0]);
+async function init(): Promise<void> {
+  await initDemo([0, 0]);
+}
+
+void init();


### PR DESCRIPTION
## Summary
- Convert demo CSV loading to return a Promise and add async `loadAndDraw`
- Add try/catch around `loadAndDraw` in `initDemo` to alert on data-load failures
- Update demo entry files to await the async initializer

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43cf37d78832b8c15f94cf3e363fc