### PR TITLE
Validate append inputs

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -130,6 +130,38 @@ describe("ChartData", () => {
     expect(cd.getPoint(1).timestamp).toBe(2);
   });
 
+  describe("append validation", () => {
+    const makeCd = () => new ChartData(makeSource([[0, 0]], [0, 1]));
+
+    it("accepts values matching series count", () => {
+      const cd = makeCd();
+      expect(() => {
+        cd.append(1, 2);
+      }).not.toThrow();
+      expect(cd.data).toEqual([[1, 2]]);
+    });
+
+    it("throws when value count does not match series count", () => {
+      const cd = makeCd();
+      expect(() => {
+        cd.append(1);
+      }).toThrow(/expected 2 values; received 1/);
+      expect(() => {
+        cd.append(1, 2, 3);
+      }).toThrow(/expected 2 values; received 3/);
+    });
+
+    it("throws when values are not finite numbers", () => {
+      const cd = makeCd();
+      expect(() => {
+        cd.append(1, NaN);
+      }).toThrow(/values\[1\]/);
+      expect(() => {
+        cd.append(Infinity, 1);
+      }).toThrow(/values\[0\]/);
+    });
+  });
+
   it("provides clamped point data and timestamp", () => {
     const cd = new ChartData(
       makeSource(
@@ -255,7 +287,7 @@ describe("ChartData", () => {
     const cd = new ChartData(source);
     expect(() => {
       cd.append(undefined as unknown as number, 2);
-    }).toThrow(/series 0/);
+    }).toThrow(/values\[0\]/);
   });
 
   it("throws when sf is invalid", () => {
@@ -269,7 +301,7 @@ describe("ChartData", () => {
     const cd = new ChartData(source);
     expect(() => {
       cd.append(2, undefined as unknown as number);
-    }).toThrow(/series 1/);
+    }).toThrow(/values\[1\]/);
   });
 
   it("computes visible temperature bounds", () => {

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -109,6 +109,14 @@ export class ChartData {
   }
 
   append(...values: number[]): void {
+    if (values.length !== this.seriesCount) {
+      throw new Error(
+        `ChartData.append expected ${String(this.seriesCount)} values; received ${String(values.length)}`,
+      );
+    }
+    values.forEach((v, i) => {
+      assertFiniteNumber(v, `ChartData.append values[${String(i)}]`);
+    });
     this.window.append(...values);
     this.axes.forEach((a) => {
       a.invalidate();

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -139,11 +139,11 @@ describe("TimeSeriesChart", () => {
     }).toThrow(/values\[0\] must be a finite number or NaN/);
   });
 
-  it("accepts NaN values", () => {
+  it("throws when values contain NaN", () => {
     const { chart } = createChart();
     expect(() => {
       chart.updateChartWithNewData([NaN]);
-    }).not.toThrow();
+    }).toThrow(/values\[0\]/);
   });
 
   it("resizes svg and refreshes render state", () => {


### PR DESCRIPTION
## Summary
- ensure ChartData.append checks series count and each value for finiteness
- add tests for valid, mismatched, and invalid append inputs
- update draw tests to expect errors for NaN values

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a454843544832b85c4976adf18e588