### PR TITLE
Clear invalid zoom window before early return

### DIFF
--- a/svg-time-series/src/chart/interaction.zoomToTimeWindow.test.ts
+++ b/svg-time-series/src/chart/interaction.zoomToTimeWindow.test.ts
@@ -57,7 +57,7 @@ describe("interaction.zoomToTimeWindow", () => {
     const chart = createChart();
     const interaction = chart.interaction;
 
-    interaction.zoomToTimeWindow(1, 3);
+    const ok = interaction.zoomToTimeWindow(1, 3);
 
     const internal = chart as unknown as {
       data: { timeToIndex: (d: Date) => number };
@@ -75,8 +75,21 @@ describe("interaction.zoomToTimeWindow", () => {
     const k = width / (sx1 - sx0);
     const expected = zoomIdentity.scale(k).translate(-sx0, 0);
     const t = zoomTransform(internal.zoomArea.node()!);
+    expect(ok).toBe(true);
     expect(t.k).toBeCloseTo(expected.k);
     expect(t.x).toBeCloseTo(expected.x);
     expect(interaction.getSelectedTimeWindow()).toEqual([1, 3]);
+  });
+
+  it("returns false and clears selection for invalid window", () => {
+    const chart = createChart();
+    const interaction = chart.interaction;
+
+    expect(interaction.zoomToTimeWindow(1, 3)).toBe(true);
+    expect(interaction.getSelectedTimeWindow()).toEqual([1, 3]);
+
+    const ok = interaction.zoomToTimeWindow(1, 1);
+    expect(ok).toBe(false);
+    expect(interaction.getSelectedTimeWindow()).toBeNull();
   });
 });

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -26,7 +26,7 @@ export interface IPublicInteraction {
   setScaleExtent: (extent: [number, number]) => void;
   enableBrush: () => void;
   disableBrush: () => void;
-  zoomToTimeWindow: (start: Date | number, end: Date | number) => void;
+  zoomToTimeWindow: (start: Date | number, end: Date | number) => boolean;
   getSelectedTimeWindow: () => [number, number] | null;
   dispose: () => void;
 }
@@ -215,7 +215,10 @@ export class TimeSeriesChart {
     this.clearBrush();
   };
 
-  public zoomToTimeWindow = (start: Date | number, end: Date | number) => {
+  public zoomToTimeWindow = (
+    start: Date | number,
+    end: Date | number,
+  ): boolean => {
     const startDate = typeof start === "number" ? new Date(start) : start;
     const endDate = typeof end === "number" ? new Date(end) : end;
     let m0 = this.data.timeToIndex(startDate);
@@ -228,7 +231,8 @@ export class TimeSeriesChart {
     const sx0 = this.state.axes.x.scale(m0);
     const sx1 = this.state.axes.x.scale(m1);
     if (m0 === m1 || sx0 === sx1) {
-      return;
+      this.selectedTimeWindow = null;
+      return false;
     }
     const { width } = this.state.getDimensions();
     const k = width / (sx1 - sx0);
@@ -237,6 +241,7 @@ export class TimeSeriesChart {
     const t0 = +this.data.indexToTime(m0);
     const t1 = +this.data.indexToTime(m1);
     this.selectedTimeWindow = [t0, t1];
+    return true;
   };
 
   public getSelectedTimeWindow = (): [number, number] | null => {


### PR DESCRIPTION
## Summary
- Clear `selectedTimeWindow` when requested zoom window is invalid
- Return a boolean from `zoomToTimeWindow` to report success
- Add tests for invalid zoom window scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4548f58c0832ba56fa8e9a21e0c73