### PR TITLE
feat: expose more chart controls via interaction

### DIFF
--- a/samples/benchmarks/chart-components/index.ts
+++ b/samples/benchmarks/chart-components/index.ts
@@ -39,7 +39,7 @@ onCsv((data: [number, number][]) => {
   let j = 0;
   animateBench(() => {
     const point = data[j % data.length];
-    chart.updateChartWithNewData([point[0], point[1]]);
+    chart.interaction.updateChartWithNewData([point[0], point[1]]);
     j++;
   });
 

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -115,7 +115,8 @@ export async function loadAndDraw(
   intervalId = setInterval(function () {
     const newData = data[j % data.length];
     charts.forEach((c) => {
-      c.updateChartWithNewData([newData[0], newData[1]]);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      c.interaction.updateChartWithNewData([newData[0], newData[1]]);
     });
     j++;
   }, 5000);

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -156,8 +156,7 @@ function createChart(data: Array<[number]>) {
   );
 
   return {
-    zoom: chart.zoom,
-    onHover: chart.onHover,
+    interaction: chart.interaction,
     svgEl,
     legend,
     chart,
@@ -182,7 +181,7 @@ afterEach(() => {
 
 describe("chart interaction single-axis", () => {
   it("zoom updates transform and axes", () => {
-    const { zoom } = createChart([[0], [1]]);
+    const { interaction } = createChart([[0], [1]]);
     vi.runAllTimers();
 
     const xAxis = axisInstances[0]!;
@@ -193,12 +192,14 @@ describe("chart interaction single-axis", () => {
     const yCalls = yAxis.axisUpCalls;
     const callCount = updateNodeCalls;
 
-    zoom({
+    interaction.zoom({
       transform: { x: 10, k: 2 },
       sourceEvent: new Event("wheel"),
-    } as Parameters<typeof zoom>[0]);
+    } as Parameters<typeof interaction.zoom>[0]);
     vi.runAllTimers();
-    zoom({ transform: { x: 10, k: 2 } } as Parameters<typeof zoom>[0]);
+    interaction.zoom({
+      transform: { x: 10, k: 2 },
+    } as Parameters<typeof interaction.zoom>[0]);
     vi.runAllTimers();
 
     expect(mtNy.onZoomPan).toHaveBeenCalledWith({ x: 10, k: 2 });
@@ -211,10 +212,10 @@ describe("chart interaction single-axis", () => {
 
   it("onHover updates legend text and dot position", () => {
     const data: Array<[number]> = [[10], [30]];
-    const { onHover, svgEl, legend } = createChart(data);
+    const { interaction, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
-    onHover(1);
+    interaction.onHover(1);
     vi.runAllTimers();
 
     expect(
@@ -229,13 +230,13 @@ describe("chart interaction single-axis", () => {
 
   it("updates circle after appending data", () => {
     const data: Array<[number]> = [[10], [30]];
-    const { onHover, svgEl, legend, chart } = createChart(data);
+    const { interaction, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData([50]);
+    interaction.updateChartWithNewData([50]);
     vi.runAllTimers();
 
-    onHover(1);
+    interaction.onHover(1);
     vi.runAllTimers();
 
     expect(

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -167,8 +167,7 @@ function createChart(
   );
 
   return {
-    zoom: chart.zoom,
-    onHover: chart.onHover,
+    interaction: chart.interaction,
     svgEl,
     legend,
     chart,
@@ -194,7 +193,7 @@ afterEach(() => {
 
 describe("chart interaction", () => {
   it("zoom updates transforms and axes", () => {
-    const { zoom } = createChart([
+    const { interaction } = createChart([
       [0, 0],
       [1, 1],
     ]);
@@ -213,9 +212,9 @@ describe("chart interaction", () => {
       transform: { x: 10, k: 2 },
       sourceEvent: new Event("wheel"),
     } as D3ZoomEvent<SVGRectElement, unknown>;
-    zoom(event);
+    interaction.zoom(event);
     vi.runAllTimers();
-    zoom({ transform: { x: 10, k: 2 } } as D3ZoomEvent<
+    interaction.zoom({ transform: { x: 10, k: 2 } } as D3ZoomEvent<
       SVGRectElement,
       unknown
     >);
@@ -234,10 +233,10 @@ describe("chart interaction", () => {
       [10, 20],
       [30, 40],
     ];
-    const { onHover, svgEl, legend } = createChart(data);
+    const { interaction, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
-    onHover(1);
+    interaction.onHover(1);
     vi.runAllTimers();
 
     expect(
@@ -261,13 +260,13 @@ describe("chart interaction", () => {
       [10, 20],
       [30, 40],
     ];
-    const { onHover, svgEl, legend, chart } = createChart(data);
+    const { interaction, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
-    chart.updateChartWithNewData([50, 60]);
+    interaction.updateChartWithNewData([50, 60]);
     vi.runAllTimers();
 
-    onHover(1);
+    interaction.onHover(1);
     vi.runAllTimers();
 
     expect(
@@ -292,10 +291,10 @@ describe("chart interaction", () => {
       [30, 40],
     ];
     const formatter = vi.fn((ts: number) => `ts:${String(ts)}`);
-    const { onHover, legend } = createChart(data, formatter);
+    const { interaction, legend } = createChart(data, formatter);
     vi.runAllTimers();
 
-    onHover(1);
+    interaction.onHover(1);
     vi.runAllTimers();
 
     expect(legend.querySelector(".chart-legend__time")!.textContent).toBe(
@@ -316,10 +315,10 @@ describe("chart interaction", () => {
       [30, 40],
       [50, 60],
     ];
-    const { onHover, svgEl, legend } = createChart(data);
+    const { interaction, svgEl, legend } = createChart(data);
     vi.runAllTimers();
 
-    onHover(-100);
+    interaction.onHover(-100);
     vi.runAllTimers();
     let circles = svgEl.querySelectorAll("circle");
     let greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
@@ -335,7 +334,7 @@ describe("chart interaction", () => {
     expect(blueTransform.e).toBe(0);
     expect(blueTransform.f).toBe(20);
 
-    onHover(100);
+    interaction.onHover(100);
     vi.runAllTimers();
     circles = svgEl.querySelectorAll("circle");
     greenTransform = nodeTransforms.get(circles[0] as SVGCircleElement)!;
@@ -422,7 +421,8 @@ describe("chart interaction", () => {
     zoomRect.dispatchEvent(new MouseEvent("mousemove"));
     expect(mouseMoveHandler).toHaveBeenCalledTimes(1);
 
-    chart.interaction.dispose();
+    const interaction = chart.interaction;
+    interaction.dispose();
 
     expect(destroySpy).toHaveBeenCalled();
 

--- a/svg-time-series/src/draw.test.ts
+++ b/svg-time-series/src/draw.test.ts
@@ -102,7 +102,7 @@ describe("TimeSeriesChart", () => {
     appendSpy.mockClear();
     drawSpy.mockClear();
 
-    chart.updateChartWithNewData([10]);
+    chart.interaction.updateChartWithNewData([10]);
 
     expect(appendSpy).toHaveBeenCalledWith(10);
     expect(drawSpy).toHaveBeenCalledWith(internal.data.data);
@@ -111,7 +111,7 @@ describe("TimeSeriesChart", () => {
   it("throws when provided fewer values than series count", () => {
     const { chart } = createChart();
     expect(() => {
-      chart.updateChartWithNewData([]);
+      chart.interaction.updateChartWithNewData([]);
     }).toThrow(
       "TimeSeriesChart.updateChartWithNewData expected 1 values, received 0",
     );
@@ -120,7 +120,7 @@ describe("TimeSeriesChart", () => {
   it("throws when provided more values than series count", () => {
     const { chart } = createChart();
     expect(() => {
-      chart.updateChartWithNewData([10, 20]);
+      chart.interaction.updateChartWithNewData([10, 20]);
     }).toThrow(
       "TimeSeriesChart.updateChartWithNewData expected 1 values, received 2",
     );
@@ -129,20 +129,22 @@ describe("TimeSeriesChart", () => {
   it("throws for invalid value types", () => {
     const { chart } = createChart();
     expect(() => {
-      chart.updateChartWithNewData([undefined as unknown as number]);
+      chart.interaction.updateChartWithNewData([
+        undefined as unknown as number,
+      ]);
     }).toThrow(/values\[0\] must be a finite number or NaN/);
     expect(() => {
-      chart.updateChartWithNewData([Infinity]);
+      chart.interaction.updateChartWithNewData([Infinity]);
     }).toThrow(/values\[0\] must be a finite number or NaN/);
     expect(() => {
-      chart.updateChartWithNewData(["oops" as unknown as number]);
+      chart.interaction.updateChartWithNewData(["oops" as unknown as number]);
     }).toThrow(/values\[0\] must be a finite number or NaN/);
   });
 
   it("accepts NaN values", () => {
     const { chart } = createChart();
     expect(() => {
-      chart.updateChartWithNewData([NaN]);
+      chart.interaction.updateChartWithNewData([NaN]);
     }).not.toThrow();
   });
 
@@ -176,7 +178,7 @@ describe("TimeSeriesChart", () => {
     updateExtentsSpy.mockClear();
     legendRefreshSpy.mockClear();
 
-    chart.resize({ width: 200, height: 150 });
+    chart.interaction.resize({ width: 200, height: 150 });
 
     expect(svgEl.getAttribute("width")).toBe("200");
     expect(svgEl.getAttribute("height")).toBe("150");
@@ -203,7 +205,7 @@ describe("TimeSeriesChart", () => {
     };
     vi.spyOn(internal.state, "screenToModelX").mockReturnValue(10);
 
-    chart.onHover(5);
+    chart.interaction.onHover(5);
 
     expect(legend.highlightIndexRaf).toHaveBeenCalledWith(
       internal.data.length - 1,
@@ -217,7 +219,7 @@ describe("TimeSeriesChart", () => {
       zoomState: { setScaleExtent: ReturnType<typeof vi.fn> };
     };
 
-    chart.setScaleExtent([1, 3]);
+    chart.interaction.setScaleExtent([1, 3]);
 
     expect(internal.zoomState.setScaleExtent).toHaveBeenCalledWith([1, 3]);
   });
@@ -272,10 +274,10 @@ describe("TimeSeriesChart", () => {
     internal.selectedTimeWindow = [1, 2];
     const clearBrushSpy = vi.spyOn(internal, "clearBrush");
 
-    chart.enableBrush();
+    chart.interaction.enableBrush();
 
     expect(clearBrushSpy).toHaveBeenCalled();
-    expect(chart.getSelectedTimeWindow()).toBeNull();
+    expect(chart.interaction.getSelectedTimeWindow()).toBeNull();
   });
 
   it("clears brush and skips zoom when selection collapses", () => {
@@ -298,7 +300,7 @@ describe("TimeSeriesChart", () => {
 
     expect(transformSpy).not.toHaveBeenCalled();
     expect(clearBrushSelection).toHaveBeenCalled();
-    expect(chart.getSelectedTimeWindow()).toBeNull();
+    expect(chart.interaction.getSelectedTimeWindow()).toBeNull();
   });
 
   it("returns a cloned selected time window", () => {
@@ -306,12 +308,12 @@ describe("TimeSeriesChart", () => {
     (
       chart as unknown as { selectedTimeWindow: [number, number] }
     ).selectedTimeWindow = [1, 2];
-    const window1 = chart.getSelectedTimeWindow();
+    const window1 = chart.interaction.getSelectedTimeWindow();
     expect(window1).toEqual([1, 2]);
     if (window1) {
       window1[0] = 100;
     }
-    expect(chart.getSelectedTimeWindow()).toEqual([1, 2]);
+    expect(chart.interaction.getSelectedTimeWindow()).toEqual([1, 2]);
   });
 
   it("resets data without recreating the svg container", () => {
@@ -341,7 +343,7 @@ describe("TimeSeriesChart", () => {
       getSeries: (i, j) => rows[i]![j]!,
     };
 
-    chart.resetData(source);
+    chart.interaction.resetData(source);
 
     expect(replaceSpy).toHaveBeenCalledWith(source);
     expect(destroySpy).toHaveBeenCalledTimes(1);

--- a/svg-time-series/src/draw.ts
+++ b/svg-time-series/src/draw.ts
@@ -28,6 +28,9 @@ export interface IPublicInteraction {
   disableBrush: () => void;
   zoomToTimeWindow: (start: Date | number, end: Date | number) => void;
   getSelectedTimeWindow: () => [number, number] | null;
+  updateChartWithNewData: (values: number[]) => void;
+  resize: (dimensions: { width: number; height: number }) => void;
+  resetData: (source: IDataSource) => void;
   dispose: () => void;
 }
 
@@ -129,6 +132,9 @@ export class TimeSeriesChart {
       disableBrush: this.disableBrush,
       zoomToTimeWindow: this.zoomToTimeWindow,
       getSelectedTimeWindow: this.getSelectedTimeWindow,
+      updateChartWithNewData: this.updateChartWithNewData,
+      resize: this.resize,
+      resetData: this.resetData,
       dispose: this.dispose,
     };
   }
@@ -137,7 +143,7 @@ export class TimeSeriesChart {
     return this.publicInteraction;
   }
 
-  public updateChartWithNewData(values: number[]): void {
+  public updateChartWithNewData = (values: number[]): void => {
     if (values.length !== this.data.seriesCount) {
       throw new Error(
         `TimeSeriesChart.updateChartWithNewData expected ${String(
@@ -150,9 +156,9 @@ export class TimeSeriesChart {
     }
     this.data.append(...values);
     this.refreshAll();
-  }
+  };
 
-  public resetData(source: IDataSource): void {
+  public resetData = (source: IDataSource): void => {
     this.data.replace(source);
     this.state.destroy();
     this.state = setupRender(this.svg, this.data);
@@ -178,7 +184,7 @@ export class TimeSeriesChart {
     this.refreshAll();
     const { width } = this.state.getDimensions();
     this.onHover(width - 1);
-  }
+  };
 
   public dispose = () => {
     this.zoomState.destroy();


### PR DESCRIPTION
## Summary
- expose update, resize and reset methods through interaction API
- route demos and tests through chart.interaction

## Testing
- `npm run lint`
- `npm run typecheck --workspaces --if-present`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a454b74ff8832b86d21449f064e4a4