### PR TITLE
refactor ChartData initialization

### DIFF
--- a/svg-time-series/src/chart/data.test.ts
+++ b/svg-time-series/src/chart/data.test.ts
@@ -585,4 +585,41 @@ describe("ChartData", () => {
     expect(cd.timeStep).toBe(1);
     expect(cd.length).toBe(2);
   });
+
+  it("matches new instance state after replace", () => {
+    const source1 = makeSource(
+      [
+        [1, 2],
+        [3, 4],
+      ],
+      [0, 1],
+    );
+    const source2 = makeSource(
+      [
+        [5, 6, 7],
+        [8, 9, 10],
+      ],
+      [1, 0, 1],
+    );
+    const cd = new ChartData(source1);
+    cd.replace(source2);
+    const expected = new ChartData(source2);
+    expect(cd.seriesAxes).toEqual(expected.seriesAxes);
+    expect(cd.seriesByAxis).toEqual(expected.seriesByAxis);
+    expect(cd.seriesCount).toBe(expected.seriesCount);
+    expect(cd.startTime).toBe(expected.startTime);
+    expect(cd.timeStep).toBe(expected.timeStep);
+    expect(cd.data).toEqual(expected.data);
+    expect(cd.length).toBe(expected.length);
+    const tree0 = cd.buildAxisTree(0);
+    const tree0Expected = expected.buildAxisTree(0);
+    expect(tree0.query(0, cd.length - 1)).toEqual(
+      tree0Expected.query(0, expected.length - 1),
+    );
+    const tree1 = cd.buildAxisTree(1);
+    const tree1Expected = expected.buildAxisTree(1);
+    expect(tree1.query(0, cd.length - 1)).toEqual(
+      tree1Expected.query(0, expected.length - 1),
+    );
+  });
 });

--- a/svg-time-series/src/chart/data.ts
+++ b/svg-time-series/src/chart/data.ts
@@ -47,43 +47,25 @@ export class ChartData {
   }
 
   public readonly seriesByAxis: [number[], number[]] = [[], []];
-  public seriesAxes: number[];
-  public seriesCount: number;
-  public startTime: number;
-  public timeStep: number;
-  public window: DataWindow;
-  public axes: [AxisData, AxisData];
+  public seriesAxes!: number[];
+  public seriesCount!: number;
+  public startTime!: number;
+  public timeStep!: number;
+  public window!: DataWindow;
+  public axes!: [AxisData, AxisData];
 
   constructor(source: IDataSource) {
     ChartData.validateSource(source);
-    this.seriesAxes = source.seriesAxes;
-    this.seriesCount = this.seriesAxes.length;
-    this.seriesAxes.forEach((axis, axisIdx) =>
-      this.seriesByAxis[axis as 0 | 1].push(axisIdx),
-    );
-    const initialData = Array.from({ length: source.length }).map((_, i) =>
-      Array.from({ length: this.seriesCount }).map((_, j) =>
-        source.getSeries(i, j),
-      ),
-    );
-    this.window = new DataWindow(
-      initialData,
-      source.startTime,
-      source.timeStep,
-    );
-    this.startTime = this.window.startTime;
-    this.timeStep = this.window.timeStep;
-    this.axes = [
-      new AxisData(this.window, this.seriesByAxis[0]),
-      new AxisData(this.window, this.seriesByAxis[1]),
-    ];
+    this.initializeFromSource(source);
   }
 
   replace(source: IDataSource): void {
     ChartData.validateSource(source);
+    this.initializeFromSource(source);
+  }
 
-    this.seriesAxes.length = 0;
-    this.seriesAxes.push(...source.seriesAxes);
+  private initializeFromSource(source: IDataSource): void {
+    this.seriesAxes = [...source.seriesAxes];
     this.seriesCount = this.seriesAxes.length;
 
     this.seriesByAxis[0].length = 0;
@@ -104,8 +86,10 @@ export class ChartData {
     );
     this.startTime = this.window.startTime;
     this.timeStep = this.window.timeStep;
-    this.axes[0] = new AxisData(this.window, this.seriesByAxis[0]);
-    this.axes[1] = new AxisData(this.window, this.seriesByAxis[1]);
+    this.axes = [
+      new AxisData(this.window, this.seriesByAxis[0]),
+      new AxisData(this.window, this.seriesByAxis[1]),
+    ];
   }
 
   append(...values: number[]): void {


### PR DESCRIPTION
## Summary
- extract `initializeFromSource` helper in ChartData and reuse in constructor/replace
- ensure series arrays, window and axes reset uniformly
- add tests comparing constructor and replace state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a454756f0c832bb4b6fede74941f00