### PR TITLE
fix(samples): clean up demo button listeners

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -150,16 +150,19 @@ export async function initDemo(
       c.interaction.onHover(0);
     });
     const resetButton = document.getElementById("reset-zoom");
-    resetButton?.addEventListener("click", () => {
+    let resetHandler: (() => void) | null = null;
+    resetHandler = () => {
       charts.forEach((c) => {
         c.interaction.resetZoom();
       });
-    });
+    };
+    resetButton?.addEventListener("click", resetHandler);
 
     const brushButton = document.getElementById("toggle-brush");
+    let brushHandler: (() => void) | null = null;
     if (brushButton) {
       let brushEnabled = false;
-      brushButton.addEventListener("click", () => {
+      brushHandler = () => {
         brushEnabled = !brushEnabled;
         charts.forEach((c) => {
           if (brushEnabled) {
@@ -171,7 +174,8 @@ export async function initDemo(
         brushButton.textContent = brushEnabled
           ? "Disable Brush"
           : "Enable Brush";
-      });
+      };
+      brushButton.addEventListener("click", brushHandler);
     }
 
     let disposed = false;
@@ -185,6 +189,14 @@ export async function initDemo(
         if (resizeListener) {
           window.removeEventListener("resize", resizeListener);
           resizeListener = null;
+        }
+        if (resetButton && resetHandler) {
+          resetButton.removeEventListener("click", resetHandler);
+          resetHandler = null;
+        }
+        if (brushButton && brushHandler) {
+          brushButton.removeEventListener("click", brushHandler);
+          brushHandler = null;
         }
       }
     };


### PR DESCRIPTION
## Summary
- keep references to demo reset and brush button handlers
- remove handlers in disposeAll and ensure interaction.dispose triggers cleanup

## Testing
- `npm run format samples/demos/common.ts`
- `git commit -am "fix(samples): clean up demo button listeners"`


------
https://chatgpt.com/codex/tasks/task_e_68a490517af4832b83731712e9695b01