### PR TITLE
refactor: replace d3-request with d3-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2451,6 +2451,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -2465,23 +2475,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-request": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-request/-/d3-request-1.0.9.tgz",
-      "integrity": "sha512-gD2991YKzdQu5lJGhWHEjptxQvWRZKwZF3QdWqjnqrWfVd15e7/WuL6X2Pl/4sRyLKaXWbB2xuk1tSBPVLlNhg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "^1"
-      }
-    },
-    "node_modules/@types/d3-request/node_modules/@types/d3-dsv": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-1.2.8.tgz",
-      "integrity": "sha512-x1m1s0lVstZQ5/Kzp4bVIMee3fFuDm+hphVnvrYA7wU16XqwgbCBfeVvHYZzVQQIy4jyi3MEtgduLVuwIRCKLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4984,6 +4977,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-force": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
@@ -5089,18 +5094,6 @@
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
       "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-request": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-request/-/d3-request-1.0.6.tgz",
-      "integrity": "sha512-FJj8ySY6GYuAJHZMaCQ83xEYE4KbkPkmxZ3Hu6zA1xxG2GD+z6P+Lyp+zjdsHf0xEbp2xcluDI50rCS855EQ6w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-dsv": "1",
-        "xmlhttprequest": "1"
-      }
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
@@ -13539,15 +13532,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -13699,14 +13683,14 @@
       "license": "ISC",
       "dependencies": {
         "buffer": "^6.0.3",
-        "d3-request": "^1.0.6",
+        "d3-fetch": "^3.0.1",
         "plotly.js": "^3.1.0"
       },
       "devDependencies": {
         "@types/d3-array": "^3.2.1",
         "@types/d3-axis": "^3.0.6",
         "@types/d3-dsv": "^3.0.7",
-        "@types/d3-request": "^1.0.1",
+        "@types/d3-fetch": "^3.0.7",
         "@types/plotly.js": "^3.0.3"
       }
     },

--- a/samples/benchmarks/bench.ts
+++ b/samples/benchmarks/bench.ts
@@ -1,20 +1,18 @@
-import { csv } from "d3-request";
+import { csv } from "d3-fetch";
 import { timer as runTimer } from "d3-timer";
 
 export { measure, measureOnce } from "../measure.ts";
 
 export function onCsv(f: (csv: number[][]) => void): void {
-  csv("../../demos/ny-vs-sf.csv")
-    .row((d: { NY: string; SF: string }) => [
-      parseFloat(d.NY.split(";")[0]),
-      parseFloat(d.SF.split(";")[0]),
-    ])
-    .get((error: Error | null, data: number[][]) => {
-      if (error != null) {
-        console.error("Data can't be downloaded or parsed");
-        return;
-      }
+  csv("../../demos/ny-vs-sf.csv", (d: { NY: string; SF: string }) => [
+    parseFloat(d.NY.split(";")[0]),
+    parseFloat(d.SF.split(";")[0]),
+  ])
+    .then((data: number[][]) => {
       f(data);
+    })
+    .catch(() => {
+      console.error("Data can't be downloaded or parsed");
     });
 }
 

--- a/samples/benchmarks/demo2-without-grid/index.ts
+++ b/samples/benchmarks/demo2-without-grid/index.ts
@@ -1,4 +1,4 @@
-import { csv } from "d3-request";
+import { csv } from "d3-fetch";
 import { select, selectAll } from "d3-selection";
 
 import { measure, measureOnce } from "../bench.ts";
@@ -11,29 +11,28 @@ const resize: {
   eval?: () => void;
 } = { interval: 60 };
 
-csv("../../demos/ny-vs-sf.csv")
-  .row((d: { NY: string; SF: string }) => ({
-    NY: parseFloat(d.NY.split(";")[0]),
-    SF: parseFloat(d.SF.split(";")[0]),
-  }))
-  .get((error: Error | null, data: { NY: number; SF: number }[]) => {
-    if (error != null) console.error("Data can't be downloaded or parsed");
-    else {
-      common.drawCharts(data);
+csv("../../demos/ny-vs-sf.csv", (d: { NY: string; SF: string }) => ({
+  NY: parseFloat(d.NY.split(";")[0]),
+  SF: parseFloat(d.SF.split(";")[0]),
+}))
+  .then((data: { NY: number; SF: number }[]) => {
+    common.drawCharts(data);
 
-      resize.request = () => {
-        if (resize.timer) clearTimeout(resize.timer);
-        resize.timer = setTimeout(() => {
-          resize.eval?.();
-        }, resize.interval);
-      };
-      resize.eval = () => {
-        selectAll("svg").remove();
-        select(".charts").selectAll("div").append("svg");
-        common.drawCharts(data);
-      };
-      window.addEventListener("resize", resize.request, false);
-    }
+    resize.request = () => {
+      if (resize.timer) clearTimeout(resize.timer);
+      resize.timer = setTimeout(() => {
+        resize.eval?.();
+      }, resize.interval);
+    };
+    resize.eval = () => {
+      selectAll("svg").remove();
+      select(".charts").selectAll("div").append("svg");
+      common.drawCharts(data);
+    };
+    window.addEventListener("resize", resize.request, false);
+  })
+  .catch(() => {
+    console.error("Data can't be downloaded or parsed");
   });
 
 measure(3, ({ fps }) => {

--- a/samples/benchmarks/viewing-pipeline-transformations/index.ts
+++ b/samples/benchmarks/viewing-pipeline-transformations/index.ts
@@ -1,4 +1,4 @@
-import { csv } from "d3-request";
+import { csv } from "d3-fetch";
 
 import { line } from "d3-shape";
 import { select, selectAll, type Selection } from "d3-selection";
@@ -6,17 +6,11 @@ import * as draw from "./draw.ts";
 import * as drawModelCS from "./drawModelCS.ts";
 
 const startDate = new Date();
-csv("../../demos/ny-vs-sf.csv")
-  .row((d: { NY: string; SF: string }) => [
-    parseFloat(d.NY.split(";")[0]),
-    parseFloat(d.SF.split(";")[0]),
-  ])
-  .get((error: Error | null, data: number[][]) => {
-    if (error != null) {
-      console.error("Data can't be downloaded or parsed");
-      return;
-    }
-
+csv("../../demos/ny-vs-sf.csv", (d: { NY: string; SF: string }) => [
+  parseFloat(d.NY.split(";")[0]),
+  parseFloat(d.SF.split(";")[0]),
+])
+  .then((data: number[][]) => {
     const onPath = (
       path: Selection<SVGPathElement, number[], SVGGElement, unknown>,
     ) => {
@@ -54,6 +48,9 @@ csv("../../demos/ny-vs-sf.csv")
         data.length,
       );
     });
+  })
+  .catch(() => {
+    console.error("Data can't be downloaded or parsed");
   });
 
 function calcDate(index: number, offset: Date, step: number) {

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -1,4 +1,4 @@
-import { csv } from "d3-request";
+import { csv } from "d3-fetch";
 import type { ValueFn } from "d3-selection";
 import { select, selectAll, pointer } from "d3-selection";
 import type { D3ZoomEvent } from "d3-zoom";
@@ -73,21 +73,16 @@ export function drawCharts(
   return charts;
 }
 
-export function onCsv(): Promise<[number, number][]> {
-  return new Promise((resolve, reject) => {
-    csv("./ny-vs-sf.csv")
-      .row((d: { NY: string; SF: string }) => [
-        parseFloat(d.NY.split(";")[0]),
-        parseFloat(d.SF.split(";")[0]),
-      ])
-      .get((error: Error | null, data: [number, number][]) => {
-        if (error != null) {
-          reject(error);
-          return;
-        }
-        resolve(data);
-      });
-  });
+export async function onCsv(): Promise<[number, number][]> {
+  try {
+    const rows = (await csv("./ny-vs-sf.csv")) as { NY: string; SF: string }[];
+    return rows.map(({ NY, SF }) => [
+      parseFloat(NY.split(";")[0]),
+      parseFloat(SF.split(";")[0]),
+    ]);
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
 }
 
 interface Resize {

--- a/samples/package.json
+++ b/samples/package.json
@@ -14,14 +14,14 @@
   "description": "",
   "dependencies": {
     "buffer": "^6.0.3",
-    "d3-request": "^1.0.6",
+    "d3-fetch": "^3.0.1",
     "plotly.js": "^3.1.0"
   },
   "devDependencies": {
     "@types/d3-array": "^3.2.1",
     "@types/d3-axis": "^3.0.6",
     "@types/d3-dsv": "^3.0.7",
-    "@types/d3-request": "^1.0.1",
+    "@types/d3-fetch": "^3.0.7",
     "@types/plotly.js": "^3.0.3"
   }
 }

--- a/samples/tsconfig.json
+++ b/samples/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["*.ts"],
+  "include": ["**/*.ts"],
   "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- replace d3-request with d3-fetch across sample code
- rewrite onCsv to use async/await with error handling
- update sample dependencies and tsconfig

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a49037415c832b925971d599cf5ed1