### PR TITLE
feat(demos): resize charts using ResizeObserver

### DIFF
--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -90,23 +90,34 @@ export function onCsv(): Promise<[number, number][]> {
   });
 }
 
-interface Resize {
-  interval: number;
-  request: (() => void) | null;
-  timer: ReturnType<typeof setTimeout> | null;
-  eval: (() => void) | null;
-}
-
-const resize: Resize = { interval: 60, request: null, timer: null, eval: null };
-
 let intervalId: ReturnType<typeof setInterval> | null = null;
-let resizeListener: (() => void) | null = null;
+let resizeObservers: ResizeObserver[] = [];
+
+function setupResizeObservers(charts: TimeSeriesChart[]): void {
+  resizeObservers.forEach((o) => {
+    o.disconnect();
+  });
+  resizeObservers = [];
+  selectAll<HTMLElement, unknown>(".chart-drawing").each(function (
+    this: HTMLElement,
+    _,
+    i,
+  ) {
+    const chart = charts[i]!;
+    const observer = new ResizeObserver((entries) => {
+      const { width, height } = entries[0]!.contentRect;
+      chart.resize({ width, height });
+    });
+    observer.observe(this);
+    resizeObservers.push(observer);
+  });
+}
 
 export async function loadAndDraw(
   seriesAxes: number[] = [0, 0],
 ): Promise<TimeSeriesChart[]> {
   const data = await onCsv();
-  let charts = drawCharts(data, seriesAxes);
+  const charts = drawCharts(data, seriesAxes);
 
   if (intervalId) {
     clearInterval(intervalId);
@@ -120,23 +131,7 @@ export async function loadAndDraw(
     j++;
   }, 5000);
 
-  resize.request = function () {
-    if (resize.timer) clearTimeout(resize.timer);
-    resize.timer = setTimeout(() => {
-      resize.eval?.();
-    }, resize.interval);
-  };
-  resize.eval = function () {
-    selectAll("svg").remove();
-    selectAll(".chart-drawing").append("svg");
-    charts = drawCharts(data, seriesAxes);
-  };
-
-  if (resizeListener) {
-    window.removeEventListener("resize", resizeListener);
-  }
-  resizeListener = () => resize.request?.();
-  window.addEventListener("resize", resizeListener);
+  setupResizeObservers(charts);
 
   return charts;
 }
@@ -186,10 +181,10 @@ export async function initDemo(
           clearInterval(intervalId);
           intervalId = null;
         }
-        if (resizeListener) {
-          window.removeEventListener("resize", resizeListener);
-          resizeListener = null;
-        }
+        resizeObservers.forEach((o) => {
+          o.disconnect();
+        });
+        resizeObservers = [];
         if (resetButton && resetHandler) {
           resetButton.removeEventListener("click", resetHandler);
           resetHandler = null;


### PR DESCRIPTION
## Summary
- observe chart containers with `ResizeObserver`
- call chart resize on container changes instead of redrawing
- clean up observers on demo dispose

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4972e3f30832b9d4f7d0ba4d0e168