### PR TITLE
feat(bench): add loop vs segment tree min-max benchmark

### DIFF
--- a/segment-tree-rmq/bench/minMax.bench.ts
+++ b/segment-tree-rmq/bench/minMax.bench.ts
@@ -1,0 +1,44 @@
+import { bench, describe } from "vitest";
+import { SegmentTree } from "../src/index.ts";
+
+// Deterministic seed for reproducible benchmarks
+const SEED = 123456789;
+let seed = SEED;
+const random = (): number => {
+  seed ^= seed << 13;
+  seed ^= seed >>> 17;
+  seed ^= seed << 5;
+  return (seed >>> 0) / 0xffffffff;
+};
+
+describe("Min/max calculation", () => {
+  const size = 50_000;
+  const data = Array.from({ length: size }, () => random());
+
+  let _result: { min: number; max: number };
+
+  bench("loop", () => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (let i = 0; i < size; i++) {
+      const v = data[i]!;
+      if (v < min) {
+        min = v;
+      }
+      if (v > max) {
+        max = v;
+      }
+    }
+    _result = { min, max };
+  });
+
+  const tree = new SegmentTree<{ min: number; max: number }>(
+    data.map((v) => ({ min: v, max: v })),
+    (a, b) => ({ min: Math.min(a.min, b.min), max: Math.max(a.max, b.max) }),
+    { min: Infinity, max: -Infinity },
+  );
+
+  bench("segment tree", () => {
+    _result = tree.query(0, size - 1);
+  });
+});

--- a/segment-tree-rmq/package.json
+++ b/segment-tree-rmq/package.json
@@ -19,8 +19,7 @@
     "build": "tsc -p tsconfig.json",
     "lint": "eslint src",
     "typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "bench": "npm run bench:segment-tree",
-    "bench:segment-tree": "vitest bench bench/segmentTree.bench.ts --run",
+    "bench": "vitest bench bench/*.bench.ts --run",
     "test": "vitest run --reporter=dot",
     "prepare": "npm run build"
   }


### PR DESCRIPTION
## Summary
- add benchmark comparing loop and segment tree min/max computation
- run benchmark for 50k elements

## Testing
- `npm run bench --workspace=segment-tree-rmq`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8bc2a101c832bade16c1ea24a1374