### PR TITLE
refactor: reuse time scale in dIndexFromTransform

### DIFF
--- a/svg-time-series/src/chart/dataWindow.ts
+++ b/svg-time-series/src/chart/dataWindow.ts
@@ -80,10 +80,9 @@ export class DataWindow {
   }
 
   dIndexFromTransform(transform: ZoomTransform): [number, number] {
-    const base = scaleUtc<number, number>()
-      .domain(this.timeScale.domain())
-      .range(this.timeRange);
-    const [t0, t1] = transform.rescaleX(base).domain() as [Date, Date];
+    const [t0, t1] = transform
+      .rescaleX(this.timeScale.copy().range(this.timeRange))
+      .domain() as [Date, Date];
     return [this.timeScale(t0), this.timeScale(t1)];
   }
 


### PR DESCRIPTION
## Summary
- refactor dataWindow's transform logic to clone and rescale existing time scale

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7f0f3dbc832bbee203a321ef6f22