### PR TITLE
refactor axis scaling to use persistent base scale

### DIFF
--- a/svg-time-series/src/chart/axisManager.helpers.test.ts
+++ b/svg-time-series/src/chart/axisManager.helpers.test.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { scaleTime } from "d3-scale";
-import { zoomIdentity } from "d3-zoom";
 
 import { polyfillDom } from "../setupDom.ts";
-import { AxisModel, createBaseXScale, updateAxisModel } from "./axisManager.ts";
+import { createBaseXScale } from "./axisManager.ts";
 import { ChartData } from "./data.ts";
 
 await polyfillDom();
@@ -26,34 +25,5 @@ describe("createBaseXScale", () => {
     const base = createBaseXScale(x, data.window);
     expect(base.domain()).toEqual(data.window.timeDomainFull());
     expect(x.domain()).toEqual([new Date(5), new Date(6)]);
-  });
-});
-
-describe("updateAxisModel", () => {
-  it("updates the axis when series data exists", () => {
-    const data = makeChartData();
-    const axis = new AxisModel();
-    axis.scale.range([100, 0]);
-    const x = scaleTime()
-      .domain([new Date(0), new Date(9)])
-      .range([0, 100]);
-    const baseX = createBaseXScale(x, data.window);
-    const t = zoomIdentity.scale(2);
-    data.window.onViewPortResize(baseX.range() as [number, number]);
-    const dIndexVisible = data.dIndexFromTransform(t);
-    updateAxisModel(axis, 0, data, t, dIndexVisible);
-    const { scale: baseScaleRaw } = data.axisTransform(0, dIndexVisible);
-    const expectedDomain = t
-      .rescaleY(baseScaleRaw.range(axis.scale.range() as [number, number]))
-      .domain();
-    expect(axis.scale.domain()).toEqual(expectedDomain);
-  });
-
-  it("skips axes without series", () => {
-    const data = makeChartData();
-    const axis = new AxisModel();
-    const spy = vi.spyOn(axis, "updateFromData");
-    updateAxisModel(axis, 1, data, zoomIdentity, [0, 1]);
-    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/svg-time-series/src/chart/axisManager.test.ts
+++ b/svg-time-series/src/chart/axisManager.test.ts
@@ -70,12 +70,7 @@ describe("AxisManager", () => {
 
     const t = zoomIdentity.scale(2);
     axisManager.updateScales(t);
-    const dIndexVisible = data.dIndexFromTransform(t);
-    const { scale: baseScaleRaw } = data.axisTransform(0, dIndexVisible);
-    const baseScale = baseScaleRaw.range(
-      axisManager.axes[0]!.scale.range() as [number, number],
-    );
-    const expectedDomain = t.rescaleY(baseScale).domain();
+    const expectedDomain = t.rescaleY(axisManager.axes[0]!.baseScale).domain();
     expect(axisManager.axes[0]!.scale.domain()).toEqual(expectedDomain);
   });
 });


### PR DESCRIPTION
## Summary
- keep a persistent base scale in each AxisModel
- rescale axes directly from the base scale
- drop updateAxisModel helper and simplify tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7f10a690832baca000f6e1e73d3f