### PR TITLE
feat: expose viewport scales and drop wrappers

### DIFF
--- a/svg-time-series/bench/viewportTransform.bench.ts
+++ b/svg-time-series/bench/viewportTransform.bench.ts
@@ -16,11 +16,12 @@ describe("ViewportTransform performance", () => {
     vt.onZoomPan(t);
   });
 
-  bench("fromScreenToModelX", () => {
-    vt.fromScreenToModelX(50);
+  bench("scaleX.invert", () => {
+    vt.scaleX.invert(50);
   });
 
-  bench("fromScreenToModelBasisX", () => {
-    vt.fromScreenToModelBasisX([20, 40]);
+  bench("scaleX.invert basis", () => {
+    vt.scaleX.invert(20);
+    vt.scaleX.invert(40);
   });
 });

--- a/svg-time-series/src/ViewportTransform.ts
+++ b/svg-time-series/src/ViewportTransform.ts
@@ -5,23 +5,23 @@ import { scalesToDomMatrix } from "./utils/domMatrix.ts";
 export class ViewportTransform {
   private baseScaleX = scaleLinear();
   private baseScaleY = scaleLinear();
-  private scaleX = this.baseScaleX;
-  private scaleY = this.baseScaleY;
+  private _scaleX = this.baseScaleX;
+  private _scaleY = this.baseScaleY;
   private zoomTransform: ZoomTransform = zoomIdentity;
   private composedMatrix: DOMMatrix = new DOMMatrix();
 
   private static readonly EPSILON = 1e-12;
 
   private updateScales() {
-    this.scaleX = this.zoomTransform.rescaleX(this.baseScaleX);
+    this._scaleX = this.zoomTransform.rescaleX(this.baseScaleX);
     // Ignore the zoom transform for the Y axis so that it always fits the data
     // based on its current domain.
-    this.scaleY = this.baseScaleY.copy();
+    this._scaleY = this.baseScaleY.copy();
     this.updateComposedMatrix();
   }
 
   private updateComposedMatrix() {
-    this.composedMatrix = scalesToDomMatrix(this.scaleX, this.scaleY);
+    this.composedMatrix = scalesToDomMatrix(this._scaleX, this._scaleY);
   }
 
   public onViewPortResize(
@@ -65,52 +65,14 @@ export class ViewportTransform {
     }
   }
 
-  public fromScreenToModelX(x: number) {
-    this.assertNonDegenerate(this.scaleX);
-    return this.scaleX.invert(x);
+  public get scaleX(): ScaleLinear<number, number> {
+    this.assertNonDegenerate(this._scaleX);
+    return this._scaleX;
   }
 
-  public fromScreenToModelY(y: number) {
-    this.assertNonDegenerate(this.scaleY);
-    return this.scaleY.invert(y);
-  }
-
-  public fromScreenToModelBasisX(
-    b: readonly [number, number],
-  ): [number, number] {
-    this.assertNonDegenerate(this.scaleX);
-    return [this.scaleX.invert(b[0]), this.scaleX.invert(b[1])];
-  }
-
-  public fromScreenToModelBasisY(
-    b: readonly [number, number],
-  ): [number, number] {
-    this.assertNonDegenerate(this.scaleY);
-    return [this.scaleY.invert(b[0]), this.scaleY.invert(b[1])];
-  }
-
-  public toScreenFromModelX(x: number) {
-    this.assertNonDegenerate(this.scaleX);
-    return this.scaleX(x);
-  }
-
-  public toScreenFromModelY(y: number) {
-    this.assertNonDegenerate(this.scaleY);
-    return this.scaleY(y);
-  }
-
-  public toScreenFromModelBasisX(
-    b: readonly [number, number],
-  ): [number, number] {
-    this.assertNonDegenerate(this.scaleX);
-    return [this.scaleX(b[0]), this.scaleX(b[1])];
-  }
-
-  public toScreenFromModelBasisY(
-    b: readonly [number, number],
-  ): [number, number] {
-    this.assertNonDegenerate(this.scaleY);
-    return [this.scaleY(b[0]), this.scaleY(b[1])];
+  public get scaleY(): ScaleLinear<number, number> {
+    this.assertNonDegenerate(this._scaleY);
+    return this._scaleY;
   }
 
   public get matrix(): DOMMatrix {

--- a/svg-time-series/src/chart/interaction.hoverClamp.test.ts
+++ b/svg-time-series/src/chart/interaction.hoverClamp.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import type * as d3Zoom from "d3-zoom";
+import { scaleLinear, type ScaleLinear } from "d3-scale";
 import { TimeSeriesChart } from "../draw.ts";
 import type { IDataSource } from "../draw.ts";
 import { polyfillDom } from "../setupDom.ts";
@@ -21,10 +22,9 @@ class MockViewportTransform {
     this.dataLength = dataLength;
   }
   onZoomPan = vi.fn();
-  fromScreenToModelX = vi.fn((x: number) => x);
-  fromScreenToModelBasisX = vi.fn(function (this: MockViewportTransform) {
-    return [0, Math.max(this.dataLength - 1, 0)] as [number, number];
-  });
+  scaleX: ScaleLinear<number, number> = scaleLinear();
+  scaleY: ScaleLinear<number, number> = scaleLinear();
+  matrix = new DOMMatrix();
   onViewPortResize = vi.fn();
   onReferenceViewWindowResize = vi.fn();
 }

--- a/svg-time-series/src/chart/interaction.resetZoom.test.ts
+++ b/svg-time-series/src/chart/interaction.resetZoom.test.ts
@@ -13,6 +13,7 @@ import {
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import type { D3BrushEvent } from "d3-brush";
+import { scaleLinear, type ScaleLinear } from "d3-scale";
 import { TimeSeriesChart } from "../draw.ts";
 import type { IDataSource, IZoomStateOptions } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
@@ -26,7 +27,6 @@ vi.mock("../utils/domNodeTransform.ts", () => ({
   },
 }));
 
-let currentDataLength = 0;
 const transformInstances: Array<{ onZoomPan: Mock }> = [];
 vi.mock("../ViewportTransform.ts", () => ({
   ViewportTransform: class {
@@ -34,10 +34,9 @@ vi.mock("../ViewportTransform.ts", () => ({
       transformInstances.push(this);
     }
     onZoomPan = vi.fn();
-    fromScreenToModelX = vi.fn((x: number) => x);
-    fromScreenToModelBasisX = vi.fn(
-      () => [0, Math.max(currentDataLength - 1, 0)] as [number, number],
-    );
+    scaleX: ScaleLinear<number, number> = scaleLinear();
+    scaleY: ScaleLinear<number, number> = scaleLinear();
+    matrix = new DOMMatrix();
     onViewPortResize = vi.fn();
     onReferenceViewWindowResize = vi.fn();
   },
@@ -122,9 +121,8 @@ function createChart(
   data: Array<[number, number]>,
   options?: IZoomStateOptions,
 ) {
-  currentDataLength = data.length;
   const parent = document.createElement("div");
-  const w = Math.max(currentDataLength - 1, 0);
+  const w = Math.max(data.length - 1, 0);
   Object.defineProperty(parent, "clientWidth", {
     value: w,
     configurable: true,

--- a/svg-time-series/src/chart/interaction.single.test.ts
+++ b/svg-time-series/src/chart/interaction.single.test.ts
@@ -14,6 +14,7 @@ import {
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import type * as d3Zoom from "d3-zoom";
+import { scaleLinear, type ScaleLinear } from "d3-scale";
 import { TimeSeriesChart } from "../draw.ts";
 import type { IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
@@ -29,7 +30,6 @@ vi.mock("../utils/domNodeTransform.ts", () => ({
   },
 }));
 
-let currentDataLength = 0;
 const transformInstances: Array<{ onZoomPan: Mock }> = [];
 vi.mock("../ViewportTransform.ts", () => ({
   ViewportTransform: class {
@@ -38,10 +38,8 @@ vi.mock("../ViewportTransform.ts", () => ({
     }
     matrix = new DOMMatrix();
     onZoomPan = vi.fn();
-    fromScreenToModelX = vi.fn((x: number) => x);
-    fromScreenToModelBasisX = vi.fn(
-      () => [0, Math.max(currentDataLength - 1, 0)] as [number, number],
-    );
+    scaleX: ScaleLinear<number, number> = scaleLinear();
+    scaleY: ScaleLinear<number, number> = scaleLinear();
     onViewPortResize = vi.fn();
     onReferenceViewWindowResize = vi.fn();
   },
@@ -108,9 +106,8 @@ vi.mock("d3-zoom", async () => {
 });
 
 function createChart(data: Array<[number]>) {
-  currentDataLength = data.length;
   const parent = document.createElement("div");
-  const w = Math.max(currentDataLength - 1, 0);
+  const w = Math.max(data.length - 1, 0);
   Object.defineProperty(parent, "clientWidth", {
     value: w,
     configurable: true,

--- a/svg-time-series/src/chart/interaction.test.ts
+++ b/svg-time-series/src/chart/interaction.test.ts
@@ -14,6 +14,7 @@ import {
 import type { Selection } from "d3-selection";
 import { select } from "d3-selection";
 import type { D3ZoomEvent } from "d3-zoom";
+import { scaleLinear, type ScaleLinear } from "d3-scale";
 import { TimeSeriesChart } from "../draw.ts";
 import type { IDataSource } from "../draw.ts";
 import { LegendController } from "../../../samples/LegendController.ts";
@@ -33,14 +34,12 @@ const transformInstances: Array<{ onZoomPan: Mock }> = [];
 class MockViewportTransform {
   dataLength: number;
   matrix = new DOMMatrix();
+  scaleX: ScaleLinear<number, number> = scaleLinear();
+  scaleY: ScaleLinear<number, number> = scaleLinear();
   constructor(dataLength: number) {
     this.dataLength = dataLength;
   }
   onZoomPan = vi.fn();
-  fromScreenToModelX = vi.fn((x: number) => x);
-  fromScreenToModelBasisX = vi.fn(function (this: MockViewportTransform) {
-    return [0, Math.max(this.dataLength - 1, 0)] as [number, number];
-  });
   onViewPortResize = vi.fn();
   onReferenceViewWindowResize = vi.fn();
 }

--- a/svg-time-series/src/chart/render.ts
+++ b/svg-time-series/src/chart/render.ts
@@ -203,7 +203,7 @@ export class RenderState {
   }
 
   public screenToModelX(x: number): number {
-    return this.xTransform.fromScreenToModelX(x);
+    return this.xTransform.scaleX.invert(x);
   }
 
   public createLegendContext(data: ChartData): LegendContext {

--- a/svg-time-series/test/viewportTransform.test.ts
+++ b/svg-time-series/test/viewportTransform.test.ts
@@ -10,8 +10,8 @@ describe("ViewportTransform degeneracy", () => {
     vt.onViewPortResize([0, 100], [0, 100]);
     vt.onReferenceViewWindowResize([0, 0], [0, 10]);
 
-    expect(() => vt.fromScreenToModelY(50)).not.toThrow();
-    expect(() => vt.fromScreenToModelX(50)).toThrow();
+    expect(() => vt.scaleY.invert(50)).not.toThrow();
+    expect(() => vt.scaleX.invert(50)).toThrow();
   });
 
   it("throws only for degenerate Y domain", () => {
@@ -19,8 +19,8 @@ describe("ViewportTransform degeneracy", () => {
     vt.onViewPortResize([0, 100], [0, 100]);
     vt.onReferenceViewWindowResize([0, 10], [0, 0]);
 
-    expect(() => vt.fromScreenToModelX(50)).not.toThrow();
-    expect(() => vt.fromScreenToModelY(50)).toThrow();
+    expect(() => vt.scaleX.invert(50)).not.toThrow();
+    expect(() => vt.scaleY.invert(50)).toThrow();
   });
 
   it("throws only for degenerate X range", () => {
@@ -28,8 +28,8 @@ describe("ViewportTransform degeneracy", () => {
     vt.onViewPortResize([0, 0], [0, 100]);
     vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
-    expect(() => vt.fromScreenToModelY(50)).not.toThrow();
-    expect(() => vt.toScreenFromModelX(5)).toThrow();
+    expect(() => vt.scaleY.invert(50)).not.toThrow();
+    expect(() => vt.scaleX(5)).toThrow();
   });
 
   it("throws only for degenerate Y range", () => {
@@ -37,7 +37,7 @@ describe("ViewportTransform degeneracy", () => {
     vt.onViewPortResize([0, 100], [0, 0]);
     vt.onReferenceViewWindowResize([0, 10], [0, 10]);
 
-    expect(() => vt.fromScreenToModelX(5)).not.toThrow();
-    expect(() => vt.fromScreenToModelY(50)).toThrow();
+    expect(() => vt.scaleX.invert(5)).not.toThrow();
+    expect(() => vt.scaleY.invert(50)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- expose `scaleX` and `scaleY` from `ViewportTransform`
- remove deprecated screen/model wrapper helpers
- update chart rendering to call scale `invert` directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7f193268832b81c392a47eaa6eb0