### PR TITLE
docs: add SVG DOM structure guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This monorepo is organized into several workspaces:
 - `segment-tree-rmq/` – generic segment tree implementation used for range queries. Its unit tests live in `segment-tree-rmq/src`.
 - `samples/` – Vite-powered demos and sample code showcasing the library.
 
-For an overview of the chart's SVG element hierarchy and how to select or style nodes with D3, see [docs/dom-structure.md](docs/dom-structure.md).
+For a guide to the chart's SVG element hierarchy—views, axes, and interaction layers—and examples of selecting or styling nodes with D3, see [docs/dom-structure.md](docs/dom-structure.md).
 
 Run tests and benchmarks from the repository root:
 

--- a/docs/dom-structure.md
+++ b/docs/dom-structure.md
@@ -8,12 +8,15 @@
     <path />
   </g>
   <!-- one <g class="view"> per series -->
+  <g class="axis">...</g> <!-- X axis -->
+  <g class="axis">...</g> <!-- one per Y axis -->
   <rect class="zoom-overlay cursor-grab" />
   <g class="brush-layer" />
 </svg>
 ```
 
 - **`g.view`** – container for a data series. Each group holds a `<path>` node that draws the series line.
+- **`g.axis`** – axis groups. The first is the bottom X axis. Subsequent groups render Y axes: index `0` on the right and index `1` on the left.
 - **`rect.zoom-overlay`** – transparent overlay capturing zoom and pan gestures. The chart toggles `cursor-grab` and `cursor-grabbing` on this element.
 - **`g.brush-layer`** – hidden layer activated for rectangular brush selections.
 
@@ -31,4 +34,13 @@ brushLayer.style("display", null).select(".selection").attr("stroke", "red");
 
 // style all series paths
 selectAll("g.view > path").attr("stroke", "steelblue").attr("fill", "none");
+
+// dim X-axis labels
+select("svg").select("g.axis").selectAll("text").attr("fill", "#777");
+
+// color Y-axis lines
+selectAll("g.axis")
+  .filter((_, i) => i > 0)
+  .selectAll("path, line")
+  .attr("stroke", "orange");
 ```


### PR DESCRIPTION
## Summary
- document SVG DOM hierarchy and D3 selection examples
- link SVG DOM guide from main README

## Testing
- `npm run format`
- `git commit -m "docs: document SVG DOM structure"`


------
https://chatgpt.com/codex/tasks/task_e_68adb118c3d8832b9a9589dd110e10cc