### PR TITLE
feat: add event dispatch system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2444,6 +2444,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-dsv": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
@@ -13702,7 +13708,9 @@
       "version": "0.1.0",
       "license": "WTFPL",
       "dependencies": {
+        "@types/d3-dispatch": "^3.0.7",
         "d3-brush": "^3.0.0",
+        "d3-dispatch": "^3.0.1",
         "d3-scale": "^4.0.2",
         "d3-selection": "^3.0.0",
         "d3-shape": "^3.2.0",
@@ -13721,6 +13729,15 @@
         "rollup-plugin-node-externals": "^8.0.1",
         "vite": "^7.1.2",
         "vite-plugin-dts": "^4.5.4"
+      }
+    },
+    "svg-time-series/node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     }
   }

--- a/samples/demos/common.ts
+++ b/samples/demos/common.ts
@@ -61,15 +61,16 @@ export function drawCharts(
       onMouseMove,
     );
     charts.push(chart);
-    chart.interaction.onZoom = (
-      event: D3ZoomEvent<SVGRectElement, unknown>,
-    ) => {
-      onZoom(chart, event);
-      console.log("Zoom transform:", chart.interaction.getZoomTransform());
-    };
-    chart.interaction.onBrushEnd = (timeWindow) => {
+    chart.interaction.on(
+      "afterZoom",
+      (event: D3ZoomEvent<SVGRectElement, unknown>) => {
+        onZoom(chart, event);
+        console.log("Zoom transform:", chart.interaction.getZoomTransform());
+      },
+    );
+    chart.interaction.on("brushEnd", (timeWindow) => {
       console.log("Brushed window:", timeWindow);
-    };
+    });
   };
 
   selectAll(".chart").each(onSelectChart);

--- a/svg-time-series/package.json
+++ b/svg-time-series/package.json
@@ -16,6 +16,7 @@
   "type": "module",
   "dependencies": {
     "d3-brush": "^3.0.0",
+    "d3-dispatch": "^3.0.1",
     "d3-scale": "^4.0.2",
     "d3-selection": "^3.0.0",
     "d3-shape": "^3.2.0",
@@ -33,7 +34,8 @@
     "@types/d3-zoom": "^3.0.8",
     "rollup-plugin-node-externals": "^8.0.1",
     "vite": "^7.1.2",
-    "vite-plugin-dts": "^4.5.4"
+    "vite-plugin-dts": "^4.5.4",
+    "@types/d3-dispatch": "^3.0.7"
   },
   "scripts": {
     "prepare": "npm run build",


### PR DESCRIPTION
## Summary
- integrate d3-dispatch and replace custom listener map with centralized dispatcher
- expose on/off wrappers and new chart events for rendering, zooming, brushing, and data updates
- sample demo updated to use new event API

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68adb10a4440832b8b4fc1bf4d5230e0