### PR TITLE
chore(ci): build npm tarball artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,23 @@ jobs:
           cache-dependency-path: "package-lock.json"
       - run: npm ci
       - run: npm test
+
+  pack:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
+      - run: npm ci
+      - run: mkdir -p tarballs
+      - run: npm pack --workspace segment-tree-rmq --workspace svg-time-series --pack-destination=tarballs
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-packages
+          path: tarballs/*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -298,3 +298,6 @@ dist/
 # dotenv
 .env
 .aider*
+
+# npm package tarballs
+*.tgz


### PR DESCRIPTION
## Summary
- produce npm package tarballs for libraries during CI
- archive generated tarballs as build artifacts
- ignore generated *.tgz files

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb48df700832b9d7b972b4acd2362