### PR TITLE
refactor: simplify chart event on/off by using D3 dispatch namespacing

### DIFF
--- a/svg-time-series/src/chart/eventEmitter.test.ts
+++ b/svg-time-series/src/chart/eventEmitter.test.ts
@@ -66,7 +66,7 @@ describe("TimeSeriesChart event emitter", () => {
     chart.updateChartWithNewData([5]);
     expect(dataCb).toHaveBeenCalledWith([5]);
 
-    interaction.off("dataUpdate", dataCb);
+    interaction.off("dataUpdate");
     chart.updateChartWithNewData([6]);
     expect(dataCb).toHaveBeenCalledTimes(1);
     interaction.on("dataUpdate", dataCb);


### PR DESCRIPTION
### Motivation
- Simplify event listener lifecycle by relying on D3 `dispatch` namespacing rather than manual handler bookkeeping. 
- Remove fragile generated handler IDs and reduce surface area for bugs in the chart event API. 
- Keep the published event names stable while allowing callers to use namespaced strings when desired. 

### Description
- Removed the separate `ChartEventName` type and instead accept `ChartEvent | \\`${ChartEvent}.${string}\\`` inline in the `IPublicInteraction` `on`/`off` signatures. 
- Replaced the `handlerIds` map and generated ID logic with direct calls to `this.dispatch.on(eventName, handler)` in `on` and `this.dispatch.on(eventName, null)` in `off`. 
- Updated `dispose` to clear listeners via the dispatcher and removed handler-id cleanup. 
- Reverted the test to use the base event names in `svg-time-series/src/chart/eventEmitter.test.ts` so it verifies `on`/`off` behavior with the existing event names. 

### Testing
- Ran `npm run format` which completed successfully. 
- Ran `npm run typecheck --workspaces --if-present` with no type errors. 
- Ran `vitest run --reporter=dot` and all tests passed (44 test files, 233 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6977fcf1196483258f672233bcb5234c)